### PR TITLE
build: stabilize JAXB generation for core

### DIFF
--- a/application/core/pom.xml
+++ b/application/core/pom.xml
@@ -42,6 +42,7 @@
 			<plugin>
 				<groupId>com.sun.tools.xjc.maven2</groupId>
 				<artifactId>maven-jaxb-plugin</artifactId>
+				<version>1.1.1</version>
 				<executions>
 					<execution>
 						<id>config</id>
@@ -51,7 +52,7 @@
 						<configuration>
 							<generatePackage>com.dabi.habitv.config.entities</generatePackage>
 							<schemaDirectory>xsd</schemaDirectory>
-							<generateDirectory>generated</generateDirectory>
+							<generateDirectory>${project.build.directory}/generated-sources/jaxb</generateDirectory>
 							<includeSchemas>
 								<includeSchema>config.xsd</includeSchema>
 							</includeSchemas>
@@ -65,7 +66,7 @@
 						<configuration>
 							<generatePackage>com.dabi.habitv.configuration.entities</generatePackage>
 							<schemaDirectory>xsd</schemaDirectory>
-							<generateDirectory>generated</generateDirectory>
+							<generateDirectory>${project.build.directory}/generated-sources/jaxb</generateDirectory>
 							<includeSchemas>
 								<includeSchema>configuration.xsd</includeSchema>
 							</includeSchemas>
@@ -79,7 +80,7 @@
 						<configuration>
 							<generatePackage>com.dabi.habitv.grabconfig.entities</generatePackage>
 							<schemaDirectory>xsd</schemaDirectory>
-							<generateDirectory>generated</generateDirectory>
+							<generateDirectory>${project.build.directory}/generated-sources/jaxb</generateDirectory>
 							<includeSchemas>
 								<includeSchema>grab-config.xsd</includeSchema>
 							</includeSchemas>

--- a/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
@@ -273,11 +273,12 @@ public class XMLUserConfig implements UserConfig {
 				.newInstance(Configuration.class.getPackage().getName());
 		final Marshaller marshaller = jaxbContext.createMarshaller();
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+		marshaller.setProperty(Marshaller.JAXB_ENCODING, HabitTvConf.ENCODING);
 		FileUtils.setValidation(marshaller, CONF_XSD);
 		try (FileOutputStream outputFile = new FileOutputStream(file)) {
 			marshaller.marshal(config, outputFile);
 		} catch (IOException e) {
-			throw new TechnicalException(e);
+			throw new JAXBException("Unable to save configuration to " + file, e);
 		}
 	}
 

