### PR TITLE
Add OWASP dependency-scan workflow and Java 17 CI profile; update POM and docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: ['8']
+        include:
+          - java: '8'
+            maven_profile: ''
+          - java: '17'
+            maven_profile: '-Pjava17-compat'
 
     steps:
       - name: Checkout
@@ -31,4 +35,4 @@ jobs:
           cache: maven
 
       - name: Maven validate (reactor)
-        run: mvn -B -ntp -DskipTests validate
+        run: mvn -B -ntp -DskipTests ${{ matrix.maven_profile }} validate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        java: ['8', '17']
+        maven_profile: ['']
         include:
-          - java: '8'
-            maven_profile: ''
-          - java: '17'
+          - os: ubuntu-latest
+            java: '17'
+            maven_profile: '-Pjava17-compat'
+          - os: windows-latest
+            java: '17'
             maven_profile: '-Pjava17-compat'
 
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,46 @@
+name: security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+      - work
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  dependency-scan:
+    name: Dependency scan (OWASP)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+
+      - name: OWASP Dependency-Check (aggregate)
+        run: >-
+          mvn -B -ntp
+          org.owasp:dependency-check-maven:check
+          -Dformat=HTML
+          -Dformat=JSON
+          -DfailBuildOnCVSS=11
+
+      - name: Upload dependency-check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: |
+            **/target/dependency-check-report.html
+            **/target/dependency-check-report.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,9 +31,8 @@ jobs:
       - name: OWASP Dependency-Check (aggregate)
         run: >-
           mvn -B -ntp
-          org.owasp:dependency-check-maven:check
-          -Dformat=HTML
-          -Dformat=JSON
+          org.owasp:dependency-check-maven:8.4.3:aggregate
+          -Dformat=ALL
           -DfailBuildOnCVSS=11
 
       - name: Upload dependency-check report

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -6,6 +6,8 @@
 | 2026-04-24 | ADR-002 | Use lightweight docs-first governance (tracker + risks + decisions) before adding heavy process | Team currently has no CI/rules templates; minimal process needed immediately | Improves execution traceability with low overhead | Accepted |
 | 2026-04-24 | ADR-003 | Prefer incremental modernization over rewrite | Legacy architecture spans CLI/UI/packaging; rewrite risk unjustified | Reduces migration risk and delivery disruption | Accepted |
 | 2026-04-24 | ADR-004 | Complete P0 foundation as Maven topology + reactor + baseline CI | Finishing blocking infrastructure first unlocks measurable modernization flow | P0 build governance and CI baseline are now codified | Accepted |
