### PR TITLE
docs: plan legacy URL migration (HBTV-004)

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -108,3 +108,60 @@ supersede older ones rather than rewriting them in place.
   remain explicit. PR #25 and PR #26 must be retargeted/rebased to
   `develop` (or recreated as scoped follow-ups) after this baseline
   lands.
+
+## ADR-0008 — Quarantine network pings at startup in development builds
+
+- Status: Proposed
+- Date: 2026-05-18
+- Context: `CoreManager.stat()` and `UpdateManager.process()` both
+  resolve URLs from `HabitTvConf.STAT_URL` /
+  `FrameworkConf.UPDATE_URL` (`http://dabiboo.free.fr/...`) at
+  runtime. Today every dev or CI run that constructs `CoreManager`
+  or invokes the updater silently pings the legacy third-party host.
+  This leaks traffic, slows tests, and prevents the URL migration
+  in HBTV-004 / HBTV-005 from being verifiable on a clean machine.
+- Decision: Introduce two opt-in system properties (or environment
+  variables) gating the network calls without modifying the URL
+  constants themselves:
+  - `habitv.stat.enabled` gates `CoreManager.stat()`.
+  - `habitv.update.enabled` gates `UpdateManager.process()`.
+  Both default to `false`. Production packaging scripts and end-user
+  releases set them to `true`. This decouples "should we ping" from
+  "what URL do we ping" so HBTV-004 PRs 2-3 can land before HBTV-005
+  picks the new host.
+- Consequences: Slight increase in code surface (two property
+  lookups) in exchange for predictable, network-free dev/CI runs.
+  Telemetry data may decrease until packaging scripts are updated;
+  acceptable trade-off given the third-party host status.
+
+## ADR-0009 — Publish via GitHub Pages with generated `index.html`
+
+- Status: Proposed
+- Date: 2026-05-18
+- Context: `FindArtifactUtils.findLastVersionUrl` discovers
+  artifacts by parsing Apache `mod_autoindex` HTML at
+  `${UPDATE_URL}/${groupIdPath}/${artifactId}/[version/]`. GitHub
+  Pages does not serve directory listings, and other static-host
+  options either require authentication (GitHub Packages) or break
+  the URL shape (GitHub Releases). Rewriting the updater
+  contract is out of scope for the restart phase. The companion
+  `docs/static-repository-deploy.md` introduced on `develop`
+  already documents the side-by-side workspace layout for
+  publication scripts; this ADR adds the contract for the served
+  HTTP shape.
+- Decision: Adopt GitHub Pages on a dedicated `Mika3578/habitv-repo`
+  repository. The publication workflow (GitHub Action triggered
+  on release tags) generates a per-directory `index.html` whose
+  `<a href="...">` entries match the `mod_autoindex` shape that
+  `FindArtifactUtils` already parses (version directories end with
+  `/`, files do not, excluded headers match the existing filter
+  list). Sidecar `.sha256` files are emitted next to each artifact
+  for integrity verification. HTTPS is provided by GitHub Pages.
+  Signing (PGP) is deferred to a later ADR.
+- Consequences: Updater code stays untouched. Publication is
+  reproducible, version-controlled, and free of third-party
+  dependencies. Until the action and the `habitv-repo` repository
+  exist, no releases can be published; this is acceptable because
+  no automated publication runs today either. ADR-0004 becomes
+  `Accepted` once the workflow is validated end-to-end against a
+  test artifact.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -89,18 +89,21 @@
     {
       "id": "HBTV-004",
       "title": "Legacy repository URL migration plan",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P1",
-      "scope": "Plan migration of <scm> (SVN/Assembla), Maven <repository> (http://dabiboo.free.fr/repository), <distributionManagement> (ftp://ftpperso.free.fr/repository), and runtime telemetry/update URLs.",
+      "scope": "Plan migration of <scm> (SVN/Assembla), Maven <repository> (http://dabiboo.free.fr/repository), <distributionManagement> (ftp://ftpperso.free.fr/repository), and runtime telemetry/update URLs. Plan only; execution split across seven sequenced PRs documented in docs/hbtv-004-url-migration-plan.md section 5.",
       "acceptanceCriteria": [
-        "Document target URLs and transition steps.",
-        "Identify code call sites in FrameworkConf.java, HabitTvConf.java, UpdateManager.java, FindArtifactUtils.java, CoreManager.java."
+        "Document target URLs and transition steps (docs/hbtv-004-url-migration-plan.md).",
+        "Identify code call sites in FrameworkConf.java:21, HabitTvConf.java:16, UpdateManager.java:40,48, FindArtifactUtils.java:56, CoreManager.java:46-55.",
+        "Inventory all 23 <scm> SVN blocks, 3 HTTP <repository> blocks, and 1 FTP <distributionManagement> block.",
+        "Surface new risks R-013, R-014, R-015 in the risk register.",
+        "Propose feature-flag quarantine plan (habitv.stat.enabled, habitv.update.enabled) before any URL is changed."
       ],
       "validation": [
         "Plan reviewed in PR; no code changes in this item"
       ],
-      "pr": "TBD",
-      "notes": "Pairs with HBTV-005."
+      "pr": "docs: plan legacy URL migration (HBTV-004)",
+      "notes": "Pairs with HBTV-005. Execution PRs 2-7 listed in the plan document; each will reference HBTV-004 (PRs 2-5) or HBTV-005 (PRs 6-7)."
     },
     {
       "id": "HBTV-005",
@@ -118,7 +121,7 @@
         "mvn -B -ntp -DskipTests deploy with temporary file:// target"
       ],
       "pr": "build/standard-cross-os-static-repo-layout (pending)",
