### PR TITLE
build: stabilize Maven reactor from master

### DIFF
--- a/application/consoleView/pom.xml
+++ b/application/consoleView/pom.xml
@@ -4,6 +4,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>application</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>consoleView</artifactId>
 	<packaging>jar</packaging>

--- a/application/core/pom.xml
+++ b/application/core/pom.xml
@@ -5,6 +5,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>application</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>core</artifactId>
 	<name>core</name>

--- a/application/habiTv/pom.xml
+++ b/application/habiTv/pom.xml
@@ -4,6 +4,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>application</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>habiTv</artifactId>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -3,7 +3,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>application</artifactId>

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -5,6 +5,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>application</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>trayView</artifactId>
 	<packaging>jar</packaging>

--- a/docs/audit-master-baseline.md
+++ b/docs/audit-master-baseline.md
@@ -192,3 +192,110 @@ Captured at PR creation time. Update if the environment changes.
   `4.1.0-SNASPHOT` typo in `fwk/framework/pom.xml`.
 - Keep the change scope to POM topology only; do not upgrade
   plugins or dependencies in that PR.
+
+## Maven reactor stabilization findings (HBTV-001)
+
+Captured during the `build: stabilize Maven reactor from master`
+PR. Branch: `build/stabilize-maven-reactor-from-master` based on
+`develop` (which was created from `origin/master` at the bootstrap
+merge commit). Local environment: Windows 11, Apache Maven 3.9.11,
+Azul Zulu OpenJDK 1.8.0_492.
+
+### Modules wired
+
+Reactor build order observed via `mvn -B -ntp -DskipTests validate`
+walks 32 entries:
+
+- Root: `com.dabi.habitv:parent` (pom).
+- `fwk`: `api`, `framework`, plus the `fwk` aggregator itself.
+- `application`: `core`, `consoleView`, `trayView`, `habiTv`, plus
+  the `application` aggregator itself.
+- `plugins`: 22 plugin modules (`6play`, `adobeHDS`, `aria2`,
+  `arte`, `beinsport`, `canalPlus`, `clubic`, `cmd`, `curl`,
+  `email`, `ffmpeg`, `file`, `footyroom`, `globalnews`, `lequipe`,
+  `mlssoccer`, `pluzz`, `RSS`, `rtmpDump`, `sfr`, `youtube`,
+  `wat`) plus the `plugins` aggregator itself.
+
+### Modules intentionally not wired
+
+- `application/habiTv-linux` and `application/habiTv-windows`.
+  Both declare hardcoded `${jdk.home}` properties pointing at
+  Linux/Windows JDK 7 install paths, use `system`-scope
+  `javafx:jfxrt` referencing `jfxrt.jar` under those paths, depend
+  on `com.zenjava:javafx-maven-plugin:2.0` (unmaintained), and use
+  `com.sun.javafx.tools.ant` packaging tasks. They cannot build
+  on a clean machine. Tracked under HBTV-008 (JavaFX / runtime
+  packaging audit). Their POMs were not modified in this PR.
+- `plugins/plugin-tester`. It is the shared harness referenced by
+  most plugin tests at `<scope>test</scope>`. `validate` and
+  `compile` do not exercise test sources, so excluding it from
+  the reactor does not block the current CI baseline. Wiring it
+  in will be revisited when HBTV-002 extends the workflow to
+  `test-compile` (or `test`).
+
+### Cross-cutting POM changes applied
+
+- Root `pom.xml`: added `<modules>fwk, application, plugins</modules>`.
+- `fwk/pom.xml`: added `<modules>api, framework</modules>`.
+- All in-reactor child POMs now declare their `<parent>` at
+  version `4.1.0-SNAPSHOT` with an explicit `<relativePath>` to
+  the correct parent file. This eliminates the previous Maven
+  warning "`parent.relativePath` ... points at ... instead of ...".
+- `fwk/framework/pom.xml`: own `<version>` fixed from
+  `4.1.0-SNASPHOT` to `4.1.0-SNAPSHOT`.
+- `application/habiTv-windows` was deliberately not edited.
+  It still parents to root `parent` (its sibling `habiTv-linux`
+  parents to `application`); both are out of the reactor.
+
+### Cross-cutting non-changes (preserved as-is)
+
+- Dependency versions are unchanged. Plugin own versions
+  `4.1.1-SNAPSHOT` (`pluzz`, `footyroom`, `beinsport`) and
+  `4.1.2-SNAPSHOT` (`ffmpeg`) are intentional (not typos).
+- Test-scope `plugin-tester` references at version `4.1.0`
+  inside plugin POMs are unchanged. They fail to resolve when
+  `test-compile` runs, but `validate` and `compile` do not
+  trigger them. HBTV-002 will reconcile.
+- The intra-reactor version range `[4.1,4.2)` on `api` and
+  `framework` inside the root `pom.xml` dependencyManagement is
+  unchanged. It is the next real blocker (see below); fixing it
+  belongs to HBTV-002 per scope rules.
+- `maven-jaxb-plugin` (`application/core`) still has no pinned
+  `<version>`. Warning persists; no change in this PR.
+- Legacy SVN `<scm>`, HTTP `dabiboo.free.fr` `<repository>`, and
+  FTP `<distributionManagement>` are untouched (HBTV-004).
+
+### Validation results
+
+- `git status --short`: 32 modified POMs plus the four docs
+  updates listed in the PR body.
+- `git branch --show-current`:
+  `build/stabilize-maven-reactor-from-master`.
+- `mvn -B -ntp -DskipTests validate` from the repository root:
+  `BUILD SUCCESS`, 32 reactor entries built (`pom` aggregators
+  plus `jar` modules). Only remaining warning is
+  `maven-jaxb-plugin` missing version (R-011).
+- `mvn -B -ntp -DskipTests compile` from the repository root:
+  `BUILD FAILURE` at `com.dabi.habitv:framework`. Cause:
+  `No versions available for com.dabi.habitv:api:jar:[4.1,4.2)
+  within specified range`. Maven cannot satisfy the closed range
+  because the only available `api` artifact is the reactor's
+  `4.1.0-SNAPSHOT`, which is not within `[4.1,4.2)` by default,
+  and the legacy `http://dabiboo.free.fr/repository` is blocked
+  by Maven 3.9 default mirror policy. Tracked as R-010 and
+  scoped to HBTV-002.
+
+### Next recommended PR
+
+`build: stabilize Java 8 compile baseline` (HBTV-002):
+
+- In root `pom.xml`, replace the intra-reactor dependencyManagement
+  ranges `[4.1,4.2)` on `com.dabi.habitv:api` and
+  `com.dabi.habitv:framework` with `${project.version}`.
+- Pin `com.sun.tools.xjc.maven2:maven-jaxb-plugin` to its last
+  known-working version in `application/core/pom.xml`.
+- Decide on `plugins/plugin-tester` wiring (likely include it as
+  a module so test-scope reactor coordinates resolve).
+- Keep scope to POM topology / version pins. No source changes,
+  no plugin upgrades, no provider rewrites, no JavaFX work, no
+  FTP/HTTP repo migration.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -29,27 +29,30 @@
     {
       "id": "HBTV-001",
       "title": "Maven reactor audit",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P0",
-      "scope": "Investigate why root pom.xml and fwk/pom.xml have no <modules>; propose corrected reactor wiring covering fwk, application, plugins (incl. plugin-tester, habiTv-linux, habiTv-windows).",
+      "scope": "Wire the Maven multi-module reactor so mvn validate walks the full project from root; align parent versions and relativePath across fwk, application, plugins. Topology only; no dependency or plugin upgrades, no source changes.",
       "acceptanceCriteria": [
-        "Reactor wiring proposal documented with reasoning.",
-        "Parent version mismatches identified (4.1.0 vs 4.1.0-SNAPSHOT, the 4.1.0-SNASPHOT typo in fwk/framework/pom.xml).",
-        "Pilot branch demonstrates mvn -N validate succeeds at root."
+        "Root pom.xml aggregates fwk, application, plugins.",
+        "fwk/pom.xml aggregates api, framework.",
+        "application/pom.xml keeps core, consoleView, trayView, habiTv; habiTv-linux and habiTv-windows intentionally excluded.",
+        "plugins/pom.xml keeps 22 plugin modules; plugin-tester intentionally excluded.",
+        "All child POMs parent at 4.1.0-SNAPSHOT with explicit <relativePath>.",
+        "fwk/framework own version typo 4.1.0-SNASPHOT fixed to 4.1.0-SNAPSHOT."
       ],
       "validation": [
-        "mvn -B -ntp -N -DskipTests validate",
-        "per-module smoke walk via mvn -B -ntp -pl <module> validate"
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS across 32 reactor modules",
+        "mvn -B -ntp -DskipTests compile -> FAILS at framework due to intra-reactor dependency range [4.1,4.2) excluding SNAPSHOT siblings; deferred to HBTV-002"
       ],
-      "pr": "build: stabilize Maven reactor from master (planned)",
-      "notes": "Audit + minimal wiring only; no plugin/version upgrades."
+      "pr": "build: stabilize Maven reactor from master",
+      "notes": "habiTv-linux/habiTv-windows out of reactor (hardcoded jdk.home, JDK-bundled JavaFX, ZenJava plugin); plugin-tester out of reactor (deferred to HBTV-002 test-compile scope); habiTv-windows still parents to root parent (sibling habiTv-linux parents to application); preserved because both modules are excluded."
     },
     {
       "id": "HBTV-002",
       "title": "Java 8 baseline CI",
       "status": "proposed",
       "priority": "P0",
-      "scope": "Extend baseline workflow from validate to compile (and later test) once HBTV-001 lands.",
+      "scope": "Extend baseline workflow from validate to compile (and later test) once HBTV-001 lands. Includes replacing intra-reactor version range [4.1,4.2) with ${project.version}, pinning maven-jaxb-plugin version, and deciding whether to wire plugin-tester into the reactor.",
       "acceptanceCriteria": [
         "mvn -B -ntp -DskipTests compile passes on Ubuntu and Windows with Temurin 8.",
         "Network/provider tests remain excluded by default."
@@ -58,7 +61,7 @@
         "CI matrix runs green on ubuntu-latest and windows-latest"
       ],
       "pr": "TBD",
-      "notes": "Depends on HBTV-001."
+      "notes": "Depends on HBTV-001. Compile currently fails at framework because of intra-reactor range [4.1,4.2) on api/framework."
     },
     {
       "id": "HBTV-003",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -32,36 +32,71 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 
 ## HBTV-001 — Maven reactor audit
 
-- Status: proposed
+- Status: in-progress
 - Priority: P0
-- Scope: Investigate and document why the root `pom.xml`, `fwk/pom.xml`
-  do not list `<modules>`; propose a corrected reactor that includes
-  `fwk`, `application`, `plugins` (and decides on
-  `plugins/plugin-tester`, `application/habiTv-linux`,
-  `application/habiTv-windows`).
+- Scope: Wire the Maven multi-module reactor so `mvn validate` walks
+  the full project from the root and parent resolution is
+  deterministic across `fwk`, `application`, and `plugins`. Topology
+  only; no dependency or plugin upgrades, no source changes.
 - Acceptance criteria:
-  - Reactor wiring proposal documented with reasoning.
-  - Parent version mismatches identified
-    (`4.1.0` vs `4.1.0-SNAPSHOT`, the `4.1.0-SNASPHOT` typo).
-  - Pilot branch demonstrates `mvn -N validate` succeeds at root.
-- Validation: `mvn -B -ntp -N -DskipTests validate` plus a per-module
-  smoke walk.
-- PR: build: stabilize Maven reactor from master (planned).
-- Notes: Audit + minimal wiring only; no plugin/version upgrades.
+  - Root `pom.xml` aggregates `fwk`, `application`, `plugins`. (done)
+  - `fwk/pom.xml` aggregates `api`, `framework`. (done)
+  - `application/pom.xml` keeps `core`, `consoleView`, `trayView`,
+    `habiTv`. `habiTv-linux` and `habiTv-windows` intentionally
+    excluded (hardcoded `${jdk.home}`, JDK-bundled JavaFX, ZenJava
+    plugin). (done — see notes)
+  - `plugins/pom.xml` keeps the 22 plugin modules. `plugin-tester`
+    intentionally excluded (deferred to HBTV-002 test-compile
+    scope). (done — see notes)
+  - All child POMs parent at `4.1.0-SNAPSHOT` with explicit
+    `<relativePath>`. (done)
+  - `fwk/framework/pom.xml` own version typo `4.1.0-SNASPHOT`
+    fixed to `4.1.0-SNAPSHOT`. (done)
+- Validation:
+  - `mvn -B -ntp -DskipTests validate` walks all 32 reactor
+    modules and reports BUILD SUCCESS.
+  - `mvn -B -ntp -DskipTests compile` reaches the next real
+    blocker (intra-reactor dependency range `[4.1,4.2)` on
+    `api`/`framework` in the root POM excludes SNAPSHOT siblings;
+    compile FAILS at `framework`). Deferred to HBTV-002.
+- PR: build: stabilize Maven reactor from master.
+- Notes:
+  - `habiTv-linux` and `habiTv-windows` left on disk but out of
+    the reactor; status documented in
+    `docs/audit-master-baseline.md`. They remain untouched and
+    are tracked under HBTV-008 (JavaFX / runtime packaging audit).
+  - `plugin-tester` left on disk but out of the reactor; test
+    sources depend on it only when the lifecycle reaches
+    `test-compile`, which HBTV-002 will address.
+  - One latent inconsistency intentionally preserved:
+    `application/habiTv-windows` parents to root `parent` while
+    its sibling `habiTv-linux` parents to `application`. Not
+    fixed because both modules are excluded from the reactor.
 
 ## HBTV-002 — Java 8 baseline CI
 
 - Status: proposed
 - Priority: P0
 - Scope: Extend the baseline workflow from `validate` to `compile`
-  (and later `test`) once HBTV-001 lands.
+  (and later `test`) once HBTV-001 lands. Specifically:
+  - Replace intra-reactor version range `[4.1,4.2)` on
+    `com.dabi.habitv:api` / `com.dabi.habitv:framework` in root
+    `pom.xml` with `${project.version}` so reactor SNAPSHOTs
+    resolve without the blocked HTTP repository.
+  - Decide whether to wire `plugins/plugin-tester` into the
+    reactor so test sources can resolve the harness once the
+    workflow reaches `test-compile`.
+  - Pin `maven-jaxb-plugin` to an explicit version (current
+    warning: missing version) so `application/core` keeps
+    generating deterministically.
 - Acceptance criteria:
   - `mvn -B -ntp -DskipTests compile` passes on Ubuntu and Windows
     with Temurin 8.
   - Network/provider tests remain excluded by default.
 - Validation: CI matrix runs green on Ubuntu and Windows.
 - PR: TBD.
-- Notes: Depends on HBTV-001.
+- Notes: Depends on HBTV-001. Compile currently fails at
+  `framework` because of the intra-reactor range.
 
 ## HBTV-003 — Repository branch / rules setup
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -16,6 +16,8 @@ or accepted.
 | R-007 | Auto-update pulls unexpected old artifacts     | Medium     | High   | P1       |
 | R-008 | yt-dlp migration changes download behavior     | Medium     | Medium | P2       |
 | R-009 | GitHub Pages layout mismatches updater         | Medium     | High   | P1       |
+| R-010 | Intra-reactor version range excludes SNAPSHOTs | High       | High   | P0       |
+| R-011 | maven-jaxb-plugin missing pinned version       | Medium     | Medium | P1       |
 
 ---
 
@@ -105,3 +107,26 @@ or accepted.
 - Mitigation: HBTV-005 defines the layout explicitly and validates
   it against `FindArtifactUtils.findLastVersionUrl` semantics
   before cutting over.
+
+## R-010 — Intra-reactor version range `[4.1,4.2)` excludes SNAPSHOTs
+
+- Description: Root `pom.xml` declares dependencyManagement entries
+  for `com.dabi.habitv:api` and `com.dabi.habitv:framework` with the
+  closed version range `[4.1,4.2)`. Maven does not by default
+  include `4.1.0-SNAPSHOT` in that range, and the legacy
+  `dabiboo.free.fr` HTTP repository (which would have served the
+  matching release) is blocked by Maven 3.9+ defaults and likely
+  unreachable. As a result, `mvn compile` fails at `framework`
+  during dependency collection.
+- Mitigation: Replace the range with `${project.version}` for
+  intra-reactor coordinates in HBTV-002. No code change; POM only.
+
+## R-011 — `maven-jaxb-plugin` missing pinned version
+
+- Description: `application/core/pom.xml` declares
+  `com.sun.tools.xjc.maven2:maven-jaxb-plugin` without a `<version>`.
+  Maven 3.9+ warns and may refuse to build in future versions. Build
+  behavior depends on which plugin version Maven happens to resolve.
+- Mitigation: Pin the plugin version (e.g. the last known-working
+  `1.1.1`) in HBTV-002 so JAXB generation stays deterministic. No
+  source change.

--- a/fwk/api/pom.xml
+++ b/fwk/api/pom.xml
@@ -3,7 +3,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>api</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/fwk/framework/pom.xml
+++ b/fwk/framework/pom.xml
@@ -4,12 +4,13 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>framework</artifactId>
 	<packaging>jar</packaging>
 	<name>framework</name>
-	<version>4.1.0-SNASPHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<scm>
 		<connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/fwk/framework</connection>

--- a/fwk/pom.xml
+++ b/fwk/pom.xml
@@ -11,4 +11,9 @@
 
 	<name>fwk habiTv</name>
 
+	<modules>
+		<module>api</module>
+		<module>framework</module>
+	</modules>
+
 </project>

--- a/fwk/pom.xml
+++ b/fwk/pom.xml
@@ -4,6 +4,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>fwk</artifactId>

--- a/plugins/6play/pom.xml
+++ b/plugins/6play/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>6play</artifactId>
 	<name>6play</name>

--- a/plugins/RSS/pom.xml
+++ b/plugins/RSS/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>RSS</artifactId>
 	<name>RSS</name>

--- a/plugins/adobeHDS/pom.xml
+++ b/plugins/adobeHDS/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>adobeHDS</artifactId>
 	<name>adobeHDS</name>

--- a/plugins/aria2/pom.xml
+++ b/plugins/aria2/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>aria2</artifactId>
 	<name>aria2</name>

--- a/plugins/arte/pom.xml
+++ b/plugins/arte/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>arte</artifactId>
 	<name>arte</name>

--- a/plugins/beinsport/pom.xml
+++ b/plugins/beinsport/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>beinsport</artifactId>
 	<name>beinsport</name>

--- a/plugins/canalPlus/pom.xml
+++ b/plugins/canalPlus/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>canalPlus</artifactId>
 	<name>canalPlus</name>

--- a/plugins/clubic/pom.xml
+++ b/plugins/clubic/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>clubic</artifactId>
 	<name>clubic</name>

--- a/plugins/cmd/pom.xml
+++ b/plugins/cmd/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>cmd</artifactId>
 	<name>cmd</name>

--- a/plugins/curl/pom.xml
+++ b/plugins/curl/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>curl</artifactId>
 	<name>curl</name>

--- a/plugins/email/pom.xml
+++ b/plugins/email/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>email</artifactId>
 	<name>email</name>

--- a/plugins/ffmpeg/pom.xml
+++ b/plugins/ffmpeg/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>ffmpeg</artifactId>
 	<name>ffmpeg</name>

--- a/plugins/file/pom.xml
+++ b/plugins/file/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>file</artifactId>
 	<name>file</name>

--- a/plugins/footyroom/pom.xml
+++ b/plugins/footyroom/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>footyroom</artifactId>
 	<version>4.1.1-SNAPSHOT</version>

--- a/plugins/globalnews/pom.xml
+++ b/plugins/globalnews/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>globalnews</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/plugins/lequipe/pom.xml
+++ b/plugins/lequipe/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>lequipe</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/plugins/mlssoccer/pom.xml
+++ b/plugins/mlssoccer/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mlssoccer</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/plugins/plugin-tester/pom.xml
+++ b/plugins/plugin-tester/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>plugin-tester</artifactId>
 	<packaging>jar</packaging>

--- a/plugins/pluzz/pom.xml
+++ b/plugins/pluzz/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>pluzz</artifactId>
 	<name>pluzz</name>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -3,7 +3,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>plugins</artifactId>
 	<packaging>pom</packaging>

--- a/plugins/rtmpDump/pom.xml
+++ b/plugins/rtmpDump/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>rtmpDump</artifactId>
 	<name>rtmpDump</name>

--- a/plugins/sfr/pom.xml
+++ b/plugins/sfr/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>sfr</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/plugins/wat/pom.xml
+++ b/plugins/wat/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>wat</artifactId>
 	<name>wat</name>

--- a/plugins/youtube/pom.xml
+++ b/plugins/youtube/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,12 @@
 
 	<name>Parent habiTv</name>
 
+	<modules>
+		<module>fwk</module>
+		<module>application</module>
+		<module>plugins</module>
+	</modules>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
## Summary

Wire the Maven multi-module reactor from the master restart baseline. After this PR, `mvn -B -ntp -DskipTests validate` walks the full 32-module project from the repository root instead of validating only the root parent POM. Parent resolution is now deterministic across `fwk`, `application`, and `plugins`.

Tracker: HBTV-001.

## Scope

POM topology only. Three commits, ordered for review:

1. `build: wire Maven reactor modules` (a26597a3) - `pom.xml`, `fwk/pom.xml` gain `<modules>`.
2. `build: align Maven parent resolution` (41d7226f) - 31 in-reactor child POMs: parent version `4.1.0` -> `4.1.0-SNAPSHOT`, explicit `<relativePath>`, and the `4.1.0-SNASPHOT` own-version typo on `fwk/framework/pom.xml`.
3. `docs: update reactor stabilization tracker` (1504a7ea) - `docs/dev-tracker.md`, `docs/dev-tracker.json`, `docs/risk-register.md` (adds R-010, R-011), `docs/audit-master-baseline.md` (appends "Maven reactor stabilization findings").

Modules intentionally not wired (documented, not removed):

- `application/habiTv-linux`, `application/habiTv-windows` - hardcoded `${jdk.home}`, JDK-bundled JavaFX, ZenJava plugin. Tracked under HBTV-008.
- `plugins/plugin-tester` - test-only harness; `validate` and `compile` do not need it. Deferred to HBTV-002 when CI extends to `test-compile`.

## Out of scope

- No Java upgrade (still Java 8 only).
- No JavaFX fix (HBTV-008).
- No JAXB migration (R-004).
- No provider rewrite (HBTV-006).
- No plugin removal (any plugin module).
- No runtime updater change (HBTV-005, R-007).
- No Maven deploy / static repo change (HBTV-004).
- No OWASP / CodeQL / SBOM / dependency scanning.
- No Java 17/21 CI.
- No `${project.version}` rewrite of the intra-reactor `[4.1,4.2)` dependency ranges (next PR, HBTV-002).
- No pinning of `maven-jaxb-plugin` (next PR, HBTV-002).
- No source code changes.

## Validation results

Run locally on Windows 11 with Apache Maven 3.9.11 and Azul Zulu OpenJDK 1.8.0_492. Local `~/.m2/repository/com/dabi/habitv` was cleared before running to avoid cache pollution from previous builds.

- `git status --short`: clean (only the untracked `.vscode/` IDE folder remains, which is not part of the repository).
- `git branch --show-current`: `build/stabilize-maven-reactor-from-master`.
- `mvn -B -ntp -DskipTests validate`: `BUILD SUCCESS` across 32 reactor entries (root parent + `api`, `framework`, `fwk` aggregator, `application` aggregator, `core`, `consoleView`, `trayView`, `habiTv`, `plugins` aggregator, and all 22 plugin modules). Only remaining warning is `maven-jaxb-plugin` missing `<version>` in `application/core/pom.xml` (R-011, deferred). No more `parent.relativePath points at X instead of Y` warnings.
- `mvn -B -ntp -DskipTests compile`: `BUILD FAILURE` at `com.dabi.habitv:framework`. Cause:

  ```
  Could not collect dependencies for project com.dabi.habitv:framework:jar:4.1.0-SNAPSHOT
  No versions available for com.dabi.habitv:api:jar:[4.1,4.2) within specified range
  ```

  Maven cannot satisfy the closed range `[4.1,4.2)` declared in the root `pom.xml` dependencyManagement for `api` and `framework` because the only available `api` artifact is the reactor's `4.1.0-SNAPSHOT` (snapshots are not included in closed ranges by default), and the legacy `http://dabiboo.free.fr/repository` is blocked by Maven 3.9 default mirror policy. Tracked as R-010, scoped to HBTV-002.

## Known remaining blockers

Observed in this PR; not fixed because they fall outside topology scope:

- R-010: Root `pom.xml` dependencyManagement uses `[4.1,4.2)` for intra-reactor `api` / `framework`. Blocks `mvn compile`. Fix in HBTV-002 by replacing with `${project.version}`.
- R-011: `com.sun.tools.xjc.maven2:maven-jaxb-plugin` has no pinned `<version>` in `application/core/pom.xml`. Maven 3.9 warns and may refuse to build in future versions. Fix in HBTV-002 by pinning to the last known-working version.
- Plugin test-scope references to `plugin-tester:4.1.0` (vs reactor `4.1.0-SNAPSHOT`) will fail once the lifecycle reaches `test-compile`. Reconcile in HBTV-002 with reactor coordinates.
- `application/habiTv-windows` still parents to root `parent` while its sibling `habiTv-linux` parents to `application`. Both modules are out of the reactor, so the inconsistency is harmless today. Reconcile in HBTV-008 when packaging modules are revisited.

## Manual repository settings reminder

After this PR merges into `develop` (and the bootstrap PR settles on `master`), the repository owner should:

- Set `develop` as the default branch if the team prefers PRs to target the integration branch by default. `master` remains the protected stable baseline either way.
- Protect `master`: require PR, require status checks, require linear history, disallow force pushes and deletions.
- Protect `develop`: same rules as `master`.
- Once GitHub exposes them on a PR, mark these checks as required for `master` and `develop`:
  - `build / validate (ubuntu-latest, java8)`
  - `build / validate (windows-latest, java8)`

Full recommendations live in `docs/github-repository-settings.md`.

## Next PR recommendation

`build: stabilize Java 8 compile baseline` (HBTV-002):

- In root `pom.xml`, replace the dependencyManagement ranges `[4.1,4.2)` on `com.dabi.habitv:api` and `com.dabi.habitv:framework` with `${project.version}` so reactor SNAPSHOTs resolve without hitting the blocked HTTP repository.
- Pin `com.sun.tools.xjc.maven2:maven-jaxb-plugin` to its last known-working version in `application/core/pom.xml`.
- Decide on `plugins/plugin-tester` wiring (most likely add it to the `plugins` aggregator so test-scope reactor coordinates resolve).
- Keep scope to POM topology / version pins. No source changes, no plugin upgrades, no provider rewrites, no JavaFX work, no FTP/HTTP repository migration.