### PR TITLE
build: align plugin tester reactor dependency

### DIFF
--- a/docs/audit-master-baseline.md
+++ b/docs/audit-master-baseline.md
@@ -346,3 +346,52 @@ Follow up HBTV-002 with a POM-only change set to align plugin
 test-harness dependencies from `plugin-tester:4.1.0` to reactor-aligned
 coordinates (for example `${project.version}`), then re-run
 `mvn -B -ntp -DskipTests compile`.
+
+## Plugin tester alignment findings (HBTV-010)
+
+Captured during the `build: align plugin tester reactor dependency` PR on
+branch `build/align-plugin-tester-reactor-dependency` from `develop`.
+Environment: Windows 11, Apache Maven 3.9.11, Java 8.
+
+### Scope applied
+
+- Plugin module POMs that pinned
+  `com.dabi.habitv:plugin-tester:4.1.0` now use reactor-aligned version
+  expressions:
+  - `${project.version}` for modules on the parent line.
+  - `${project.parent.version}` for modules with independent own
+    versions (`beinsport`, `footyroom`, `pluzz`, `ffmpeg`).
+- `plugins/pom.xml` now includes `<module>plugin-tester</module>` before
+  the provider plugin modules, so the test harness is built in-reactor.
+
+### Validation results
+
+- Baseline `mvn -B -ntp -DskipTests validate`: `BUILD SUCCESS`
+  (32 modules).
+- Baseline `mvn -B -ntp -DskipTests compile`: `BUILD FAILURE` at
+  `6play` due to `com.dabi.habitv:plugin-tester:4.1.0` descriptor
+  resolution via blocked `http://dabiboo.free.fr/repository`.
+- After alignment `mvn -B -ntp -DskipTests validate`: `BUILD SUCCESS`
+  (33 modules, including `plugin-tester`).
+- After alignment `mvn -B -ntp -DskipTests compile`: `BUILD FAILURE`
+  later at `beinsport` while resolving
+  `com.dabi.habitv:framework:4.1.1-SNAPSHOT` and
+  `com.dabi.habitv:api:4.1.1-SNAPSHOT` from the blocked legacy
+  repository.
+
+### Risk and tracker impact
+
+- R-012 is mitigated: compile now moves past the plugin-tester
+  descriptor blocker.
+- Remaining blocker class is legacy external repository resolution,
+  mapped to HBTV-004.
+
+### Next recommended PR
+
+`build: align plugin module framework/api reactor versions` (HBTV-004):
+
+- Replace non-reactor `4.1.1-SNAPSHOT` / `4.1.2-SNAPSHOT` intra-project
+  dependency coordinates in plugin POMs with parent-reactor-aligned
+  expressions where valid.
+- Keep scope POM-only; do not change Java source, provider behavior,
+  JavaFX modules, runtime updater, or repository publication settings.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -167,6 +167,26 @@
       ],
       "pr": "TBD",
       "notes": "Pairs with Phase 7 of docs/dev-plan.md."
+    },
+    {
+      "id": "HBTV-010",
+      "title": "Plugin tester reactor dependency alignment",
+      "status": "done",
+      "priority": "P1",
+      "scope": "Align plugin module test-harness dependencies so com.dabi.habitv:plugin-tester resolves from reactor coordinates; aggregate plugins/plugin-tester in plugins/pom.xml.",
+      "acceptanceCriteria": [
+        "Plugin modules that pinned com.dabi.habitv:plugin-tester:4.1.0 use reactor-aligned expressions (${project.version} or ${project.parent.version} for modules with independent own versions).",
+        "plugins/pom.xml includes <module>plugin-tester</module>.",
+        "mvn -B -ntp -DskipTests compile moves past the previous plugin-tester descriptor blocker at 6play."
+      ],
+      "validation": [
+        "Baseline: mvn -B -ntp -DskipTests validate -> BUILD SUCCESS (32 modules)",
+        "Baseline: mvn -B -ntp -DskipTests compile -> BUILD FAILURE at 6play on com.dabi.habitv:plugin-tester:4.1.0 descriptor resolution via blocked legacy repository",
+        "After alignment: mvn -B -ntp -DskipTests validate -> BUILD SUCCESS (33 modules, plugin-tester included)",
+        "After alignment: mvn -B -ntp -DskipTests compile -> moves past 6play and fails later at beinsport on framework/api:4.1.1-SNAPSHOT resolution via blocked legacy repository (HBTV-004 class)"
+      ],
+      "pr": "build: align plugin tester reactor dependency",
+      "notes": "Mitigates R-012. Remaining compile blocker is legacy repository resolution for non-reactor versions in selected plugin modules."
     }
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -213,3 +213,37 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 - Validation: Audit reviewed in PR; no code changes in this item.
 - PR: TBD.
 - Notes: Pairs with Phase 7 of `docs/dev-plan.md`.