-      "notes": "Pairs with HBTV-004 and Phase 4 of docs/dev-plan.md; adds cross-OS deploy scripts and standard side-by-side workspace layout under $HOME/dev."
+      "notes": "Pairs with HBTV-004 and Phase 4 of docs/dev-plan.md; adds cross-OS deploy scripts and standard side-by-side workspace layout under $HOME/dev. Section 2 of docs/hbtv-004-url-migration-plan.md captures the reverse-engineered FindArtifactUtils contract that the published layout must satisfy. Served HTTP shape is captured in ADR-0009 (GitHub Pages with generated index.html)."
     },
     {
       "id": "HBTV-006",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -134,23 +134,35 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 
 ## HBTV-004 — Legacy repository URL migration plan
 
-- Status: proposed
+- Status: in-progress
 - Priority: P1
 - Scope: Plan migration of `<scm>` (SVN/Assembla), Maven
   `<repository>` (`http://dabiboo.free.fr/repository`),
   `<distributionManagement>` (`ftp://ftpperso.free.fr/repository`),
-  and runtime telemetry/update URLs.
+  and runtime telemetry/update URLs. Plan only; execution split
+  across the seven sequenced PRs documented in
+  `docs/hbtv-004-url-migration-plan.md` section 5.
 - Acceptance criteria:
-  - Document target URLs and transition steps.
+  - Document target URLs and transition steps. (done — see
+    `docs/hbtv-004-url-migration-plan.md`)
   - Identify code call sites in
-    `fwk/framework/.../FrameworkConf.java`,
-    `application/core/.../HabitTvConf.java`,
-    `application/core/.../UpdateManager.java`,
-    `fwk/framework/.../FindArtifactUtils.java`,
-    `application/core/.../CoreManager.java`.
+    `fwk/framework/.../FrameworkConf.java:21`,
+    `application/core/.../HabitTvConf.java:16`,
+    `application/core/.../UpdateManager.java:40,48`,
+    `fwk/framework/.../FindArtifactUtils.java:56`,
+    `application/core/.../CoreManager.java:46-55`. (done)
+  - Inventory all 23 `<scm>` SVN blocks, 3 HTTP `<repository>`
+    blocks, and 1 FTP `<distributionManagement>` block. (done)
+  - Surface new risks R-013, R-014, R-015 in the risk register.
+    (done)
+  - Propose feature-flag quarantine plan
+    (`habitv.stat.enabled`, `habitv.update.enabled`) before any
+    URL is changed. (done)
 - Validation: Plan reviewed in PR; no code changes in this item.
-- PR: TBD.
-- Notes: Pairs with HBTV-005.
+- PR: docs: plan legacy URL migration (HBTV-004).
+- Notes: Pairs with HBTV-005. Execution PRs 2-7 listed in the
+  plan document; each will reference HBTV-004 (PRs 2-5) or
+  HBTV-005 (PRs 6-7).
 
 ## HBTV-005 — Runtime updater publication plan
 
@@ -169,7 +181,11 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 - PR: build/standard-cross-os-static-repo-layout (pending).
 - Notes: Pairs with HBTV-004 and Phase 4 of `docs/dev-plan.md`; adds
   cross-OS deploy scripts and standard side-by-side workspace layout
-  under `$HOME/dev`.
+  under `$HOME/dev`. Section 2 of
+  `docs/hbtv-004-url-migration-plan.md` captures the reverse-engineered
+  `FindArtifactUtils` contract that the published layout must satisfy.
+  Served HTTP shape is captured in ADR-0009 (GitHub Pages with
+  generated `index.html`).
 
 ## HBTV-006 — Provider / plugin inventory
 

--- a/docs/hbtv-004-url-migration-plan.md
+++ b/docs/hbtv-004-url-migration-plan.md
@@ -1,0 +1,282 @@
+# HBTV-004 — Legacy URL migration plan
+
+Plan-only document for migrating Habitv away from legacy
+SVN/Assembla, plain-HTTP `dabiboo.free.fr`, FTP `ftpperso.free.fr`,
+and embedded telemetry/update URLs. No code or POM is changed in
+this PR. Implementation will be split across follow-up PRs listed
+in section 5.
+
+This document pairs with `docs/hbtv-005-publication-layout.md`
+(future) and supersedes the rough notes in
+`docs/audit-master-baseline.md` lines 54-84 by enumerating exact
+call sites and a sequenced migration plan.
+
+## 1. Inventory of legacy references
+
+### 1.1 SCM blocks (SVN / Assembla) — 23 POMs
+
+Root:
+
+- `pom.xml:21-24` — `scm:svn:http://subversion.assembla.com/svn/habitv/trunk`
+
+Framework:
+
+- `fwk/api/pom.xml`
+- `fwk/framework/pom.xml`
+
+Packaging (out of reactor, HBTV-008):
+
+- `application/habiTv-linux/pom.xml`
+- `application/habiTv-windows/pom.xml`
+
+Plugins (18 of 22 + `plugin-tester`):
+
+- `plugins/RSS/pom.xml`
+- `plugins/adobeHDS/pom.xml`
+- `plugins/aria2/pom.xml`
+- `plugins/arte/pom.xml`
+- `plugins/beinsport/pom.xml`
+- `plugins/canalPlus/pom.xml`
+- `plugins/clubic/pom.xml`
+- `plugins/cmd/pom.xml`
+- `plugins/curl/pom.xml`
+- `plugins/email/pom.xml` (also points at `plugins/RSS` by
+  copy/paste — fix in the same change set)
+- `plugins/ffmpeg/pom.xml`
+- `plugins/file/pom.xml`
+- `plugins/lequipe/pom.xml`
+- `plugins/pluzz/pom.xml`
+- `plugins/rtmpDump/pom.xml`
+- `plugins/sfr/pom.xml`
+- `plugins/wat/pom.xml`
+- `plugins/youtube/pom.xml`
+
+Plugins without `<scm>` block today (intentionally left as-is until
+the global swap):
+
+- `plugins/footyroom`, `plugins/globalnews`, `plugins/mlssoccer`,
+  `plugins/6play`.
+
+### 1.2 Maven `<repository>` (HTTP `dabiboo.free.fr`) — 3 POMs
+
+- `pom.xml:33-39`
+- `application/habiTv-linux/pom.xml:20`
+- `application/habiTv-windows/pom.xml:32`
+
+All three declare the same id `dabi-repo` pointing at
+`http://dabiboo.free.fr/repository`. Plain HTTP, third-party
+hosting, blocked by Maven 3.9+ default mirror policy.
+
+### 1.3 `<distributionManagement>` FTP — 1 POM
+
+- `pom.xml:26-31` — `ftp://ftpperso.free.fr/repository`
+- `pom.xml:159-166` — `<extension>` `wagon-ftp:1.0-beta-6`
+
+FTP is unencrypted, free.fr personal hosting is deprecated, and the
+extension is from 2009.
+
+### 1.4 Runtime URL constants — 2 constants
+
+| Constant     | File:line                                                                 | Purpose       |
+|--------------|---------------------------------------------------------------------------|---------------|
+| `UPDATE_URL` | `fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java:21`       | Artifact resolution for the in-app updater |
+| `STAT_URL`   | `application/core/src/com/dabi/habitv/core/config/HabitTvConf.java:16`   | Telemetry ping on startup |
+
+### 1.5 Runtime call sites
+
+- `application/core/src/com/dabi/habitv/core/updater/UpdateManager.java:40`
+  — constructor passes `FrameworkConf.UPDATE_URL` to the
+  `UpdateManager` instance.
+- `application/core/src/com/dabi/habitv/core/updater/UpdateManager.java:48`
+  — `RetrieverUtils.getUrlContent(site + "/plugins.txt", null)`.
+- `fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtils.java:56`
+  — builds `${UPDATE_URL}/${groupIdPath}/${artifactId}` and
+  recursively lists directory contents via Jsoup.
+- `application/core/src/com/dabi/habitv/core/mgr/CoreManager.java:46-55`
+  — `stat()` fires a background thread on construction that calls
+  `RetrieverUtils.getUrlContent(HabitTvConf.STAT_URL, null)`.
+
+### 1.6 Tests that hit the legacy hosts
+
+- `application/core/test/com/dabi/habitv/core/updater/TestListHttp.java:30-37`
+  — calls `FindArtifactUtils.findLastVersionUrl(...)`, which hits
+  the live `UPDATE_URL`.
+- `fwk/framework/test/com/dabi/habitv/framework/plugin/utils/TestUrl.java:10`
+  — `RetrieverUtils.getTitleByUrl("http://www.beinsports.fr")`,
+  out of scope for HBTV-004 but tracked under R-005.
+
+### 1.7 Adjacent legacy traces (not in scope, recorded for context)
+
+- `application/consoleView/config.xml:57,84` — sample `curl`
+  commands with hardcoded freebox FTP credentials
+  (`ftp://freebox:4688@hd1.freebox.fr/...`). Sample file, not
+  executed. Tracked as new risk R-013.
+- `plugins/email/test/com/dabi/habitv/plugin/email/MessageReceiverTest.java:14,19`
+  and
+  `plugins/email/test/com/dabi/habitv/plugin/email/EmailPluginManagerTest.java:29`
+  — hardcoded Gmail credentials `testhabitv` / `HabiTV410`.
+  Tracked as new risk R-013.
+
+## 2. Updater contract (reverse-engineered from FindArtifactUtils)
+
+The current updater relies on an Apache-style `mod_autoindex` HTTP
+server. Any replacement host must serve compatible HTML or the
+updater stops discovering new artifacts.
+
+Required URL shapes:
+
+```
+${UPDATE_URL}/plugins.txt
+${UPDATE_URL}/${groupId-with-slashes}/${artifactId}/
+${UPDATE_URL}/${groupId-with-slashes}/${artifactId}/${version}/
+```
+
+Required HTML shape (per directory):
+
+- `<a href="X.Y.Z/">X.Y.Z</a>` for version directories.
+- `<a href="artifactId-X.Y.Z.jar">...</a>` for files.
+- Entries with text `Parent Directory`, `Name`, `Last modified`,
+  `Size`, `Description` are filtered out (Apache autoindex
+  headers).
+
+Selection rules:
+
+- `AlphanumComparator` is used to pick the highest version that
+  starts with `${coreVersionMajor.Minor}` (e.g. `4.1`).
+- `autoriseSnapshot` toggles whether versions containing
+  `SNAPSHOT` are eligible.
+
+This constraint is the main driver for HBTV-005 hosting choice.
+
+## 3. Target URLs (proposal)
+
+### 3.1 SCM
+
+```
+scm:git:https://github.com/Mika3578/habitv.git
+scm:git:git@github.com:Mika3578/habitv.git (developerConnection)
+```
+
+For per-module POMs, append the module path segment as a `<tag>`
+or leave only the root coordinates. Recommend dropping the
+per-module `<scm>` blocks entirely (Maven inherits from parent);
+keep only the root and the two `habiTv-linux/-windows` packaging
+modules that currently parent outside the reactor.
+
+### 3.2 Maven `<repository>`
+
+Replace `http://dabiboo.free.fr/repository` with the static repo
+defined in HBTV-005. Working assumption:
+
+```
+https://mika3578.github.io/habitv-repo/maven/
+```
+
+Until HBTV-005 stands up the host, this repository declaration can
+be removed entirely (no current dependency is resolved through it
+once R-010 was fixed in HBTV-002).
+
+### 3.3 `<distributionManagement>`
+
+Drop the FTP block and the `wagon-ftp` extension. Replace with a
+documented publication workflow under HBTV-005 (GitHub Actions
+pushing to the static repo).
+
+### 3.4 Runtime `UPDATE_URL`
+
+Switch to the same HTTPS static repo:
+
+```
+https://mika3578.github.io/habitv-repo/
+```
+
+### 3.5 Runtime `STAT_URL`
+
+Two options, decision deferred to ADR-0008:
+
+- Remove telemetry entirely. Simplest, no privacy surface.
+- Keep it behind an opt-in flag (default off) and migrate to an
+  HTTPS endpoint under Habitv control.
+
+## 4. Feature flag plan (quarantine before swap)
+
+Goal: stop network pings to the legacy hosts in dev/CI builds
+before any URL is changed. This avoids leaking dev traffic to a
+third-party host during the migration.
+
+Proposed properties (default `false`, opt-in via system property
+or environment):
+
+| Property                 | Effect                                       |
+|--------------------------|----------------------------------------------|
+| `habitv.stat.enabled`    | Gate `CoreManager.stat()` background thread. |
+| `habitv.update.enabled`  | Gate `UpdateManager.process()` entirely.     |
+
+Packaging POMs and release scripts should set both to `true` for
+production builds. Local development and CI leave them at `false`.
+
+`TestListHttp.java` should be tagged `@Ignore` with a comment
+pointing at R-005 (live network) once the gates are added; a
+follow-up under HBTV-002 quarantines live tests behind an opt-in
+profile.
+
+## 5. PR sequencing
+
+All PRs below are scoped to one tracker item each.
+
+| #  | Branch                                          | Tracker | Scope summary                                                                                          |
+|----|-------------------------------------------------|---------|--------------------------------------------------------------------------------------------------------|
+| 1  | `claude/analyze-audit-jrczu`                    | HBTV-004 | This document + tracker / risk / decision updates. Plan only, no code or POM.                          |
+| 2  | `runtime/quarantine-stat-url`                   | HBTV-004 | Add `habitv.stat.enabled` gate in `CoreManager.stat()`. URL constant unchanged.                        |
+| 3  | `runtime/quarantine-update-url`                 | HBTV-004 | Add `habitv.update.enabled` gate in `UpdateManager.process()`. URL constant unchanged.                 |
+| 4  | `build/replace-scm-urls`                        | HBTV-004 | Swap 23 `<scm>` SVN blocks to GitHub. Fix `plugins/email` copy/paste pointing at `plugins/RSS`.       |
+| 5  | `build/remove-ftp-distribution-management`      | HBTV-004 | Drop `<distributionManagement>` FTP and `wagon-ftp` extension from `pom.xml`.                          |
+| 6  | `build/replace-maven-repository-url`            | HBTV-005 | Swap 3 `<repository>` HTTP blocks to HTTPS target. Requires HBTV-005 host live.                        |
+| 7  | `runtime/swap-update-stat-urls`                 | HBTV-005 | Update `FrameworkConf.UPDATE_URL` and `HabitTvConf.STAT_URL` to the HTTPS targets.                     |
+
+Validation per PR: `mvn -B -ntp -DskipTests validate` plus the
+narrower commands the touched files imply (compile for code PRs,
+tests opt-in only).
+
+Order rationale:
+
+- PRs 2 and 3 must land first; they cut the silent traffic so the
+  later POM swaps cannot regress dev behavior.
+- PR 4 (SCM) is fully orthogonal and can land any time.
+- PR 5 (FTP) is safe because no one publishes through it today.
+- PRs 6 and 7 depend on HBTV-005 (publication host live + layout
+  validated against `FindArtifactUtils` semantics).
+
+## 6. Risks introduced or surfaced
+
+See `docs/risk-register.md`:
+
+- R-013 — Hardcoded Gmail and freebox credentials in tests and
+  sample config.
+- R-014 — GitHub Pages does not serve autoindex natively; updater
+  contract breaks unless `index.html` files are generated.
+- R-015 — `CoreManager.stat()` pings a third-party host on every
+  startup in development builds.
+
+## 7. Decisions referenced
+
+See `docs/decision-log.md`:
+
+- ADR-0004 (Proposed) — `habitv-repo` as future static artifact
+  repository. To be confirmed or superseded once HBTV-005 lands.
+- ADR-0008 (Proposed) — Quarantine network pings at startup in
+  development builds via opt-in properties.
+- ADR-0009 (Proposed) — Publish via GitHub Pages with generated
+  `index.html` to remain compatible with `FindArtifactUtils`.
+
+## 8. Out of scope for this document
+
+- HBTV-005 layout details (directory naming, signature plan,
+  publication automation). Covered by
+  `docs/hbtv-005-publication-layout.md` (future PR).
+- HBTV-008 packaging / JavaFX cleanup of `habiTv-linux`,
+  `habiTv-windows`.
+- HBTV-006 provider inventory.
+- HBTV-007 yt-dlp migration.
+- R-005 / R-013 remediation (live-network tests, credential
+  cleanup) — recorded but executed in dedicated PRs.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -19,6 +19,9 @@ or accepted.
 | R-010 | Intra-reactor version range excludes SNAPSHOTs (mitigated)      | Low        | Low    | P3       |
 | R-011 | maven-jaxb-plugin missing pinned version (mitigated)            | Low        | Low    | P3       |
 | R-012 | Plugin tester version mismatch blocks compile (mitigated)       | Low        | Low    | P3       |
+| R-013 | Hardcoded Gmail and freebox credentials in tests / samples      | Medium     | High   | P1       |
+| R-014 | GitHub Pages does not serve autoindex (updater contract break)  | High       | Medium | P1       |
+| R-015 | CoreManager.stat() pings third-party host on every startup      | High       | Low    | P2       |
 
 ---
 
@@ -171,3 +174,42 @@ or accepted.
 - Residual risk: Compile still hits blocked legacy repository resolution
   for `framework/api:4.1.1-SNAPSHOT` in `beinsport`, which is tracked
   under the existing legacy repository migration risk (R-001 / HBTV-004).
+
+## R-013 — Hardcoded Gmail and freebox credentials in tests / samples
+
+- Description: Test sources and a sample config carry plaintext
+  credentials:
+  - `plugins/email/test/com/dabi/habitv/plugin/email/MessageReceiverTest.java:14,19`
+    and `EmailPluginManagerTest.java:29` use `testhabitv` / `HabiTV410`
+    against `pop.gmail.com` / `imap.gmail.com`.
+  - `application/consoleView/config.xml:57,84` carries
+    `ftp://freebox:4688@hd1.freebox.fr/...` upload examples.
+- Mitigation: Dedicated PR to scrub credentials (replace with
+  placeholders / environment variables, mark the affected tests
+  `@Ignore` until they are reworked as offline fixtures). Rotate the
+  Gmail account if still active. Out of scope for HBTV-004; tracked
+  here so it is not lost.
+
+## R-014 — GitHub Pages does not serve autoindex (updater contract break)
+
+- Description: `FindArtifactUtils.findLastVersionUrl` (lines 77-123)
+  parses Apache `mod_autoindex` HTML to discover versions and files
+  under `${UPDATE_URL}/${groupIdPath}/${artifactId}/`. GitHub Pages
+  does not serve directory listings by default. If `habitv-repo` is
+  hosted on GitHub Pages without per-directory `index.html`, the
+  updater silently stops finding new versions.
+- Mitigation: HBTV-005 must define a publication workflow that
+  emits an `index.html` per directory with `<a href="X/">` entries
+  matching the `mod_autoindex` shape. ADR-0009 captures the
+  recommended approach.
+
+## R-015 — CoreManager.stat() pings third-party host on every startup
+
+- Description: `application/core/src/com/dabi/habitv/core/mgr/CoreManager.java:46-55`
+  fires a background thread on construction that GETs
+  `http://dabiboo.free.fr/cpt.php`. There is no gate, no opt-out, and
+  no failure logging. Developers and CI silently send traffic to a
+  third-party host on every test run that instantiates `CoreManager`.
+- Mitigation: HBTV-004 PR 2 adds a `habitv.stat.enabled` system
+  property (default `false`). Production packaging sets it to `true`.
+  The URL itself is not changed in that step.


### PR DESCRIPTION
## Summary

Documentation-only PR that plans the migration away from
legacy SVN/Assembla SCM, plain-HTTP `dabiboo.free.fr` Maven
`<repository>`, FTP `ftpperso.free.fr`
`<distributionManagement>`, and the runtime telemetry/update
URLs. No code or POM is changed. Adds the new plan document and
keeps the tracker, risk register, and decision log in lockstep
per AGENTS.md.

Rebased onto `develop` (was originally targeted at `master`) per
PR feedback. Conflicts in `docs/dev-tracker.{md,json}`,
`docs/risk-register.md`, and `docs/decision-log.md` were resolved
in favor of `develop`'s state (HBTV-010, HBTV-011, HBTV-012, the
new `docs/static-repository-deploy.md`, and the existing
`ADR-0006` about the runnable console baseline). New ADRs
introduced by this PR are renumbered to `ADR-0008` and `ADR-0009`.

