### PR TITLE
build: stabilize Java 8 compile baseline

### DIFF
--- a/application/core/pom.xml
+++ b/application/core/pom.xml
@@ -42,6 +42,7 @@
 			<plugin>
 				<groupId>com.sun.tools.xjc.maven2</groupId>
 				<artifactId>maven-jaxb-plugin</artifactId>
+				<version>1.1.1</version>
 				<executions>
 					<execution>
 						<id>config</id>

--- a/docs/audit-master-baseline.md
+++ b/docs/audit-master-baseline.md
@@ -285,7 +285,7 @@ walks 32 entries:
   by Maven 3.9 default mirror policy. Tracked as R-010 and
   scoped to HBTV-002.
 
-### Next recommended PR
+### Next recommended PR after HBTV-002
 
 `build: stabilize Java 8 compile baseline` (HBTV-002):
 
@@ -299,3 +299,50 @@ walks 32 entries:
 - Keep scope to POM topology / version pins. No source changes,
   no plugin upgrades, no provider rewrites, no JavaFX work, no
   FTP/HTTP repo migration.
+
+## Java 8 compile baseline findings (HBTV-002)
+
+Captured during the `build: stabilize Java 8 compile baseline` PR on
+branch `build/stabilize-java8-compile-baseline` from `develop`.
+Environment: Windows 11, Apache Maven 3.9.11, Java 8.
+
+### Scope applied
+
+- Root `pom.xml`: replaced dependencyManagement ranges `[4.1,4.2)` for
+  intra-reactor `com.dabi.habitv:api` and `com.dabi.habitv:framework`
+  with `${project.version}`.
+- `application/core/pom.xml`: pinned
+  `com.sun.tools.xjc.maven2:maven-jaxb-plugin` to `1.1.1`.
+- `plugins/pom.xml`: temporary evaluation adding
+  `<module>plugin-tester</module>` was tested and reverted because it
+  did not resolve compile.
+
+### Validation progression
+
+- Baseline `mvn -B -ntp -DskipTests validate`: `BUILD SUCCESS` across
+  32 modules, with warning about missing `maven-jaxb-plugin` version.
+- Baseline `mvn -B -ntp -DskipTests compile`: `BUILD FAILURE` at
+  `framework` due to `api:jar:[4.1,4.2)` resolution.
+- After root version fix: `compile` moved past `framework` and reached
+  `plugins/6play`.
+- After JAXB plugin pin: warning removed from `validate`; `compile`
+  still failed at `plugins/6play` on
+  `com.dabi.habitv:plugin-tester:4.1.0` descriptor resolution via the
+  blocked legacy repository.
+- With temporary `plugin-tester` reactor inclusion: `compile` still
+  failed at the same place because module POMs request `4.1.0` while
+  reactor builds `4.1.0-SNAPSHOT`.
+
+### Risk status impact
+
+- R-010 mitigated by replacing intra-reactor ranges with
+  `${project.version}`.
+- R-011 mitigated by pinning JAXB plugin version to `1.1.1`.
+- New blocker logged as R-012 (plugin tester version mismatch).
+
+### Next recommended PR
+
+Follow up HBTV-002 with a POM-only change set to align plugin
+test-harness dependencies from `plugin-tester:4.1.0` to reactor-aligned
+coordinates (for example `${project.version}`), then re-run
+`mvn -B -ntp -DskipTests compile`.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -50,7 +50,7 @@
     {
       "id": "HBTV-002",
       "title": "Java 8 baseline CI",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P0",
       "scope": "Extend baseline workflow from validate to compile (and later test) once HBTV-001 lands. Includes replacing intra-reactor version range [4.1,4.2) with ${project.version}, pinning maven-jaxb-plugin version, and deciding whether to wire plugin-tester into the reactor.",
       "acceptanceCriteria": [
@@ -58,10 +58,16 @@
         "Network/provider tests remain excluded by default."
       ],
       "validation": [
-        "CI matrix runs green on ubuntu-latest and windows-latest"
+        "Baseline: mvn -B -ntp -DskipTests validate -> BUILD SUCCESS (32 modules) with warning about missing maven-jaxb-plugin version",
+        "Baseline: mvn -B -ntp -DskipTests compile -> BUILD FAILURE at framework: No versions available for com.dabi.habitv:api:jar:[4.1,4.2)",
+        "After root dependencyManagement fix (${project.version} for api/framework): mvn -B -ntp -DskipTests validate -> BUILD SUCCESS",
+        "After root dependencyManagement fix (${project.version} for api/framework): mvn -B -ntp -DskipTests compile -> moves past framework, fails at 6play on plugin-tester:4.1.0 descriptor resolution",
+        "After pinning com.sun.tools.xjc.maven2:maven-jaxb-plugin to 1.1.1: mvn -B -ntp -DskipTests validate -> BUILD SUCCESS without missing plugin version warning",
+        "After pinning com.sun.tools.xjc.maven2:maven-jaxb-plugin to 1.1.1: mvn -B -ntp -DskipTests compile -> BUILD FAILURE at 6play due to plugin-tester:4.1.0 resolution via blocked legacy repository",
+        "Evaluation only: adding <module>plugin-tester</module> in plugins/pom.xml does not remove the compile blocker because plugin dependencies request 4.1.0 while reactor builds 4.1.0-SNAPSHOT; change not kept"
       ],
-      "pr": "TBD",
-      "notes": "Depends on HBTV-001. Compile currently fails at framework because of intra-reactor range [4.1,4.2) on api/framework."
+      "pr": "build: stabilize Java 8 compile baseline",
+      "notes": "Depends on HBTV-001. R-010 and R-011 are mitigated by this PR. Remaining blocker: plugin-tester test-harness version alignment (4.1.0 in plugin dependencies vs 4.1.0-SNAPSHOT in reactor)."
     },
     {
       "id": "HBTV-003",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -75,7 +75,7 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 
 ## HBTV-002 — Java 8 baseline CI
 
-- Status: proposed
+- Status: in-progress
 - Priority: P0
 - Scope: Extend the baseline workflow from `validate` to `compile`
   (and later `test`) once HBTV-001 lands. Specifically:
@@ -93,10 +93,29 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
   - `mvn -B -ntp -DskipTests compile` passes on Ubuntu and Windows
     with Temurin 8.
   - Network/provider tests remain excluded by default.
-- Validation: CI matrix runs green on Ubuntu and Windows.
-- PR: TBD.
-- Notes: Depends on HBTV-001. Compile currently fails at
-  `framework` because of the intra-reactor range.
+- Validation:
+  - Baseline (before fixes):
+    - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS` (32 modules)
+      with warning: `maven-jaxb-plugin` missing version.
+    - `mvn -B -ntp -DskipTests compile` -> `BUILD FAILURE` at
+      `framework`: `No versions available for ... api:jar:[4.1,4.2)`.
+  - After replacing root intra-reactor ranges with `${project.version}`:
+    - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS`.
+    - `mvn -B -ntp -DskipTests compile` moves past `framework` and fails
+      later at `6play` on `plugin-tester:4.1.0` descriptor resolution.
+  - After pinning `maven-jaxb-plugin` to `1.1.1` in `application/core`:
+    - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS` with no
+      missing-plugin-version warning.
+    - `mvn -B -ntp -DskipTests compile` still fails at `6play` due to
+      `plugin-tester:4.1.0` resolution via blocked legacy repository.
+  - Evaluation: adding `<module>plugin-tester</module>` to
+    `plugins/pom.xml` does not remove the compile blocker because plugin
+    modules still request `plugin-tester:4.1.0` while reactor builds
+    `4.1.0-SNAPSHOT`. Change was not kept in this PR.
+- PR: build: stabilize Java 8 compile baseline.
+- Notes: Depends on HBTV-001. R-010 and R-011 are mitigated; the next
+  blocker is plugin test-harness version alignment (`plugin-tester`
+  `4.1.0` vs reactor `4.1.0-SNAPSHOT`).
 
 ## HBTV-003 — Repository branch / rules setup
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -5,19 +5,20 @@ Severity uses `Likelihood x Impact` (Low / Medium / High) and an
 overall priority. Update when a risk is added, mitigated, realized,
 or accepted.
 
-| ID    | Title                                          | Likelihood | Impact | Priority |
-|-------|------------------------------------------------|------------|--------|----------|
-| R-001 | Legacy Maven repository / free.fr dependency   | High       | High   | P0       |
-| R-002 | FTP deployment no longer viable                | High       | High   | P0       |
-| R-003 | JavaFX tied to JDK 8 assumptions               | High       | High   | P1       |
-| R-004 | JAXB generation / runtime mismatch             | Medium     | High   | P1       |
-| R-005 | Live provider tests are non-deterministic      | High       | Medium | P1       |
-| R-006 | Provider endpoints obsolete or renamed         | High       | Medium | P1       |
-| R-007 | Auto-update pulls unexpected old artifacts     | Medium     | High   | P1       |
-| R-008 | yt-dlp migration changes download behavior     | Medium     | Medium | P2       |
-| R-009 | GitHub Pages layout mismatches updater         | Medium     | High   | P1       |
-| R-010 | Intra-reactor version range excludes SNAPSHOTs | High       | High   | P0       |
-| R-011 | maven-jaxb-plugin missing pinned version       | Medium     | Medium | P1       |
+| ID    | Title                                                           | Likelihood | Impact | Priority |
+|-------|-----------------------------------------------------------------|------------|--------|----------|
+| R-001 | Legacy Maven repository / free.fr dependency                    | High       | High   | P0       |
+| R-002 | FTP deployment no longer viable                                 | High       | High   | P0       |
+| R-003 | JavaFX tied to JDK 8 assumptions                                | High       | High   | P1       |
+| R-004 | JAXB generation / runtime mismatch                              | Medium     | High   | P1       |
+| R-005 | Live provider tests are non-deterministic                       | High       | Medium | P1       |
+| R-006 | Provider endpoints obsolete or renamed                          | High       | Medium | P1       |
+| R-007 | Auto-update pulls unexpected old artifacts                      | Medium     | High   | P1       |
+| R-008 | yt-dlp migration changes download behavior                      | Medium     | Medium | P2       |
+| R-009 | GitHub Pages layout mismatches updater                          | Medium     | High   | P1       |
+| R-010 | Intra-reactor version range excludes SNAPSHOTs (mitigated)      | Low        | Low    | P3       |
+| R-011 | maven-jaxb-plugin missing pinned version (mitigated)            | Low        | Low    | P3       |
+| R-012 | Plugin tester version mismatch blocks compile                   | High       | Medium | P1       |
 
 ---
 
@@ -120,6 +121,8 @@ or accepted.
   during dependency collection.
 - Mitigation: Replace the range with `${project.version}` for
   intra-reactor coordinates in HBTV-002. No code change; POM only.
+- Status: Mitigated in HBTV-002 by replacing the `api` and `framework`
+  root dependencyManagement versions with `${project.version}`.
 
 ## R-011 — `maven-jaxb-plugin` missing pinned version
 
@@ -130,3 +133,20 @@ or accepted.
 - Mitigation: Pin the plugin version (e.g. the last known-working
   `1.1.1`) in HBTV-002 so JAXB generation stays deterministic. No
   source change.
+- Status: Mitigated in HBTV-002 by pinning
+  `com.sun.tools.xjc.maven2:maven-jaxb-plugin` to `1.1.1` in
+  `application/core/pom.xml`.
+
+## R-012 — Plugin tester version mismatch blocks compile
+
+- Description: Plugin modules declare test-scope dependencies on
+  `com.dabi.habitv:plugin-tester:4.1.0`, while the project version is
+  `4.1.0-SNAPSHOT` and the reactor artifact is
+  `com.dabi.habitv:plugin-tester:4.1.0-SNAPSHOT`. During
+  `mvn -B -ntp -DskipTests compile`, Maven fails at `plugins/6play`
+  while resolving the `plugin-tester:4.1.0` descriptor from the blocked
+  legacy HTTP repository.
+- Mitigation: Dedicated POM-only follow-up to align plugin test-harness
+  versions to reactor coordinates (for example `${project.version}`) and
+  confirm whether `plugin-tester` should stay aggregated in
+  `plugins/pom.xml`.

--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>api</artifactId>
-			<version>[4.1,4.2)</version>
+			<version>${project.version}</version>
 		</dependency>	
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>framework</artifactId>
-			<version>[4.1,4.2)</version>
+			<version>${project.version}</version>
 		</dependency>			
 
 		<dependency>


### PR DESCRIPTION
## Summary
This PR resolves the first Java 8 compile blocker after Maven reactor stabilization by switching intra-reactor dependency management from a closed range to the reactor project version, and by pinning the JAXB generation plugin version for deterministic builds.

## Scope
- root `pom.xml`: replace dependencyManagement versions for `com.dabi.habitv:api` and `com.dabi.habitv:framework` from `[4.1,4.2)` to `${project.version}`
- `application/core/pom.xml`: pin `com.sun.tools.xjc.maven2:maven-jaxb-plugin` to `1.1.1`
- plugin-tester reactor decision: evaluated adding `<module>plugin-tester</module>` in `plugins/pom.xml`, but did not keep it because compile still fails on `plugin-tester:4.1.0` descriptor resolution
- docs updates: `docs/dev-tracker.md`, `docs/dev-tracker.json`, `docs/risk-register.md`, `docs/audit-master-baseline.md`

## Out of scope
- No Java upgrade
- No JavaFX packaging fix
- No provider rewrite
- No plugin removal
- No yt-dlp migration
- No runtime updater change
- No Maven deploy/static repo migration
- No OWASP/CodeQL/SBOM
- No Java 17/21 CI

## Validation results
### Baseline (before fixes)
`git status --short`
```text
?? .vscode/
```

`git branch --show-current`
```text
build/stabilize-java8-compile-baseline
```

`mvn -B -ntp -DskipTests validate`
```text
[INFO] BUILD SUCCESS
[INFO] Total time:  2.788 s
```

`mvn -B -ntp -DskipTests compile`
```text
[INFO] BUILD FAILURE
[ERROR] Failed to execute goal on project framework: Could not collect dependencies for project com.dabi.habitv:framework:jar:4.1.0-SNAPSHOT
[ERROR] No versions available for com.dabi.habitv:api:jar:[4.1,4.2) within specified range
```

### Final (this branch)
`git status --short`
```text
?? .vscode/
```

`git branch --show-current`
```text
build/stabilize-java8-compile-baseline
```

`mvn -B -ntp -DskipTests validate`
```text
[INFO] BUILD SUCCESS
[INFO] Reactor Summary: ... 32/32 SUCCESS
```

`mvn -B -ntp -DskipTests compile`
```text
[INFO] BUILD FAILURE
[ERROR] Failed to execute goal on project 6play: Could not collect dependencies for project com.dabi.habitv:6play:jar:4.1.0-SNAPSHOT
[ERROR] Failed to read artifact descriptor for com.dabi.habitv:plugin-tester:jar:4.1.0
[ERROR] Caused by: ... Could not transfer artifact com.dabi.habitv:plugin-tester:pom:4.1.0 ... Blocked mirror for repositories: [dabi-repo (http://dabiboo.free.fr/repository, default, releases+snapshots)]
```

## Known remaining blockers
- `mvn -B -ntp -DskipTests compile` now fails at `plugins/6play` due to plugin test-harness dependency mismatch (`plugin-tester:4.1.0` requested by plugin module POMs versus reactor `plugin-tester:4.1.0-SNAPSHOT`) and blocked legacy HTTP repository fallback.

## Risk updates
- R-010: mitigated (intra-reactor range on `api/framework` replaced with `${project.version}`)
- R-011: mitigated (`maven-jaxb-plugin` pinned to `1.1.1`)
- New risk: R-012 added for plugin tester version mismatch blocking compile

## Next PR recommendation
Follow up HBTV-002 with a POM-only PR that aligns plugin test-harness dependencies from `com.dabi.habitv:plugin-tester:4.1.0` to reactor-aligned coordinates (for example `${project.version}`), then re-run `mvn -B -ntp -DskipTests compile`.