--- a/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
@@ -3,6 +3,8 @@ package com.dabi.habitv.core.config;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -272,7 +274,11 @@ public class XMLUserConfig implements UserConfig {
 		final Marshaller marshaller = jaxbContext.createMarshaller();
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
 		FileUtils.setValidation(marshaller, CONF_XSD);
-		marshaller.marshal(config, file);
+		try (FileOutputStream outputFile = new FileOutputStream(file)) {
+			marshaller.marshal(config, outputFile);
+		} catch (IOException e) {
+			throw new TechnicalException(e);
+		}
 	}
 
 	private static Configuration buildDefaultConfig() {
@@ -469,15 +475,15 @@ public class XMLUserConfig implements UserConfig {
 	@Override
 	public boolean updateOnStartup() {
 		return config.getUpdateConfig() == null
-				|| config.getUpdateConfig().getUpdateOnStartup() == null ? true
-				: config.getUpdateConfig().getUpdateOnStartup();
+				|| config.getUpdateConfig().isUpdateOnStartup() == null ? true
+				: config.getUpdateConfig().isUpdateOnStartup();
 	}
 
 	@Override
 	public boolean autoriseSnapshot() {
 		return config.getUpdateConfig() == null
-				|| config.getUpdateConfig().getAutoriseSnapshot() == null ? false
-				: config.getUpdateConfig().getAutoriseSnapshot();
+				|| config.getUpdateConfig().isAutoriseSnapshot() == null ? false
+				: config.getUpdateConfig().isAutoriseSnapshot();
 	}
 
 	@Override

--- a/application/core/src/com/dabi/habitv/core/dao/GrabConfigDAO.java
+++ b/application/core/src/com/dabi/habitv/core/dao/GrabConfigDAO.java
@@ -186,7 +186,7 @@ public class GrabConfigDAO {
 				subCategoriesDTO = Collections.emptySet();
 			}
 
-			if (category.getDownload() == null || category.getDownload()
+			if (category.isDownload() == null || category.isDownload()
 					|| !subCategoriesDTO.isEmpty()
 					|| loadMode.equals(LoadModeEnum.ALL)) {
 				categoryDTO = buildCategoryDTO(channelName, category,
@@ -204,17 +204,17 @@ public class GrabConfigDAO {
 				category.getId(), getInclude(category), getExclude(category),
 				category.getExtension());
 
-		categoryDTO.setSelected(category.getDownload() != null
-				&& category.getDownload());
+		categoryDTO.setSelected(category.isDownload() != null
+				&& category.isDownload());
 
-		categoryDTO.setTemplate(category.getTemplate() != null
-				&& category.getTemplate());
+		categoryDTO.setTemplate(category.isTemplate() != null
+				&& category.isTemplate());
 
-		categoryDTO.setDownloadable(category.getDownloadable() == null
-				|| category.getDownloadable());
+		categoryDTO.setDownloadable(category.isDownloadable() == null
+				|| category.isDownloadable());
 
-		categoryDTO.setDeleted(category.getDeleted() != null
-				&& category.getDeleted());
+		categoryDTO.setDeleted(category.isDeleted() != null
+				&& category.isDeleted());
 
 		categoryDTO.setState(category.getStatus() == null ? StatusEnum.EXIST
 				: StatusEnum.valueOf(category.getStatus()));
@@ -299,7 +299,7 @@ public class GrabConfigDAO {
 
 		buildCategoryConfiguration(oldCategory, categoryType);
 
-		categoryType.setDownload(oldCategory.getToDownload());
+		categoryType.setDownload(oldCategory.isToDownload());
 
 		Excludes excludes = new Excludes();
 		for (String oldExclude : oldCategory.getExclude()) {
@@ -358,8 +358,8 @@ public class GrabConfigDAO {
 							plugin.getName(), buildCategoryListDTO);
 					categoryPlugin.setDownloadable(false);
 					categoryPlugin
-							.setDeleted(plugin.getDeleted() == null ? false
-									: plugin.getDeleted());
+							.setDeleted(plugin.isDeleted() == null ? false
+									: plugin.isDeleted());
 					if (plugin.getStatus() != null) {
 						categoryPlugin.setState(StatusEnum.valueOf(plugin
 								.getStatus()));

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -98,14 +98,14 @@
       "id": "HBTV-005",
       "title": "Add PR + issue templates",
       "priority": "P1",
-      "status": "todo",
+      "status": "done",
       "owner": "tech_lead",
       "dependencies": [],
       "risk": "adoption lag",
       "due_date": "2026-05-06",
-      "progress_percent": 0,
+      "progress_percent": 100,
       "links": {
-        "pr": "TBD",
+        "pr": "4",
         "issue": "TBD"
       }
     },

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -1,10 +1,10 @@
 {
   "program": {
     "name": "Habitv modernization",
-    "last_updated": "2026-04-25T11:10:00Z",
+    "last_updated": "2026-04-25T12:00:00Z",
     "phase": "Phase 0",
     "status": "in_progress",
-    "progress_percent": 40
+    "progress_percent": 45
   },
   "governance": {
     "definition_of_ready": [
@@ -138,9 +138,60 @@
       ],
       "risk": "legacy javafx blockers",
       "due_date": "2026-05-20",
-      "progress_percent": 20,
+      "progress_percent": 35,
       "links": {
-        "pr": "build/hbtv-007-jaxb-core-generation",
+        "pr": "10",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-007a",
+      "title": "Resolve application/trayView JavaFX compile blocker on modern toolchains",
+      "priority": "P1",
+      "status": "todo",
+      "owner": "desktop_lead_build_engineer",
+      "dependencies": [
+        "HBTV-007"
+      ],
+      "risk": "javafx modules absent outside jdk8",
+      "due_date": "2026-05-22",
+      "progress_percent": 0,
+      "links": {
+        "pr": "TBD",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-007b",
+      "title": "Add JAXB runtime provider for tests/runtime (com.sun.xml.bind.v2.ContextFactory)",
+      "priority": "P1",
+      "status": "todo",
+      "owner": "build_release_engineer",
+      "dependencies": [
+        "HBTV-007"
+      ],
+      "risk": "runtime jaxb provider mismatch causes test failures",
+      "due_date": "2026-05-22",
+      "progress_percent": 0,
+      "links": {
+        "pr": "TBD",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-007c",
+      "title": "Isolate remaining network-dependent TestListHttp from default install lifecycle",
+      "priority": "P1",
+      "status": "todo",
+      "owner": "qa_build_engineer",
+      "dependencies": [
+        "HBTV-008a"
+      ],
+      "risk": "network-dependent test remains non-deterministic",
+      "due_date": "2026-05-25",
+      "progress_percent": 0,
+      "links": {
+        "pr": "TBD",
         "issue": "TBD"
       }
     },
@@ -237,8 +288,52 @@
       "owner": "build_release_engineer",
       "escalate_by": "2026-04-28",
       "status": "open"
+    },
+    {
+      "id": "BLK-003",
+      "description": "application/trayView compile requires JavaFX classes not present in modern/non-JDK8 toolchains",
+      "impacted": [
+        "HBTV-007",
+        "HBTV-007a"
+      ],
+      "owner": "desktop_lead_build_engineer",
+      "escalate_by": "2026-04-29",
+      "status": "open"
+    },
+    {
+      "id": "BLK-004",
+      "description": "JAXB runtime provider com.sun.xml.bind.v2.ContextFactory missing in test/runtime paths",
+      "impacted": [
+        "HBTV-007",
+        "HBTV-007b"
+      ],
+      "owner": "build_release_engineer",
+      "escalate_by": "2026-04-29",
+      "status": "open"
+    },
+    {
+      "id": "BLK-005",
+      "description": "Remaining network-dependent TestListHttp keeps install non-deterministic",
+      "impacted": [
+        "HBTV-008",
+        "HBTV-008a",
+        "HBTV-007c"
+      ],
+      "owner": "qa_build_engineer",
+      "escalate_by": "2026-04-30",
+      "status": "open"
     }
   ],
+  "pr_10_validation_summary": {
+    "core_statement": "PR #10 fixes the application/core JAXB generation/accessor compile blocker. The next compile blocker is application/trayView because JavaFX classes are missing from the current toolchain.",
+    "install_statement": "mvn install remains blocked by JAXB runtime provider/test-runtime setup and remaining network-dependent TestListHttp.",
+    "results": [
+      "GitHub Actions Java 8 Ubuntu/Windows: success",
+      "mvn -B -ntp -DskipTests validate: success",
+      "mvn -B -ntp -DskipTests compile: core JAXB blocker fixed; next unrelated blocker is application/trayView JavaFX",
+      "mvn -B -ntp install: still blocked by JAXB runtime provider and TestListHttp network dependency"
+    ]
+  },
   "changelog": [
     {
       "timestamp": "2026-04-24T13:30:00Z",
@@ -261,8 +356,8 @@
       "change": "Started URL modernization by auditing obsolete HTTP/provider URLs and isolating network smoke tests (support task for HBTV-008)"
     },
     {
-      "timestamp": "2026-04-25T11:10:00Z",
-      "change": "Started JAXB/core generation stabilization to unblock full Maven install and Java compatibility lanes."
+      "timestamp": "2026-04-25T12:00:00Z",
+      "change": "Folded PR #11/#12 documentation updates into PR #10 context, kept HBTV-007 in progress, and tracked JavaFX/JAXB-runtime/network follow-up blockers."
     }
   ]
 }

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -1,7 +1,7 @@
 {
   "program": {
     "name": "Habitv modernization",
-    "last_updated": "2026-04-24T18:05:00Z",
+    "last_updated": "2026-04-25T11:10:00Z",
     "phase": "Phase 0",
     "status": "in_progress",
     "progress_percent": 40
@@ -27,27 +27,242 @@
     ]
   },
   "backlog": [
-    {"id":"HBTV-001","title":"Align parent versions + relativePath","priority":"P0","status":"done","owner":"build_release_engineer","dependencies":[],"risk":"latent compile failures","due_date":"2026-04-30","progress_percent":100,"links":{"pr":"3","issue":"TBD"}},
-    {"id":"HBTV-002","title":"Add root/fwk module aggregation","priority":"P0","status":"done","owner":"build_release_engineer","dependencies":["HBTV-001"],"risk":"reactor exposes failures","due_date":"2026-05-02","progress_percent":100,"links":{"pr":"3","issue":"TBD"}},
-    {"id":"HBTV-003","title":"Fix SNASPHOT typo and version policy","priority":"P1","status":"done","owner":"build_release_engineer","dependencies":["HBTV-001"],"risk":"version drift","due_date":"2026-05-02","progress_percent":100,"links":{"pr":"3","issue":"TBD"}},
-    {"id":"HBTV-004","title":"Add baseline GitHub build workflow","priority":"P0","status":"done","owner":"build_release_engineer","dependencies":["HBTV-001","HBTV-002"],"risk":"noisy CI gates","due_date":"2026-05-05","progress_percent":100,"links":{"pr":"3","issue":"TBD"}},
-    {"id":"HBTV-005","title":"Add PR + issue templates","priority":"P1","status":"todo","owner":"tech_lead","dependencies":[],"risk":"adoption lag","due_date":"2026-05-06","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
-    {"id":"HBTV-006","title":"Bootstrap security dependency scan","priority":"P1","status":"todo","owner":"security_engineer","dependencies":["HBTV-004"],"risk":"many legacy findings","due_date":"2026-05-10","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
-    {"id":"HBTV-007","title":"Java 17 compatibility profile","priority":"P1","status":"todo","owner":"architect_build_engineer","dependencies":["HBTV-001","HBTV-002"],"risk":"legacy javafx blockers","due_date":"2026-05-20","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
-    {"id":"HBTV-008","title":"Split unit vs integration tests","priority":"P1","status":"todo","owner":"qa_build_engineer","dependencies":["HBTV-002"],"risk":"ownership ambiguity","due_date":"2026-05-25","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
-    {"id":"HBTV-008a","title":"URL modernization support task for HBTV-008","priority":"P1","status":"in_progress","owner":"qa_build_engineer","dependencies":["HBTV-008"],"risk":"url updates alone do not restore provider plugins","due_date":"2026-05-25","progress_percent":25,"links":{"pr":"TBD","issue":"TBD"}},
-    {"id":"HBTV-009","title":"Modernize packaging path","priority":"P2","status":"todo","owner":"desktop_lead","dependencies":["HBTV-007"],"risk":"packaging regressions","due_date":"2026-06-15","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}},
-    {"id":"HBTV-010","title":"Add CODEOWNERS and policy docs","priority":"P2","status":"todo","owner":"eng_manager_release_manager","dependencies":["HBTV-005"],"risk":"policy drift","due_date":"2026-06-20","progress_percent":0,"links":{"pr":"TBD","issue":"TBD"}}
+    {
+      "id": "HBTV-001",
+      "title": "Align parent versions + relativePath",
+      "priority": "P0",
+      "status": "done",
+      "owner": "build_release_engineer",
+      "dependencies": [],
+      "risk": "latent compile failures",
+      "due_date": "2026-04-30",
+      "progress_percent": 100,
+      "links": {
+        "pr": "3",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-002",
+      "title": "Add root/fwk module aggregation",
+      "priority": "P0",
+      "status": "done",
+      "owner": "build_release_engineer",
+      "dependencies": [
+        "HBTV-001"
+      ],
+      "risk": "reactor exposes failures",
+      "due_date": "2026-05-02",
+      "progress_percent": 100,
+      "links": {
+        "pr": "3",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-003",
+      "title": "Fix SNASPHOT typo and version policy",
+      "priority": "P1",
+      "status": "done",
+      "owner": "build_release_engineer",
+      "dependencies": [
+        "HBTV-001"
+      ],
+      "risk": "version drift",
+      "due_date": "2026-05-02",
+      "progress_percent": 100,
+      "links": {
+        "pr": "3",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-004",
+      "title": "Add baseline GitHub build workflow",
+      "priority": "P0",
+      "status": "done",
+      "owner": "build_release_engineer",
+      "dependencies": [
+        "HBTV-001",
+        "HBTV-002"
+      ],
+      "risk": "noisy CI gates",
+      "due_date": "2026-05-05",
+      "progress_percent": 100,
+      "links": {
+        "pr": "3",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-005",
+      "title": "Add PR + issue templates",
+      "priority": "P1",
+      "status": "todo",
+      "owner": "tech_lead",
+      "dependencies": [],
+      "risk": "adoption lag",
+      "due_date": "2026-05-06",
+      "progress_percent": 0,
+      "links": {
+        "pr": "TBD",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-006",
+      "title": "Bootstrap security dependency scan",
+      "priority": "P1",
+      "status": "todo",
+      "owner": "security_engineer",
+      "dependencies": [
+        "HBTV-004"
+      ],
+      "risk": "many legacy findings",
+      "due_date": "2026-05-10",
+      "progress_percent": 0,
+      "links": {
+        "pr": "TBD",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-007",
+      "title": "Java 17 compatibility profile",
+      "priority": "P1",
+      "status": "in_progress",
+      "owner": "architect_build_engineer",
+      "dependencies": [
+        "HBTV-001",
+        "HBTV-002"
+      ],
+      "risk": "legacy javafx blockers",
+      "due_date": "2026-05-20",
+      "progress_percent": 20,
+      "links": {
+        "pr": "build/hbtv-007-jaxb-core-generation",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-008",
+      "title": "Split unit vs integration tests",
+      "priority": "P1",
+      "status": "todo",
+      "owner": "qa_build_engineer",
+      "dependencies": [
+        "HBTV-002"
+      ],
+      "risk": "ownership ambiguity",
+      "due_date": "2026-05-25",
+      "progress_percent": 0,
+      "links": {
+        "pr": "TBD",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-008a",
+      "title": "URL modernization support task for HBTV-008",
+      "priority": "P1",
+      "status": "in_progress",
+      "owner": "qa_build_engineer",
+      "dependencies": [
+        "HBTV-008"
+      ],
+      "risk": "url updates alone do not restore provider plugins",
+      "due_date": "2026-05-25",
+      "progress_percent": 25,
+      "links": {
+        "pr": "TBD",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-009",
+      "title": "Modernize packaging path",
+      "priority": "P2",
+      "status": "todo",
+      "owner": "desktop_lead",
+      "dependencies": [
+        "HBTV-007"
+      ],
+      "risk": "packaging regressions",
+      "due_date": "2026-06-15",
+      "progress_percent": 0,
+      "links": {
+        "pr": "TBD",
+        "issue": "TBD"
+      }
+    },
+    {
+      "id": "HBTV-010",
+      "title": "Add CODEOWNERS and policy docs",
+      "priority": "P2",
+      "status": "todo",
+      "owner": "eng_manager_release_manager",
+      "dependencies": [
+        "HBTV-005"
+      ],
+      "risk": "policy drift",
+      "due_date": "2026-06-20",
+      "progress_percent": 0,
+      "links": {
+        "pr": "TBD",
+        "issue": "TBD"
+      }
+    }
   ],
   "blockers": [
-    {"id":"BLK-001","description":"Parent POM mismatch prevents module builds","impacted":["HBTV-001","HBTV-002","HBTV-004"],"owner":"build_release_engineer","escalate_by":"2026-04-25","status":"closed","closed_at":"2026-04-24"},
-    {"id":"BLK-002","description":"External HTTP repository returns 403","impacted":["HBTV-006","HBTV-007"],"owner":"build_release_engineer","escalate_by":"2026-04-28","status":"open"}
+    {
+      "id": "BLK-001",
+      "description": "Parent POM mismatch prevents module builds",
+      "impacted": [
+        "HBTV-001",
+        "HBTV-002",
+        "HBTV-004"
+      ],
+      "owner": "build_release_engineer",
+      "escalate_by": "2026-04-25",
+      "status": "closed",
+      "closed_at": "2026-04-24"
+    },
+    {
+      "id": "BLK-002",
+      "description": "External HTTP repository returns 403",
+      "impacted": [
+        "HBTV-006",
+        "HBTV-007"
+      ],
+      "owner": "build_release_engineer",
+      "escalate_by": "2026-04-28",
+      "status": "open"
+    }
   ],
   "changelog": [
-    {"timestamp":"2026-04-24T13:30:00Z","change":"Initialized tracker schema and governance"},
-    {"timestamp":"2026-04-24T13:35:00Z","change":"Added initial backlog with dependencies/dates"},
-    {"timestamp":"2026-04-24T13:40:00Z","change":"Synced tracker with modernization report v2"},
-    {"timestamp":"2026-04-24T16:10:00Z","change":"Completed P0 backlog (HBTV-001/002/004) and closed BLK-001"},
-    {"timestamp":"2026-04-24T18:05:00Z","change":"Started URL modernization by auditing obsolete HTTP/provider URLs and isolating network smoke tests (support task for HBTV-008)"}
+    {
+      "timestamp": "2026-04-24T13:30:00Z",
+      "change": "Initialized tracker schema and governance"
+    },
+    {
+      "timestamp": "2026-04-24T13:35:00Z",
+      "change": "Added initial backlog with dependencies/dates"
+    },
+    {
+      "timestamp": "2026-04-24T13:40:00Z",
+      "change": "Synced tracker with modernization report v2"
+    },
+    {
+      "timestamp": "2026-04-24T16:10:00Z",
+      "change": "Completed P0 backlog (HBTV-001/002/004) and closed BLK-001"
+    },
+    {
+      "timestamp": "2026-04-24T18:05:00Z",
+      "change": "Started URL modernization by auditing obsolete HTTP/provider URLs and isolating network smoke tests (support task for HBTV-008)"
+    },
+    {
+      "timestamp": "2026-04-25T11:10:00Z",
+      "change": "Started JAXB/core generation stabilization to unblock full Maven install and Java compatibility lanes."
+    }
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -1,6 +1,6 @@
 # Habitv Living Development Tracker
 
-_Last updated: 2026-04-24T18:05:00Z_
+_Last updated: 2026-04-25T11:10:00Z_
 
 ## Governance
 
@@ -39,7 +39,7 @@ A task is Done when:
 | HBTV-004 | Add baseline GitHub build workflow | P0 | Done | Build/Release Eng | HBTV-001,HBTV-002 | CI noise if gates too strict initially | 2026-05-05 | 100% | PR:3 / Issue:TBD |
 | HBTV-005 | Add PR template + modernization/bug/feature issue templates | P1 | Done | Tech Lead | None | Process adoption lag | 2026-05-06 | 100% | PR:4 / Issue:TBD |
 | HBTV-006 | Bootstrap security/dependency scan | P1 | Todo | Security Eng | HBTV-004 | Legacy deps trigger many findings | 2026-05-10 | 0% | PR:TBD / Issue:TBD |
-| HBTV-007 | Establish Java 17 compatibility build profile | P1 | Todo | Architect + Build Eng | HBTV-001,HBTV-002 | JavaFX legacy blockers | 2026-05-20 | 0% | PR:TBD / Issue:TBD |
+| HBTV-007 | Establish Java 17 compatibility build profile | P1 | In Progress | Architect + Build Eng | HBTV-001,HBTV-002 | JavaFX legacy blockers | 2026-05-20 | 20% | PR:build/hbtv-007-jaxb-core-generation / Issue:TBD |
 | HBTV-008 | Split deterministic unit vs integration tests | P1 | Todo | QA/Build Eng | HBTV-002 | Test ownership ambiguity | 2026-05-25 | 0% | PR:TBD / Issue:TBD |
 | HBTV-008a | URL modernization support task (HTTP/provider audit + network smoke test isolation) | P1 | In Progress | QA/Build Eng | HBTV-008 | URL-only updates may not restore provider compatibility | 2026-05-25 | 25% | PR:TBD / Issue:TBD |
 | HBTV-009 | Migrate packaging away from JDK7 JavaFX paths | P2 | Todo | Desktop Lead | HBTV-007 | Packaging regression on Windows/Linux | 2026-06-15 | 0% | PR:TBD / Issue:TBD |
@@ -61,8 +61,8 @@ A task is Done when:
 - 2026-04-24T13:40:00Z — Synced tracker with modernization report v2 and marked Phase 0 active.
 - 2026-04-24T16:10:00Z — Completed P0 backlog items HBTV-001/HBTV-002/HBTV-004; closed BLK-001.
 - 2026-04-24T16:25:00Z — Completed HBTV-005: PR template + modernization/bug/feature issue templates added.
-
 - 2026-04-24T18:05:00Z — Started URL modernization by auditing obsolete HTTP/provider URLs and isolating network smoke tests (support task for HBTV-008).
+- 2026-04-25T11:10:00Z — Started JAXB/core generation stabilization to unblock full Maven install and Java compatibility lanes.
 
 ## Next update trigger
 Update this file after each of:

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -1,6 +1,6 @@
 # Habitv Living Development Tracker
 
-_Last updated: 2026-04-25T11:10:00Z_
+_Last updated: 2026-04-25T12:00:00Z_
 
 ## Governance
 
@@ -27,7 +27,7 @@ A task is Done when:
 ## Program status
 - Overall program: **In Progress**
 - Current phase: **Phase 0 (Build stabilization)**
-- Progress: **40%**
+- Progress: **45%**
 
 ## Backlog (live)
 
@@ -39,8 +39,11 @@ A task is Done when:
 | HBTV-004 | Add baseline GitHub build workflow | P0 | Done | Build/Release Eng | HBTV-001,HBTV-002 | CI noise if gates too strict initially | 2026-05-05 | 100% | PR:3 / Issue:TBD |
 | HBTV-005 | Add PR template + modernization/bug/feature issue templates | P1 | Done | Tech Lead | None | Process adoption lag | 2026-05-06 | 100% | PR:4 / Issue:TBD |
 | HBTV-006 | Bootstrap security/dependency scan | P1 | Todo | Security Eng | HBTV-004 | Legacy deps trigger many findings | 2026-05-10 | 0% | PR:TBD / Issue:TBD |
-| HBTV-007 | Establish Java 17 compatibility build profile | P1 | In Progress | Architect + Build Eng | HBTV-001,HBTV-002 | JavaFX legacy blockers | 2026-05-20 | 20% | PR:build/hbtv-007-jaxb-core-generation / Issue:TBD |
+| HBTV-007 | Establish Java 17 compatibility build profile | P1 | In Progress | Architect + Build Eng | HBTV-001,HBTV-002 | JavaFX legacy blockers | 2026-05-20 | 35% | PR:10 / Issue:TBD |
 | HBTV-008 | Split deterministic unit vs integration tests | P1 | Todo | QA/Build Eng | HBTV-002 | Test ownership ambiguity | 2026-05-25 | 0% | PR:TBD / Issue:TBD |
+| HBTV-007a | Resolve `application/trayView` JavaFX compile blocker on modern toolchains | P1 | Todo | Desktop Lead + Build Eng | HBTV-007 | JavaFX modules absent outside JDK8 | 2026-05-22 | 0% | PR:TBD / Issue:TBD |
+| HBTV-007b | Add JAXB runtime provider for tests/runtime (`com.sun.xml.bind.v2.ContextFactory`) | P1 | Todo | Build/Release Eng | HBTV-007 | Runtime JAXB provider mismatch causes test failures | 2026-05-22 | 0% | PR:TBD / Issue:TBD |
+| HBTV-007c | Isolate remaining network-dependent `TestListHttp` from default install lifecycle | P1 | Todo | QA/Build Eng | HBTV-008a | Network-dependent test remains non-deterministic | 2026-05-25 | 0% | PR:TBD / Issue:TBD |
 | HBTV-008a | URL modernization support task (HTTP/provider audit + network smoke test isolation) | P1 | In Progress | QA/Build Eng | HBTV-008 | URL-only updates may not restore provider compatibility | 2026-05-25 | 25% | PR:TBD / Issue:TBD |
 | HBTV-009 | Migrate packaging away from JDK7 JavaFX paths | P2 | Todo | Desktop Lead | HBTV-007 | Packaging regression on Windows/Linux | 2026-06-15 | 0% | PR:TBD / Issue:TBD |
 | HBTV-010 | Add CODEOWNERS + release/build policy docs | P2 | Todo | Eng Manager + Release Mgr | HBTV-005 | Policy drift | 2026-06-20 | 0% | PR:TBD / Issue:TBD |
@@ -51,6 +54,9 @@ A task is Done when:
 |---|---|---|---|---|---|
 | BLK-001 | Parent POM mismatch prevents module builds | HBTV-001,HBTV-002,HBTV-004 | Build/Release Eng | 2026-04-25 | Closed (2026-04-24) |
 | BLK-002 | External HTTP repo returns 403 | HBTV-006,HBTV-007 | Build/Release Eng | 2026-04-28 | Open |
+| BLK-003 | `application/trayView` compile requires JavaFX classes not present in modern/non-JDK8 toolchains | HBTV-007,HBTV-007a | Desktop Lead + Build Eng | 2026-04-29 | Open |
+| BLK-004 | JAXB runtime provider `com.sun.xml.bind.v2.ContextFactory` missing in test/runtime paths | HBTV-007,HBTV-007b | Build/Release Eng | 2026-04-29 | Open |
+| BLK-005 | Remaining network-dependent `TestListHttp` keeps `install` non-deterministic | HBTV-008,HBTV-008a,HBTV-007c | QA/Build Eng | 2026-04-30 | Open |
 
 ## Decisions snapshot
 - See `docs/decision-log.md`.
@@ -62,7 +68,14 @@ A task is Done when:
 - 2026-04-24T16:10:00Z — Completed P0 backlog items HBTV-001/HBTV-002/HBTV-004; closed BLK-001.
 - 2026-04-24T16:25:00Z — Completed HBTV-005: PR template + modernization/bug/feature issue templates added.
 - 2026-04-24T18:05:00Z — Started URL modernization by auditing obsolete HTTP/provider URLs and isolating network smoke tests (support task for HBTV-008).
-- 2026-04-25T11:10:00Z — Started JAXB/core generation stabilization to unblock full Maven install and Java compatibility lanes.
+- 2026-04-25T12:00:00Z — Linked JAXB stabilization progress to PR:10, kept HBTV-007 In Progress, and added follow-up backlog items for JavaFX trayView, JAXB runtime provider, and TestListHttp isolation.
+
+## PR #10 final validation snapshot (for PR body sync)
+- GitHub Actions (Java 8 Ubuntu + Windows): **Success**.
+- `mvn -B -ntp -DskipTests validate`: **Success**.
+- `mvn -B -ntp -DskipTests compile`: **PR #10 fixes the application/core JAXB generation/accessor compile blocker. The next compile blocker is application/trayView because JavaFX classes are missing from the current toolchain.**
+- `mvn -B -ntp install`: **mvn install remains blocked by JAXB runtime provider/test-runtime setup and remaining network-dependent TestListHttp.**
+- Follow-ups are intentionally tracked outside PR #10 scope (HBTV-007a/HBTV-007b/HBTV-007c).
 
 ## Next update trigger
 Update this file after each of:

--- a/docs/jaxb-generation.md
+++ b/docs/jaxb-generation.md
@@ -1,0 +1,51 @@
+# JAXB generation in `application/core`
+
+## Scope
+This document describes how JAXB classes for the `application/core` module are generated and consumed.
+
+## Source schemas
+The JAXB model is generated from XSD files under:
+
+- `application/core/xsd/config.xsd`
+- `application/core/xsd/configuration.xsd`
+- `application/core/xsd/grab-config.xsd`
+
+## Maven generation contract
+Generation is configured in `application/core/pom.xml` with `com.sun.tools.xjc.maven2:maven-jaxb-plugin` pinned to `1.1.1`.
+
+Three executions are defined:
+
+- `config` -> `com.dabi.habitv.config.entities`
+- `configuration` -> `com.dabi.habitv.configuration.entities`
+- `grabconfig` -> `com.dabi.habitv.grabconfig.entities`
+
+Generated sources are written to:
+
+- `${project.build.directory}/generated-sources/jaxb`
+
+This keeps generated artifacts out of source control and avoids stale, root-level generated files causing compile drift.
+
+## Accessor naming expectations
+Boolean XSD elements are generated with `isXxx()` accessors by JAXB in this module (for example `isUpdateOnStartup`, `isDownload`, `isDeleted`).
+
+Production code in `application/core/src` must use the generated accessor contract and should not assume `getXxx()` for nullable booleans.
+
+## Committed vs regenerated sources
+Generated JAXB classes are **not committed**.
+
+- They are generated during Maven builds.
+- Build and IDE setups should rely on Maven lifecycle generation instead of editing generated Java files.
+
+## Validation commands
+Use these commands from repository root:
+
+```bash
+mvn -B -ntp -DskipTests validate
+mvn -B -ntp -DskipTests compile
+mvn -B -ntp install
+```
+
+## Java 8 / Java 17 notes
+- The current build lane remains Java 8-compatible and keeps `javax.xml.bind` usage intact.
+- This JAXB stabilization is intended to unblock `application/core` so Java 17 compatibility work can rebase cleanly afterward.
+- No `jakarta.xml.bind` migration is included in this scope.

--- a/docs/pr-10-body.md
+++ b/docs/pr-10-body.md
@@ -1,0 +1,37 @@
+# build: stabilize JAXB generation for core
+
+## Summary
+
+PR #10 stabilizes JAXB generation usage in `application/core` and aligns documentation so code, tracker status, and risk follow-ups land together in one linear history.
+
+## Root cause
+
+`application/core` consumed JAXB-generated types/accessors that drifted from the current generated model surface, causing compile-time symbol/accessor mismatches when the reactor reached core generation consumers.
+
+## What changed
+
+- Stabilized JAXB generation/accessor usage for `application/core` in PR #10 code.
+- Folded useful documentation updates from duplicate PR #11/#12 directly into this PR branch.
+- Added explicit follow-up tracker items for:
+  - JavaFX/trayView compile blocker (`HBTV-007a`)
+  - JAXB runtime provider gap (`HBTV-007b`)
+  - Remaining network-dependent `TestListHttp` (`HBTV-007c`)
+- Updated risk register entries for JAXB drift, JavaFX toolchain gap, JAXB runtime provider gap, and remaining network-dependent test risk.
+
+## Validation results
+
+- `mvn -B -ntp -DskipTests validate`: **Success**.
+- `mvn -B -ntp -DskipTests compile`: **PR #10 fixes the application/core JAXB generation/accessor compile blocker. The next compile blocker is application/trayView because JavaFX classes are missing from the current toolchain.**
+- `mvn -B -ntp install`: **mvn install remains blocked by JAXB runtime provider/test-runtime setup and remaining network-dependent TestListHttp.**
+
+## Known remaining blockers
+
+- `application/trayView` requires JavaFX classes not present in the current toolchain.
+- JAXB runtime provider setup for tests/runtime is still incomplete.
+- Remaining network-dependent `TestListHttp` is still in the default install path.
+
+## Follow-up PRs
+
+1. Resolve `application/trayView` JavaFX compile blocker (`HBTV-007a`).
+2. Add JAXB runtime provider for tests/runtime (`HBTV-007b`).
+3. Isolate `TestListHttp` from default install lifecycle (`HBTV-007c`).

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -11,6 +11,7 @@
 | R-006 | Legacy provider URLs may be obsolete or moved to new platforms | High | Medium | High | Maintain `docs/url-inventory.md` and review URLs during each provider touchpoint | QA/Build Eng | URL-based smoke checks fail or redirect unexpectedly | Open |
 | R-007 | HTTPS URL replacement alone may not restore provider plugins due to API/page changes | High | High | High | Track as `needs-dedicated-provider-rewrite` and schedule provider-specific rewrite PRs | Provider Maintainer | Parsing/downloading fails after URL modernization | Open |
 | R-008 | Network-dependent tests make local/CI builds non-deterministic | Medium | High | High | Keep network tests opt-in under `-Pnetwork-tests`; do not run by default lifecycle | Build/Release Eng | Flaky failures in default build pipelines | Open |
+| R-009 | JAXB-generated model drift breaks `application/core` compilation when schema-derived boolean accessors diverge from hand-coded `getXxx()` calls | Medium | High | High | Pin `maven-jaxb-plugin` version and align core code with generated JAXB accessor contract (`isXxx()` for booleans) | Architect + Build Eng | `application/core` compile errors against generated entities | Open |
 
 ## Escalation
 - If any exposure remains **High** for >10 calendar days, escalate to Architect and Engineering Manager.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -1,7 +1,7 @@
 # Habitv Risk Register
 
 | Risk ID | Description | Probability | Impact | Exposure | Mitigation | Owner role | Trigger | Status |
-|---|---|---|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | R-001 | Reactor wiring reveals many latent compile failures | Medium | High | Medium | Enable module profiles and fix iteratively; track compile fallout per module | Build/Release Eng | First full reactor CI run | Monitoring |
 | R-002 | Legacy external repository remains unavailable | Medium | High | High | Mirror artifacts into managed HTTPS repository | Build/Release Eng | Dependency resolve failure / 403 | Open |
 | R-003 | JavaFX packaging modernization breaks installer output | Medium | High | High | Keep packaging migration behind dedicated branch/profile + smoke tests | Desktop Lead | First jpackage trial | Open |
@@ -11,7 +11,11 @@
 | R-006 | Legacy provider URLs may be obsolete or moved to new platforms | High | Medium | High | Maintain `docs/url-inventory.md` and review URLs during each provider touchpoint | QA/Build Eng | URL-based smoke checks fail or redirect unexpectedly | Open |
 | R-007 | HTTPS URL replacement alone may not restore provider plugins due to API/page changes | High | High | High | Track as `needs-dedicated-provider-rewrite` and schedule provider-specific rewrite PRs | Provider Maintainer | Parsing/downloading fails after URL modernization | Open |
 | R-008 | Network-dependent tests make local/CI builds non-deterministic | Medium | High | High | Keep network tests opt-in under `-Pnetwork-tests`; do not run by default lifecycle | Build/Release Eng | Flaky failures in default build pipelines | Open |
-| R-009 | JAXB-generated model drift breaks `application/core` compilation when schema-derived boolean accessors diverge from hand-coded `getXxx()` calls | Medium | High | High | Pin `maven-jaxb-plugin` version and align core code with generated JAXB accessor contract (`isXxx()` for booleans) | Architect + Build Eng | `application/core` compile errors against generated entities | Open |
+| R-009 | JAXB model/accessor drift may recur until full `compile` + `install` are green in target toolchains | Medium | High | High | Keep deterministic generation + generated-source path controls; run full compile/install gates before closing HBTV-007 | Architect + Build/Release Eng | JAXB accessor mismatch compile/runtime regression | Mitigated (not closed) |
+| R-010 | `application/trayView` depends on JavaFX classes unavailable on modern/non-JDK8 toolchains | High | Medium | High | Track dedicated JavaFX blocker task (HBTV-007a) and validate with explicit JavaFX-enabled profile/toolchain | Desktop Lead + Build Eng | Compile fails when toolchain lacks JavaFX | Open |
+| R-011 | JAXB runtime provider (`com.sun.xml.bind.v2.ContextFactory`) missing during tests/runtime on modern JDKs | High | Medium | High | Add explicit JAXB runtime dependencies/provider wiring in follow-up task HBTV-007b | Build/Release Eng | `install` test phase fails creating JAXB context | Open |
+| R-012 | Remaining network-dependent `TestListHttp` keeps `mvn install` non-deterministic | High | Medium | High | Isolate `TestListHttp` as opt-in integration/network test and remove it from default install path | QA/Build Eng | `mvn install` fails in restricted networking or unstable remote conditions | Open |
 
 ## Escalation
+
 - If any exposure remains **High** for >10 calendar days, escalate to Architect and Engineering Manager.


### PR DESCRIPTION
# build: stabilize JAXB generation for core

## Summary

PR #10 stabilizes JAXB generation usage in `application/core` and aligns documentation so code, tracker status, and risk follow-ups land together in one linear history.

## Root cause

`application/core` consumed JAXB-generated types/accessors that drifted from the current generated model surface, causing compile-time symbol/accessor mismatches when the reactor reached core generation consumers.

## What changed

- Stabilized JAXB generation/accessor usage for `application/core` in PR #10 code.
- Folded useful documentation updates from duplicate PR #11/#12 directly into this PR branch.
- Added explicit follow-up tracker items for:
  - JavaFX/trayView compile blocker (`HBTV-007a`)
  - JAXB runtime provider gap (`HBTV-007b`)
  - Remaining network-dependent `TestListHttp` (`HBTV-007c`)
- Updated risk register entries for JAXB drift, JavaFX toolchain gap, JAXB runtime provider gap, and remaining network-dependent test risk.

## Validation results

- `mvn -B -ntp -DskipTests validate`: **Success**.
- `mvn -B -ntp -DskipTests compile`: **PR #10 fixes the application/core JAXB generation/accessor compile blocker. The next compile blocker is application/trayView because JavaFX classes are missing from the current toolchain.**
- `mvn -B -ntp install`: **mvn install remains blocked by JAXB runtime provider/test-runtime setup and remaining network-dependent TestListHttp.**

## Known remaining blockers

- `application/trayView` requires JavaFX classes not present in the current toolchain.
- JAXB runtime provider setup for tests/runtime is still incomplete.
- Remaining network-dependent `TestListHttp` is still in the default install path.

## Follow-up PRs

1. Resolve `application/trayView` JavaFX compile blocker (`HBTV-007a`).
2. Add JAXB runtime provider for tests/runtime (`HBTV-007b`).
3. Isolate `TestListHttp` from default install lifecycle (`HBTV-007c`).
