### PR TITLE
ci: update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   verify:
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     name: Verify (${{ matrix.os }}, Java ${{ matrix.java }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -21,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
### Motivation
- The Actions workflow referenced Node.js 20-based action majors which will be transitioned to Node 24, so the workflow needs to be aligned to avoid future runtime/deprecation issues.

### Description
- Add `env` with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the `verify` job and bump `actions/checkout@v4`→`actions/checkout@v5` and `actions/setup-java@v4`→`actions/setup-java@v5` in `.github/workflows/build.yml`.

### Testing
- Ran `mvn -B -ntp -DskipTests validate` against the repository and it completed with `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d3ad32408324ad5314daa6b6146d)