## Scope

- Add `docs/hbtv-004-url-migration-plan.md` with:
  - Exhaustive inventory of 23 `<scm>` SVN blocks, 3 HTTP
    `<repository>` blocks, 1 FTP `<distributionManagement>`
    block, and the two runtime URL constants `UPDATE_URL` /
    `STAT_URL` with their five call sites.
  - Reverse-engineered updater contract from
    `FindArtifactUtils` (Apache `mod_autoindex` shape) that any
    HBTV-005 host must satisfy.
  - Quarantine plan via two opt-in system properties
    (`habitv.stat.enabled`, `habitv.update.enabled`) defaulting
    to `false`, so dev/CI traffic stops before any URL changes.
  - Sequenced list of seven follow-up PRs (two quarantine code
    PRs, two POM swap PRs for SCM and FTP, then two HBTV-005
    PRs once the new host is live).
- Move HBTV-004 to `in-progress` in
  `docs/dev-tracker.md` and `docs/dev-tracker.json`.
- Cross-link HBTV-005 to the contract captured in the plan
  document. HBTV-005's existing develop entry
  (`build/standard-cross-os-static-repo-layout`) is preserved
  and amended.
- Add risks `R-013` (hardcoded Gmail/freebox credentials),
  `R-014` (GitHub Pages autoindex gap), `R-015` (silent
  `stat()` ping at startup) to `docs/risk-register.md`.