+
+## HBTV-010 — Plugin tester reactor dependency alignment
+
+- Status: done
+- Priority: P1
+- Scope: Align plugin module test-harness dependencies so
+  `com.dabi.habitv:plugin-tester` resolves from the local reactor line
+  instead of the blocked legacy HTTP repository; aggregate
+  `plugins/plugin-tester` in `plugins/pom.xml`.
+- Acceptance criteria:
+  - Every plugin module that pinned
+    `com.dabi.habitv:plugin-tester:4.1.0` now uses the reactor version
+    expression (`${project.version}` or `${project.parent.version}` for
+    modules with independent own versions).
+  - `plugins/pom.xml` includes `<module>plugin-tester</module>`.
+  - `mvn -B -ntp -DskipTests compile` moves past the former
+    `plugin-tester:4.1.0` descriptor blocker.
+- Validation:
+  - Baseline:
+    - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS` (32 modules).
+    - `mvn -B -ntp -DskipTests compile` -> `BUILD FAILURE` at `6play` on
+      `com.dabi.habitv:plugin-tester:4.1.0` descriptor resolution from
+      blocked `http://dabiboo.free.fr/repository`.
+  - After alignment:
+    - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS` (33 modules;
+      includes `plugin-tester`).
+    - `mvn -B -ntp -DskipTests compile` -> moves past `6play` and fails
+      later at `beinsport` on `framework/api:4.1.1-SNAPSHOT` resolution
+      from blocked legacy repository (HBTV-004-class blocker).
+- PR: build: align plugin tester reactor dependency.
+- Notes: R-012 is mitigated by this item. Remaining compile blocker is
+  legacy repository resolution for non-reactor versions in selected
+  plugin modules (`beinsport`, with similar risk for `footyroom`,
+  `pluzz`, and `ffmpeg`).

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -18,7 +18,7 @@ or accepted.
 | R-009 | GitHub Pages layout mismatches updater                          | Medium     | High   | P1       |
 | R-010 | Intra-reactor version range excludes SNAPSHOTs (mitigated)      | Low        | Low    | P3       |
 | R-011 | maven-jaxb-plugin missing pinned version (mitigated)            | Low        | Low    | P3       |
-| R-012 | Plugin tester version mismatch blocks compile                   | High       | Medium | P1       |
+| R-012 | Plugin tester version mismatch blocks compile (mitigated)       | Low        | Low    | P3       |
 
 ---
 
@@ -150,3 +150,10 @@ or accepted.
   versions to reactor coordinates (for example `${project.version}`) and
   confirm whether `plugin-tester` should stay aggregated in
   `plugins/pom.xml`.
+- Status: Mitigated in HBTV-010 by aligning plugin test-harness
+  dependency versions to reactor expressions and including
+  `plugins/plugin-tester` in `plugins/pom.xml`; `mvn compile` now moves
+  past the former `6play`/`plugin-tester:4.1.0` descriptor blocker.
+- Residual risk: Compile still hits blocked legacy repository resolution
+  for `framework/api:4.1.1-SNAPSHOT` in `beinsport`, which is tracked
+  under the existing legacy repository migration risk (R-001 / HBTV-004).

--- a/plugins/6play/pom.xml
+++ b/plugins/6play/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>		
 		<dependency>

--- a/plugins/RSS/pom.xml
+++ b/plugins/RSS/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/adobeHDS/pom.xml
+++ b/plugins/adobeHDS/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/aria2/pom.xml
+++ b/plugins/aria2/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/arte/pom.xml
+++ b/plugins/arte/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/plugins/beinsport/pom.xml
+++ b/plugins/beinsport/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/plugins/canalPlus/pom.xml
+++ b/plugins/canalPlus/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/clubic/pom.xml
+++ b/plugins/clubic/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/cmd/pom.xml
+++ b/plugins/cmd/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/curl/pom.xml
+++ b/plugins/curl/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/email/pom.xml
+++ b/plugins/email/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/plugins/ffmpeg/pom.xml
+++ b/plugins/ffmpeg/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/footyroom/pom.xml
+++ b/plugins/footyroom/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/globalnews/pom.xml
+++ b/plugins/globalnews/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/lequipe/pom.xml
+++ b/plugins/lequipe/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/mlssoccer/pom.xml
+++ b/plugins/mlssoccer/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/pluzz/pom.xml
+++ b/plugins/pluzz/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -11,6 +11,7 @@
 	<name>plugins habiTv</name>
 
 	<modules>
+		<module>plugin-tester</module>
 		<module>6play</module>
 		<module>adobeHDS</module>
 		<module>aria2</module>	

--- a/plugins/rtmpDump/pom.xml
+++ b/plugins/rtmpDump/pom.xml
@@ -20,7 +20,7 @@
 			<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/plugins/sfr/pom.xml
+++ b/plugins/sfr/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/plugins/wat/pom.xml
+++ b/plugins/wat/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>		
 		<dependency>

--- a/plugins/youtube/pom.xml
+++ b/plugins/youtube/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>4.1.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>	
 		<dependency>


### PR DESCRIPTION
## Summary
This PR resolves the plugin test-harness dependency mismatch left after HBTV-002 by aligning plugin modules to reactor-resolved `plugin-tester` coordinates and wiring `plugin-tester` into the plugins reactor.

## Scope
- plugin-tester dependency version alignment across plugin module POMs
- plugin-tester reactor inclusion in `plugins/pom.xml`
- tracker/risk/audit documentation updates (HBTV-010, R-012, and latest compile blocker)

## Out of scope
- No Java source changes
- No provider rewrite
- No plugin removal
- No Java upgrade
- No JavaFX work
- No YouTube/yt-dlp work
- No runtime updater change
- No Maven deploy/static repo migration

## Validation results
`git status --short`
```text
?? .vscode/
```

`git branch --show-current`
```text
build/align-plugin-tester-reactor-dependency
```

`mvn -B -ntp -DskipTests validate`
```text
[INFO] BUILD SUCCESS
[INFO] Total time:  0.765 s
[INFO] Finished at: 2026-05-16T23:31:27+02:00
```

`mvn -B -ntp -DskipTests compile`
```text
[INFO] beinsport 4.1.1-SNAPSHOT ........................... FAILURE [  0.130 s]
[INFO] BUILD FAILURE
[ERROR] Failed to execute goal on project beinsport: Could not collect dependencies for project com.dabi.habitv:beinsport:jar:4.1.1-SNAPSHOT
[ERROR] Failed to read artifact descriptor for com.dabi.habitv:framework:jar:4.1.1-SNAPSHOT
[ERROR]   Caused by: The following artifacts could not be resolved: com.dabi.habitv:framework:pom:4.1.1-SNAPSHOT (absent): Could not transfer artifact com.dabi.habitv:framework:pom:4.1.1-SNAPSHOT from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [dabi-repo (http://dabiboo.free.fr/repository, default, releases+snapshots)]
[ERROR] Failed to read artifact descriptor for com.dabi.habitv:api:jar:4.1.1-SNAPSHOT
[ERROR]   Caused by: The following artifacts could not be resolved: com.dabi.habitv:api:pom:4.1.1-SNAPSHOT (absent): Could not transfer artifact com.dabi.habitv:api:pom:4.1.1-SNAPSHOT from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [dabi-repo (http://dabiboo.free.fr/repository, default, releases+snapshots)]
```

## Known remaining blockers
- `mvn -B -ntp -DskipTests compile` now fails at `beinsport` due to non-reactor intra-project dependencies (`framework/api:4.1.1-SNAPSHOT`) resolving through blocked legacy repository `http://dabiboo.free.fr/repository`.

## Risk updates
- R-012 is mitigated by this PR (plugin-tester descriptor mismatch no longer blocks compile).
- Legacy repository resolution risk remains open under HBTV-004/R-001 and is now the active compile blocker.

## Next PR recommendation
Start an HBTV-004-scoped POM-only PR to align non-reactor plugin intra-project coordinates (e.g. `framework/api` in modules with own versions like `beinsport`, likely `footyroom`/`pluzz` and related cases) to reactor-resolved parent coordinates, then rerun `mvn -B -ntp -DskipTests compile`.