### PR TITLE
build(maven): switch parent pom to static maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<habitv.static.repo.dir>${env.HABITV_MAVEN_REPO_DIR}</habitv.static.repo.dir>
 	</properties>
 
 	 <scm>
@@ -21,16 +22,16 @@
 	
 	<distributionManagement>
 		<repository>
-			<id>ftp-repository</id>
-			<url>ftp://ftpperso.free.fr/repository</url>
+			<id>habitv-static-repository</id>
+			<url>file:///${habitv.static.repo.dir}</url>
 		</repository>	
   </distributionManagement>	
 	
 	<repositories>
 		<repository>
-			<id>dabi-repo</id>
-			<name>dabi-repo</name>
-			<url>http://dabiboo.free.fr/repository</url>
+			<id>habitv-static-repository</id>
+			<name>habitv-static-repository</name>
+			<url>https://raw.githubusercontent.com/Mika3578/habitv-repo/main</url>
 		</repository>
 	</repositories>	
 
@@ -168,14 +169,6 @@
 				<filtering>true</filtering>
 			</resource>			
 		</resources>	
-		<extensions>
-		<!-- Enabling the use of FTP -->
-			<extension>
-				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-ftp</artifactId>
-				<version>1.0-beta-6</version>
-			</extension>
-		</extensions>		
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<habitv.static.repo.dir>${env.HABITV_MAVEN_REPO_DIR}</habitv.static.repo.dir>
+		<habitv.static.repo.dir>${project.build.directory}/habitv-repo</habitv.static.repo.dir>
 	</properties>
 
 	 <scm>
@@ -23,15 +23,22 @@
 	<distributionManagement>
 		<repository>
 			<id>habitv-static-repository</id>
-			<url>file:///${habitv.static.repo.dir}</url>
-		</repository>	
+			<url>file:${habitv.static.repo.dir}</url>
+		</repository>
+		<snapshotRepository>
+			<id>habitv-static-snapshot-repository</id>
+			<url>file:${habitv.static.repo.dir}</url>
+		</snapshotRepository>
   </distributionManagement>	
 	
 	<repositories>
 		<repository>
 			<id>habitv-static-repository</id>
 			<name>habitv-static-repository</name>
-			<url>https://raw.githubusercontent.com/Mika3578/habitv-repo/main</url>
+			<url>https://raw.githubusercontent.com/Mika3578/habitv-repo/main/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</repository>
 	</repositories>	
 


### PR DESCRIPTION
## Summary
- replace legacy HTTP/FTP Maven endpoints in the parent POM with a static Maven repository strategy
- configure read access from https://raw.githubusercontent.com/Mika3578/habitv-repo/main
- configure deploy target as local file repository via HABITV_MAVEN_REPO_DIR and remove FTP wagon extension

## Test plan
- [x] run mvn -DskipTests package from repository root
- [ ] set HABITV_MAVEN_REPO_DIR and run mvn -DskipTests deploy
- [ ] verify published artifacts exist in static repo layout

## Notes
mvn -DskipTests package now passes the previous HTTP-blocker stage, but still fails on unresolved javax.xml.bind:jaxb-api:2.3.3 from configured repositories.

Made with [Cursor](https://cursor.com)