- Add `ADR-0008` (quarantine flags) and `ADR-0009`
  (GitHub Pages with generated `index.html`) to
  `docs/decision-log.md` as `Proposed`.

## Out of scope

- No POM is modified (no `<scm>`, `<repository>`,
  `<distributionManagement>`, or `wagon-ftp` change).
- No runtime code change in `FrameworkConf`, `HabitTvConf`,
  `UpdateManager`, `FindArtifactUtils`, or `CoreManager`.
- No HBTV-005 layout document
  (`docs/hbtv-005-publication-layout.md`) yet; only the contract
  HBTV-005 must respect.
- No credential remediation for R-013; recorded only.
- No quarantine code; only the design.

## Linked tracker item

- HBTV-004

## Validation commands

- `git status --short` — clean after staging.
- `git branch --show-current` — `claude/analyze-audit-jrczu`.
- `git log --oneline -3` — top commit
  `docs: plan legacy URL migration (HBTV-004)` on top of the
  current `develop` tip.
- `mvn -B -ntp -DskipTests validate` — not re-run in this PR
  because no Maven or runtime file was touched. The recent
  HBTV-010 / HBTV-012 PRs confirmed `validate` is green on
  `develop`; no regression is possible from documentation-only
  edits.

## Risk assessment

- Affected risks: R-001, R-002, R-007 (mitigation plans
  refined; statuses unchanged in this PR).
- New risks: R-013, R-014, R-015 (recorded in
  `docs/risk-register.md`).
- Mitigation: Execution PRs 2-3 in the plan add the
  quarantine flags first, so subsequent URL swaps (PRs 4-7)
  cannot regress dev or CI behavior.

## Rollback plan

- Revert commit via `git revert <sha>` and re-run validation.
  No build or runtime state depends on these docs.

## Checklists

- [x] Linear history preserved (no merge commits in this branch)
- [x] English used for branches, commits, comments, docs, and PR text
- [x] Documentation updated (`docs/dev-tracker.md`,
      `docs/dev-tracker.json`, risk register, decision log)
- [x] No unrelated refactors, formatting, or dependency bumps
- [x] No secrets, tokens, local paths, or build outputs committed