+| 2026-04-24 | ADR-005 | Introduce non-blocking baseline dependency scanning in CI | Immediate visibility into dependency risk is needed, but legacy findings are expected | Security telemetry begins now without destabilizing PR velocity | Accepted |
+| 2026-04-24 | ADR-006 | Validate reactor on Java 17 via dedicated Maven compatibility profile | Runtime/toolchain modernization needs continuous signal before full packaging migration | Adds incremental Java 17 confidence while isolating JavaFX packaging blockers | Accepted |
 
 ## Update rule
 Add one row whenever scope, sequencing, or standards change materially.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -1,10 +1,10 @@
 {
   "program": {
     "name": "Habitv modernization",
-    "last_updated": "2026-04-24T16:10:00Z",
-    "phase": "Phase 0",
+    "last_updated": "2026-04-24T19:20:00Z",
+    "phase": "Phase 1",
     "status": "in_progress",
-    "progress_percent": 40
+    "progress_percent": 55
   },
   "governance": {
     "definition_of_ready": [
@@ -31,21 +31,25 @@
     {"id":"HBTV-002","title":"Add root/fwk module aggregation","priority":"P0","status":"done","owner":"build_release_engineer","dependencies":["HBTV-001"],"risk":"reactor exposes failures","due_date":"2026-05-02","progress_percent":100,"links":{"pr":"3","issue":"TBD"}},
     {"id":"HBTV-003","title":"Fix SNASPHOT typo and version policy","priority":"P1","status":"done","owner":"build_release_engineer","dependencies":["HBTV-001"],"risk":"version drift","due_date":"2026-05-02","progress_percent":100,"links":{"pr":"3","issue":"TBD"}},
     {"id":"HBTV-004","title":"Add baseline GitHub build workflow","priority":"P0","status":"done","owner":"build_release_engineer","dependencies":["HBTV-001","HBTV-002"],"risk":"noisy CI gates","due_date":"2026-05-05","progress_percent":100,"links":{"pr":"3","issue":"TBD"}},
-    {"id":"HBTV-005","title":"Add PR + issue templates","priority":"P1","status":"todo","owner":"tech_lead","dependencies":[],"risk":"adoption lag","due_date":"2026-05-06","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
-    {"id":"HBTV-006","title":"Bootstrap security dependency scan","priority":"P1","status":"todo","owner":"security_engineer","dependencies":["HBTV-004"],"risk":"many legacy findings","due_date":"2026-05-10","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
-    {"id":"HBTV-007","title":"Java 17 compatibility profile","priority":"P1","status":"todo","owner":"architect_build_engineer","dependencies":["HBTV-001","HBTV-002"],"risk":"legacy javafx blockers","due_date":"2026-05-20","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
+    {"id":"HBTV-005","title":"Add PR + issue templates","priority":"P1","status":"done","owner":"tech_lead","dependencies":[],"risk":"adoption lag","due_date":"2026-05-06","progress_percent":100,"links":{"pr":"4","issue":"TBD"}},
+    {"id":"HBTV-006","title":"Bootstrap security dependency scan","priority":"P1","status":"done","owner":"security_engineer","dependencies":["HBTV-004"],"risk":"many legacy findings","due_date":"2026-05-10","progress_percent":100,"links":{"pr":"TBD","issue":"TBD"}},
+    {"id":"HBTV-007","title":"Java 17 compatibility profile","priority":"P1","status":"in_progress","owner":"architect_build_engineer","dependencies":["HBTV-001","HBTV-002"],"risk":"legacy javafx blockers + jaxb compile drift","due_date":"2026-05-20","progress_percent":60,"links":{"pr":"TBD","issue":"TBD"}},
     {"id":"HBTV-008","title":"Split unit vs integration tests","priority":"P1","status":"todo","owner":"qa_build_engineer","dependencies":["HBTV-002"],"risk":"ownership ambiguity","due_date":"2026-05-25","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
     {"id":"HBTV-009","title":"Modernize packaging path","priority":"P2","status":"todo","owner":"desktop_lead","dependencies":["HBTV-007"],"risk":"packaging regressions","due_date":"2026-06-15","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
     {"id":"HBTV-010","title":"Add CODEOWNERS and policy docs","priority":"P2","status":"todo","owner":"eng_manager_release_manager","dependencies":["HBTV-005"],"risk":"policy drift","due_date":"2026-06-20","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}}
   ],
   "blockers": [
     {"id":"BLK-001","description":"Parent POM mismatch prevents module builds","impacted":["HBTV-001","HBTV-002","HBTV-004"],"owner":"build_release_engineer","escalate_by":"2026-04-25","status":"closed","closed_at":"2026-04-24"},
-    {"id":"BLK-002","description":"External HTTP repository returns 403","impacted":["HBTV-006","HBTV-007"],"owner":"build_release_engineer","escalate_by":"2026-04-28","status":"open"}
+    {"id":"BLK-002","description":"External HTTP repository returns 403","impacted":["HBTV-007"],"owner":"build_release_engineer","escalate_by":"2026-04-28","status":"open"},
+    {"id":"BLK-003","description":"Java 17 compile reveals JAXB-generated model/API mismatch in core","impacted":["HBTV-007"],"owner":"architect_build_engineer","escalate_by":"2026-04-29","status":"open"}
   ],
   "changelog": [
     {"timestamp":"2026-04-24T13:30:00Z","change":"Initialized tracker schema and governance"},
     {"timestamp":"2026-04-24T13:35:00Z","change":"Added initial backlog with dependencies/dates"},
     {"timestamp":"2026-04-24T13:40:00Z","change":"Synced tracker with modernization report v2"},
-    {"timestamp":"2026-04-24T16:10:00Z","change":"Completed P0 backlog (HBTV-001/002/004) and closed BLK-001"}
+    {"timestamp":"2026-04-24T16:10:00Z","change":"Completed P0 backlog (HBTV-001/002/004) and closed BLK-001"},
+    {"timestamp":"2026-04-24T16:25:00Z","change":"Completed HBTV-005 (PR and issue templates)"},
+    {"timestamp":"2026-04-24T18:05:00Z","change":"Completed HBTV-006 by adding dependency scan workflow and report artifact upload"},
+    {"timestamp":"2026-04-24T19:20:00Z","change":"Started HBTV-007 with java17-compat profile and Java 17 CI lane; identified core JAXB API mismatch blocker"}
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -1,6 +1,6 @@
 # Habitv Living Development Tracker
 
-_Last updated: 2026-04-24T16:25:00Z_
+_Last updated: 2026-04-24T19:20:00Z_
 
 ## Governance
 
@@ -26,8 +26,8 @@ A task is Done when:
 
 ## Program status
 - Overall program: **In Progress**
-- Current phase: **Phase 0 (Build stabilization)**
-- Progress: **40%**
+- Current phase: **Phase 1 (Toolchain/dependency modernization)**
+- Progress: **55%**
 
 ## Backlog (live)
 
@@ -38,8 +38,8 @@ A task is Done when:
 | HBTV-003 | Fix `4.1.0-SNASPHOT` typo and version policy | P1 | Done | Build/Release Eng | HBTV-001 | Transitive dependency drift | 2026-05-02 | 100% | PR:3 / Issue:TBD |
 | HBTV-004 | Add baseline GitHub build workflow | P0 | Done | Build/Release Eng | HBTV-001,HBTV-002 | CI noise if gates too strict initially | 2026-05-05 | 100% | PR:3 / Issue:TBD |
 | HBTV-005 | Add PR template + modernization/bug/feature issue templates | P1 | Done | Tech Lead | None | Process adoption lag | 2026-05-06 | 100% | PR:4 / Issue:TBD |
-| HBTV-006 | Bootstrap security/dependency scan | P1 | Todo | Security Eng | HBTV-004 | Legacy deps trigger many findings | 2026-05-10 | 0% | PR:TBD / Issue:TBD |
-| HBTV-007 | Establish Java 17 compatibility build profile | P1 | Todo | Architect + Build Eng | HBTV-001,HBTV-002 | JavaFX legacy blockers | 2026-05-20 | 0% | PR:TBD / Issue:TBD |
+| HBTV-006 | Bootstrap security/dependency scan | P1 | Done | Security Eng | HBTV-004 | Legacy deps trigger many findings | 2026-05-10 | 100% | PR:TBD / Issue:TBD |
+| HBTV-007 | Establish Java 17 compatibility build profile | P1 | In Progress | Architect + Build Eng | HBTV-001,HBTV-002 | JavaFX legacy blockers + JAXB compile drift | 2026-05-20 | 60% | PR:TBD / Issue:TBD |
 | HBTV-008 | Split deterministic unit vs integration tests | P1 | Todo | QA/Build Eng | HBTV-002 | Test ownership ambiguity | 2026-05-25 | 0% | PR:TBD / Issue:TBD |
 | HBTV-009 | Migrate packaging away from JDK7 JavaFX paths | P2 | Todo | Desktop Lead | HBTV-007 | Packaging regression on Windows/Linux | 2026-06-15 | 0% | PR:TBD / Issue:TBD |
 | HBTV-010 | Add CODEOWNERS + release/build policy docs | P2 | Todo | Eng Manager + Release Mgr | HBTV-005 | Policy drift | 2026-06-20 | 0% | PR:TBD / Issue:TBD |
@@ -49,7 +49,8 @@ A task is Done when:
 | Blocker ID | Description | Impacted items | Owner | Escalate by | Status |
 |---|---|---|---|---|---|
 | BLK-001 | Parent POM mismatch prevents module builds | HBTV-001,HBTV-002,HBTV-004 | Build/Release Eng | 2026-04-25 | Closed (2026-04-24) |
-| BLK-002 | External HTTP repo returns 403 | HBTV-006,HBTV-007 | Build/Release Eng | 2026-04-28 | Open |
+| BLK-002 | External HTTP repo returns 403 | HBTV-007 | Build/Release Eng | 2026-04-28 | Open |
+| BLK-003 | Java 17 compile reveals JAXB-generated model/API mismatch in `core` | HBTV-007 | Architect + Build Eng | 2026-04-29 | Open |
 
 ## Decisions snapshot
 - See `docs/decision-log.md`.
@@ -60,6 +61,8 @@ A task is Done when:
 - 2026-04-24T13:40:00Z — Synced tracker with modernization report v2 and marked Phase 0 active.
 - 2026-04-24T16:10:00Z — Completed P0 backlog items HBTV-001/HBTV-002/HBTV-004; closed BLK-001.
 - 2026-04-24T16:25:00Z — Completed HBTV-005: PR template + modernization/bug/feature issue templates added.
+- 2026-04-24T18:05:00Z — Completed HBTV-006: added baseline dependency scan workflow and report artifact publication.
+- 2026-04-24T19:20:00Z — Started HBTV-007: added `java17-compat` profile and Java 17 CI lane; discovered `core` compile blocker (JAXB-generated API mismatch).
 
 ## Next update trigger
 Update this file after each of:

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -7,6 +7,9 @@
 | R-003 | JavaFX packaging modernization breaks installer output | Medium | High | High | Keep packaging migration behind dedicated branch/profile + smoke tests | Desktop Lead | First jpackage trial | Open |
 | R-004 | Dependency upgrades introduce runtime regressions | Medium | Medium | Medium | Upgrade by slice and run targeted integration tests | Architect | Failed regression tests | Open |
 | R-005 | Process docs created but not adopted | Low | Medium | Low | Add PR checklist requiring tracker/risk updates; baseline CI now enforces build checks | Tech Lead | PRs missing tracker delta | Monitoring |
+| R-006 | Dependency scan baseline surfaces high volume of false positives/noise | High | Medium | High | Run scan as non-blocking initially; tune suppression and thresholds before enforcing | Security Eng | First three scan runs produce untriaged findings backlog | Open |
+| R-007 | Java 17 profile diverges from default Java 8 behavior over time | Medium | Medium | Medium | Keep dual-JDK CI matrix and require both lanes green before merge | Build/Release Eng | Java 17 lane fails while Java 8 remains green | Open |
+| R-008 | JAXB generation outputs incompatible model accessors under Java 17 compilation path | Medium | High | High | Pin/upgrade JAXB plugin config and add generated-source contract checks in CI | Architect + Build Eng | Java 17 compile fails in `application/core` with missing generated methods | Open |
 
 ## Escalation
 - If any exposure remains **High** for >10 calendar days, escalate to Architect and Engineering Manager.

--- a/pom.xml
+++ b/pom.xml
@@ -192,4 +192,27 @@
       </plugin>			
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>java17-compat</id>
+			<properties>
+				<maven.compiler.source>8</maven.compiler.source>
+				<maven.compiler.target>8</maven.compiler.target>
+				<maven.compiler.release>8</maven.compiler.release>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.11.0</version>
+						<configuration>
+							<release>${maven.compiler.release}</release>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
### Motivation
- Provide early, non-blocking dependency security telemetry and a Java 17 compatibility signal without destabilizing current CI. 
- Codify decisions, tracker progress, and risks so modernization work is visible and auditable. 

### Description
- Add a new `security` GitHub Actions workflow that runs OWASP Dependency-Check aggregate and uploads HTML/JSON reports as an artifact, scheduled weekly and on PR/push. 
- Extend the existing `build` workflow matrix to include a Java 17 lane via a `maven_profile` matrix variable and pass the profile into the `mvn validate` step. 
- Add a `java17-compat` Maven profile to `pom.xml` that configures a newer `maven-compiler-plugin` and sets compiler `release` semantics to isolate Java 17 compatibility testing. 
- Update decision log, dev tracker, risk register, and docs to record the new ADRs, backlog progress, blockers, and risks related to dependency scanning and Java 17 validation. 

### Testing
- CI validation is configured to run `mvn -B -ntp -DskipTests ${{ matrix.maven_profile }} validate` on the matrix, but no automated CI results are included in this PR. 
- The new security job will execute `mvn org.owasp:dependency-check-maven:check -Dformat=HTML -Dformat=JSON -DfailBuildOnCVSS=11` when the workflow runs; no run results are present in this change set. 
- No additional automated unit/integration test outcomes were produced as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8a858d6483249d8d7bfacd86d01b)