### PR TITLE
fix(youtube): configurable API key + readable HTTP error bodies

### DIFF
--- a/application/consoleView/pom.xml
+++ b/application/consoleView/pom.xml
@@ -4,6 +4,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>application</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>consoleView</artifactId>
 	<packaging>jar</packaging>

--- a/application/core/pom.xml
+++ b/application/core/pom.xml
@@ -5,6 +5,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>application</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>core</artifactId>
 	<name>core</name>

--- a/application/core/pom.xml
+++ b/application/core/pom.xml
@@ -42,6 +42,7 @@
 			<plugin>
 				<groupId>com.sun.tools.xjc.maven2</groupId>
 				<artifactId>maven-jaxb-plugin</artifactId>
+				<version>1.1.1</version>
 				<executions>
 					<execution>
 						<id>config</id>

--- a/application/habiTv/pom.xml
+++ b/application/habiTv/pom.xml
@@ -4,6 +4,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>application</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>habiTv</artifactId>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -3,7 +3,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>application</artifactId>

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -5,6 +5,7 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>application</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>trayView</artifactId>
 	<packaging>jar</packaging>

--- a/docs/audit-master-baseline.md
+++ b/docs/audit-master-baseline.md
@@ -192,3 +192,110 @@ Captured at PR creation time. Update if the environment changes.
   `4.1.0-SNASPHOT` typo in `fwk/framework/pom.xml`.
 - Keep the change scope to POM topology only; do not upgrade
   plugins or dependencies in that PR.
+
+## Maven reactor stabilization findings (HBTV-001)
+
+Captured during the `build: stabilize Maven reactor from master`
+PR. Branch: `build/stabilize-maven-reactor-from-master` based on
+`develop` (which was created from `origin/master` at the bootstrap
+merge commit). Local environment: Windows 11, Apache Maven 3.9.11,
+Azul Zulu OpenJDK 1.8.0_492.
+
+### Modules wired
+
+Reactor build order observed via `mvn -B -ntp -DskipTests validate`
+walks 32 entries:
+
+- Root: `com.dabi.habitv:parent` (pom).
+- `fwk`: `api`, `framework`, plus the `fwk` aggregator itself.
+- `application`: `core`, `consoleView`, `trayView`, `habiTv`, plus
+  the `application` aggregator itself.
+- `plugins`: 22 plugin modules (`6play`, `adobeHDS`, `aria2`,
+  `arte`, `beinsport`, `canalPlus`, `clubic`, `cmd`, `curl`,
+  `email`, `ffmpeg`, `file`, `footyroom`, `globalnews`, `lequipe`,
+  `mlssoccer`, `pluzz`, `RSS`, `rtmpDump`, `sfr`, `youtube`,
+  `wat`) plus the `plugins` aggregator itself.
+
+### Modules intentionally not wired
+
+- `application/habiTv-linux` and `application/habiTv-windows`.
+  Both declare hardcoded `${jdk.home}` properties pointing at
+  Linux/Windows JDK 7 install paths, use `system`-scope
+  `javafx:jfxrt` referencing `jfxrt.jar` under those paths, depend
+  on `com.zenjava:javafx-maven-plugin:2.0` (unmaintained), and use
+  `com.sun.javafx.tools.ant` packaging tasks. They cannot build
+  on a clean machine. Tracked under HBTV-008 (JavaFX / runtime
+  packaging audit). Their POMs were not modified in this PR.
+- `plugins/plugin-tester`. It is the shared harness referenced by
+  most plugin tests at `<scope>test</scope>`. `validate` and
+  `compile` do not exercise test sources, so excluding it from
+  the reactor does not block the current CI baseline. Wiring it
+  in will be revisited when HBTV-002 extends the workflow to
+  `test-compile` (or `test`).
+
+### Cross-cutting POM changes applied
+
+- Root `pom.xml`: added `<modules>fwk, application, plugins</modules>`.
+- `fwk/pom.xml`: added `<modules>api, framework</modules>`.
+- All in-reactor child POMs now declare their `<parent>` at
+  version `4.1.0-SNAPSHOT` with an explicit `<relativePath>` to
+  the correct parent file. This eliminates the previous Maven
+  warning "`parent.relativePath` ... points at ... instead of ...".
+- `fwk/framework/pom.xml`: own `<version>` fixed from
+  `4.1.0-SNASPHOT` to `4.1.0-SNAPSHOT`.
+- `application/habiTv-windows` was deliberately not edited.
+  It still parents to root `parent` (its sibling `habiTv-linux`
+  parents to `application`); both are out of the reactor.
+
+### Cross-cutting non-changes (preserved as-is)
+
+- Dependency versions are unchanged. Plugin own versions
+  `4.1.1-SNAPSHOT` (`pluzz`, `footyroom`, `beinsport`) and
+  `4.1.2-SNAPSHOT` (`ffmpeg`) are intentional (not typos).
+- Test-scope `plugin-tester` references at version `4.1.0`
+  inside plugin POMs are unchanged. They fail to resolve when
+  `test-compile` runs, but `validate` and `compile` do not
+  trigger them. HBTV-002 will reconcile.
+- The intra-reactor version range `[4.1,4.2)` on `api` and
+  `framework` inside the root `pom.xml` dependencyManagement is
+  unchanged. It is the next real blocker (see below); fixing it
+  belongs to HBTV-002 per scope rules.
+- `maven-jaxb-plugin` (`application/core`) still has no pinned
+  `<version>`. Warning persists; no change in this PR.
+- Legacy SVN `<scm>`, HTTP `dabiboo.free.fr` `<repository>`, and
+  FTP `<distributionManagement>` are untouched (HBTV-004).
+
+### Validation results
+
+- `git status --short`: 32 modified POMs plus the four docs
+  updates listed in the PR body.
+- `git branch --show-current`:
+  `build/stabilize-maven-reactor-from-master`.
+- `mvn -B -ntp -DskipTests validate` from the repository root:
+  `BUILD SUCCESS`, 32 reactor entries built (`pom` aggregators
+  plus `jar` modules). Only remaining warning is
+  `maven-jaxb-plugin` missing version (R-011).
+- `mvn -B -ntp -DskipTests compile` from the repository root:
+  `BUILD FAILURE` at `com.dabi.habitv:framework`. Cause:
+  `No versions available for com.dabi.habitv:api:jar:[4.1,4.2)
+  within specified range`. Maven cannot satisfy the closed range
+  because the only available `api` artifact is the reactor's
+  `4.1.0-SNAPSHOT`, which is not within `[4.1,4.2)` by default,
+  and the legacy `http://dabiboo.free.fr/repository` is blocked
+  by Maven 3.9 default mirror policy. Tracked as R-010 and
+  scoped to HBTV-002.
+
+### Next recommended PR
+
+`build: stabilize Java 8 compile baseline` (HBTV-002):
+
+- In root `pom.xml`, replace the intra-reactor dependencyManagement
+  ranges `[4.1,4.2)` on `com.dabi.habitv:api` and
+  `com.dabi.habitv:framework` with `${project.version}`.
+- Pin `com.sun.tools.xjc.maven2:maven-jaxb-plugin` to its last
+  known-working version in `application/core/pom.xml`.
+- Decide on `plugins/plugin-tester` wiring (likely include it as
+  a module so test-scope reactor coordinates resolve).
+- Keep scope to POM topology / version pins. No source changes,
+  no plugin upgrades, no provider rewrites, no JavaFX work, no
+  FTP/HTTP repo migration.

--- a/docs/audit-master-baseline.md
+++ b/docs/audit-master-baseline.md
@@ -285,7 +285,7 @@ walks 32 entries:
   by Maven 3.9 default mirror policy. Tracked as R-010 and
   scoped to HBTV-002.
 
-### Next recommended PR
+### Next recommended PR after HBTV-002
 
 `build: stabilize Java 8 compile baseline` (HBTV-002):
 
@@ -299,3 +299,50 @@ walks 32 entries:
 - Keep scope to POM topology / version pins. No source changes,
   no plugin upgrades, no provider rewrites, no JavaFX work, no
   FTP/HTTP repo migration.
+
+## Java 8 compile baseline findings (HBTV-002)
+
+Captured during the `build: stabilize Java 8 compile baseline` PR on
+branch `build/stabilize-java8-compile-baseline` from `develop`.
+Environment: Windows 11, Apache Maven 3.9.11, Java 8.
+
+### Scope applied
+
+- Root `pom.xml`: replaced dependencyManagement ranges `[4.1,4.2)` for
+  intra-reactor `com.dabi.habitv:api` and `com.dabi.habitv:framework`
+  with `${project.version}`.
+- `application/core/pom.xml`: pinned
+  `com.sun.tools.xjc.maven2:maven-jaxb-plugin` to `1.1.1`.
+- `plugins/pom.xml`: temporary evaluation adding
+  `<module>plugin-tester</module>` was tested and reverted because it
+  did not resolve compile.
+
+### Validation progression
+
+- Baseline `mvn -B -ntp -DskipTests validate`: `BUILD SUCCESS` across
+  32 modules, with warning about missing `maven-jaxb-plugin` version.
+- Baseline `mvn -B -ntp -DskipTests compile`: `BUILD FAILURE` at
+  `framework` due to `api:jar:[4.1,4.2)` resolution.
+- After root version fix: `compile` moved past `framework` and reached
+  `plugins/6play`.
+- After JAXB plugin pin: warning removed from `validate`; `compile`
+  still failed at `plugins/6play` on
+  `com.dabi.habitv:plugin-tester:4.1.0` descriptor resolution via the
+  blocked legacy repository.
+- With temporary `plugin-tester` reactor inclusion: `compile` still
+  failed at the same place because module POMs request `4.1.0` while
+  reactor builds `4.1.0-SNAPSHOT`.
+
+### Risk status impact
+
+- R-010 mitigated by replacing intra-reactor ranges with
+  `${project.version}`.
+- R-011 mitigated by pinning JAXB plugin version to `1.1.1`.
+- New blocker logged as R-012 (plugin tester version mismatch).
+
+### Next recommended PR
+
+Follow up HBTV-002 with a POM-only change set to align plugin
+test-harness dependencies from `plugin-tester:4.1.0` to reactor-aligned
+coordinates (for example `${project.version}`), then re-run
+`mvn -B -ntp -DskipTests compile`.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -50,7 +50,7 @@
     {
       "id": "HBTV-002",
       "title": "Java 8 baseline CI",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P0",
       "scope": "Extend baseline workflow from validate to compile (and later test) once HBTV-001 lands. Includes replacing intra-reactor version range [4.1,4.2) with ${project.version}, pinning maven-jaxb-plugin version, and deciding whether to wire plugin-tester into the reactor.",
       "acceptanceCriteria": [
@@ -58,10 +58,16 @@
         "Network/provider tests remain excluded by default."
       ],
       "validation": [
-        "CI matrix runs green on ubuntu-latest and windows-latest"
+        "Baseline: mvn -B -ntp -DskipTests validate -> BUILD SUCCESS (32 modules) with warning about missing maven-jaxb-plugin version",
+        "Baseline: mvn -B -ntp -DskipTests compile -> BUILD FAILURE at framework: No versions available for com.dabi.habitv:api:jar:[4.1,4.2)",
+        "After root dependencyManagement fix (${project.version} for api/framework): mvn -B -ntp -DskipTests validate -> BUILD SUCCESS",
+        "After root dependencyManagement fix (${project.version} for api/framework): mvn -B -ntp -DskipTests compile -> moves past framework, fails at 6play on plugin-tester:4.1.0 descriptor resolution",
+        "After pinning com.sun.tools.xjc.maven2:maven-jaxb-plugin to 1.1.1: mvn -B -ntp -DskipTests validate -> BUILD SUCCESS without missing plugin version warning",
+        "After pinning com.sun.tools.xjc.maven2:maven-jaxb-plugin to 1.1.1: mvn -B -ntp -DskipTests compile -> BUILD FAILURE at 6play due to plugin-tester:4.1.0 resolution via blocked legacy repository",
+        "Evaluation only: adding <module>plugin-tester</module> in plugins/pom.xml does not remove the compile blocker because plugin dependencies request 4.1.0 while reactor builds 4.1.0-SNAPSHOT; change not kept"
       ],
-      "pr": "TBD",
-      "notes": "Depends on HBTV-001. Compile currently fails at framework because of intra-reactor range [4.1,4.2) on api/framework."
+      "pr": "build: stabilize Java 8 compile baseline",
+      "notes": "Depends on HBTV-001. R-010 and R-011 are mitigated by this PR. Remaining blocker: plugin-tester test-harness version alignment (4.1.0 in plugin dependencies vs 4.1.0-SNAPSHOT in reactor)."
     },
     {
       "id": "HBTV-003",

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -29,27 +29,30 @@
     {
       "id": "HBTV-001",
       "title": "Maven reactor audit",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P0",
-      "scope": "Investigate why root pom.xml and fwk/pom.xml have no <modules>; propose corrected reactor wiring covering fwk, application, plugins (incl. plugin-tester, habiTv-linux, habiTv-windows).",
+      "scope": "Wire the Maven multi-module reactor so mvn validate walks the full project from root; align parent versions and relativePath across fwk, application, plugins. Topology only; no dependency or plugin upgrades, no source changes.",
       "acceptanceCriteria": [
-        "Reactor wiring proposal documented with reasoning.",
-        "Parent version mismatches identified (4.1.0 vs 4.1.0-SNAPSHOT, the 4.1.0-SNASPHOT typo in fwk/framework/pom.xml).",
-        "Pilot branch demonstrates mvn -N validate succeeds at root."
+        "Root pom.xml aggregates fwk, application, plugins.",
+        "fwk/pom.xml aggregates api, framework.",
+        "application/pom.xml keeps core, consoleView, trayView, habiTv; habiTv-linux and habiTv-windows intentionally excluded.",
+        "plugins/pom.xml keeps 22 plugin modules; plugin-tester intentionally excluded.",
+        "All child POMs parent at 4.1.0-SNAPSHOT with explicit <relativePath>.",
+        "fwk/framework own version typo 4.1.0-SNASPHOT fixed to 4.1.0-SNAPSHOT."
       ],
       "validation": [
-        "mvn -B -ntp -N -DskipTests validate",
-        "per-module smoke walk via mvn -B -ntp -pl <module> validate"
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS across 32 reactor modules",
+        "mvn -B -ntp -DskipTests compile -> FAILS at framework due to intra-reactor dependency range [4.1,4.2) excluding SNAPSHOT siblings; deferred to HBTV-002"
       ],
-      "pr": "build: stabilize Maven reactor from master (planned)",
-      "notes": "Audit + minimal wiring only; no plugin/version upgrades."
+      "pr": "build: stabilize Maven reactor from master",
+      "notes": "habiTv-linux/habiTv-windows out of reactor (hardcoded jdk.home, JDK-bundled JavaFX, ZenJava plugin); plugin-tester out of reactor (deferred to HBTV-002 test-compile scope); habiTv-windows still parents to root parent (sibling habiTv-linux parents to application); preserved because both modules are excluded."
     },
     {
       "id": "HBTV-002",
       "title": "Java 8 baseline CI",
       "status": "proposed",
       "priority": "P0",
-      "scope": "Extend baseline workflow from validate to compile (and later test) once HBTV-001 lands.",
+      "scope": "Extend baseline workflow from validate to compile (and later test) once HBTV-001 lands. Includes replacing intra-reactor version range [4.1,4.2) with ${project.version}, pinning maven-jaxb-plugin version, and deciding whether to wire plugin-tester into the reactor.",
       "acceptanceCriteria": [
         "mvn -B -ntp -DskipTests compile passes on Ubuntu and Windows with Temurin 8.",
         "Network/provider tests remain excluded by default."
@@ -58,7 +61,7 @@
         "CI matrix runs green on ubuntu-latest and windows-latest"
       ],
       "pr": "TBD",
-      "notes": "Depends on HBTV-001."
+      "notes": "Depends on HBTV-001. Compile currently fails at framework because of intra-reactor range [4.1,4.2) on api/framework."
     },
     {
       "id": "HBTV-003",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -75,7 +75,7 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 
 ## HBTV-002 — Java 8 baseline CI
 
-- Status: proposed
+- Status: in-progress
 - Priority: P0
 - Scope: Extend the baseline workflow from `validate` to `compile`
   (and later `test`) once HBTV-001 lands. Specifically:
@@ -93,10 +93,29 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
   - `mvn -B -ntp -DskipTests compile` passes on Ubuntu and Windows
     with Temurin 8.
   - Network/provider tests remain excluded by default.
-- Validation: CI matrix runs green on Ubuntu and Windows.
-- PR: TBD.
-- Notes: Depends on HBTV-001. Compile currently fails at
-  `framework` because of the intra-reactor range.
+- Validation:
+  - Baseline (before fixes):
+    - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS` (32 modules)
+      with warning: `maven-jaxb-plugin` missing version.
+    - `mvn -B -ntp -DskipTests compile` -> `BUILD FAILURE` at
+      `framework`: `No versions available for ... api:jar:[4.1,4.2)`.
+  - After replacing root intra-reactor ranges with `${project.version}`:
+    - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS`.
+    - `mvn -B -ntp -DskipTests compile` moves past `framework` and fails
+      later at `6play` on `plugin-tester:4.1.0` descriptor resolution.
+  - After pinning `maven-jaxb-plugin` to `1.1.1` in `application/core`:
+    - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS` with no
+      missing-plugin-version warning.
+    - `mvn -B -ntp -DskipTests compile` still fails at `6play` due to
+      `plugin-tester:4.1.0` resolution via blocked legacy repository.
+  - Evaluation: adding `<module>plugin-tester</module>` to
+    `plugins/pom.xml` does not remove the compile blocker because plugin
+    modules still request `plugin-tester:4.1.0` while reactor builds
+    `4.1.0-SNAPSHOT`. Change was not kept in this PR.
+- PR: build: stabilize Java 8 compile baseline.
+- Notes: Depends on HBTV-001. R-010 and R-011 are mitigated; the next
+  blocker is plugin test-harness version alignment (`plugin-tester`
+  `4.1.0` vs reactor `4.1.0-SNAPSHOT`).
 
 ## HBTV-003 — Repository branch / rules setup
 

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -32,36 +32,71 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 
 ## HBTV-001 — Maven reactor audit
 
-- Status: proposed
+- Status: in-progress
 - Priority: P0
-- Scope: Investigate and document why the root `pom.xml`, `fwk/pom.xml`
-  do not list `<modules>`; propose a corrected reactor that includes
-  `fwk`, `application`, `plugins` (and decides on
-  `plugins/plugin-tester`, `application/habiTv-linux`,
-  `application/habiTv-windows`).
+- Scope: Wire the Maven multi-module reactor so `mvn validate` walks
+  the full project from the root and parent resolution is
+  deterministic across `fwk`, `application`, and `plugins`. Topology
+  only; no dependency or plugin upgrades, no source changes.
 - Acceptance criteria:
-  - Reactor wiring proposal documented with reasoning.
-  - Parent version mismatches identified
-    (`4.1.0` vs `4.1.0-SNAPSHOT`, the `4.1.0-SNASPHOT` typo).
-  - Pilot branch demonstrates `mvn -N validate` succeeds at root.
-- Validation: `mvn -B -ntp -N -DskipTests validate` plus a per-module
-  smoke walk.
-- PR: build: stabilize Maven reactor from master (planned).
-- Notes: Audit + minimal wiring only; no plugin/version upgrades.
+  - Root `pom.xml` aggregates `fwk`, `application`, `plugins`. (done)
+  - `fwk/pom.xml` aggregates `api`, `framework`. (done)
+  - `application/pom.xml` keeps `core`, `consoleView`, `trayView`,
+    `habiTv`. `habiTv-linux` and `habiTv-windows` intentionally
+    excluded (hardcoded `${jdk.home}`, JDK-bundled JavaFX, ZenJava
+    plugin). (done — see notes)
+  - `plugins/pom.xml` keeps the 22 plugin modules. `plugin-tester`
+    intentionally excluded (deferred to HBTV-002 test-compile
+    scope). (done — see notes)
+  - All child POMs parent at `4.1.0-SNAPSHOT` with explicit
+    `<relativePath>`. (done)
+  - `fwk/framework/pom.xml` own version typo `4.1.0-SNASPHOT`
+    fixed to `4.1.0-SNAPSHOT`. (done)
+- Validation:
+  - `mvn -B -ntp -DskipTests validate` walks all 32 reactor
+    modules and reports BUILD SUCCESS.
+  - `mvn -B -ntp -DskipTests compile` reaches the next real
+    blocker (intra-reactor dependency range `[4.1,4.2)` on
+    `api`/`framework` in the root POM excludes SNAPSHOT siblings;
+    compile FAILS at `framework`). Deferred to HBTV-002.
+- PR: build: stabilize Maven reactor from master.
+- Notes:
+  - `habiTv-linux` and `habiTv-windows` left on disk but out of
+    the reactor; status documented in
+    `docs/audit-master-baseline.md`. They remain untouched and
+    are tracked under HBTV-008 (JavaFX / runtime packaging audit).
+  - `plugin-tester` left on disk but out of the reactor; test
+    sources depend on it only when the lifecycle reaches
+    `test-compile`, which HBTV-002 will address.
+  - One latent inconsistency intentionally preserved:
+    `application/habiTv-windows` parents to root `parent` while
+    its sibling `habiTv-linux` parents to `application`. Not
+    fixed because both modules are excluded from the reactor.
 
 ## HBTV-002 — Java 8 baseline CI
 
 - Status: proposed
 - Priority: P0
 - Scope: Extend the baseline workflow from `validate` to `compile`
-  (and later `test`) once HBTV-001 lands.
+  (and later `test`) once HBTV-001 lands. Specifically:
+  - Replace intra-reactor version range `[4.1,4.2)` on
+    `com.dabi.habitv:api` / `com.dabi.habitv:framework` in root
+    `pom.xml` with `${project.version}` so reactor SNAPSHOTs
+    resolve without the blocked HTTP repository.
+  - Decide whether to wire `plugins/plugin-tester` into the
+    reactor so test sources can resolve the harness once the
+    workflow reaches `test-compile`.
+  - Pin `maven-jaxb-plugin` to an explicit version (current
+    warning: missing version) so `application/core` keeps
+    generating deterministically.
 - Acceptance criteria:
   - `mvn -B -ntp -DskipTests compile` passes on Ubuntu and Windows
     with Temurin 8.
   - Network/provider tests remain excluded by default.
 - Validation: CI matrix runs green on Ubuntu and Windows.
 - PR: TBD.
-- Notes: Depends on HBTV-001.
+- Notes: Depends on HBTV-001. Compile currently fails at
+  `framework` because of the intra-reactor range.
 
 ## HBTV-003 — Repository branch / rules setup
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -16,6 +16,8 @@ or accepted.
 | R-007 | Auto-update pulls unexpected old artifacts     | Medium     | High   | P1       |
 | R-008 | yt-dlp migration changes download behavior     | Medium     | Medium | P2       |
 | R-009 | GitHub Pages layout mismatches updater         | Medium     | High   | P1       |
+| R-010 | Intra-reactor version range excludes SNAPSHOTs | High       | High   | P0       |
+| R-011 | maven-jaxb-plugin missing pinned version       | Medium     | Medium | P1       |
 
 ---
 
@@ -105,3 +107,26 @@ or accepted.
 - Mitigation: HBTV-005 defines the layout explicitly and validates
   it against `FindArtifactUtils.findLastVersionUrl` semantics
   before cutting over.
+
+## R-010 — Intra-reactor version range `[4.1,4.2)` excludes SNAPSHOTs
+
+- Description: Root `pom.xml` declares dependencyManagement entries
+  for `com.dabi.habitv:api` and `com.dabi.habitv:framework` with the
+  closed version range `[4.1,4.2)`. Maven does not by default
+  include `4.1.0-SNAPSHOT` in that range, and the legacy
+  `dabiboo.free.fr` HTTP repository (which would have served the
+  matching release) is blocked by Maven 3.9+ defaults and likely
+  unreachable. As a result, `mvn compile` fails at `framework`
+  during dependency collection.
+- Mitigation: Replace the range with `${project.version}` for
+  intra-reactor coordinates in HBTV-002. No code change; POM only.
+
+## R-011 — `maven-jaxb-plugin` missing pinned version
+
+- Description: `application/core/pom.xml` declares
+  `com.sun.tools.xjc.maven2:maven-jaxb-plugin` without a `<version>`.
+  Maven 3.9+ warns and may refuse to build in future versions. Build
+  behavior depends on which plugin version Maven happens to resolve.
+- Mitigation: Pin the plugin version (e.g. the last known-working
+  `1.1.1`) in HBTV-002 so JAXB generation stays deterministic. No
+  source change.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -5,19 +5,20 @@ Severity uses `Likelihood x Impact` (Low / Medium / High) and an
 overall priority. Update when a risk is added, mitigated, realized,
 or accepted.
 
-| ID    | Title                                          | Likelihood | Impact | Priority |
-|-------|------------------------------------------------|------------|--------|----------|
-| R-001 | Legacy Maven repository / free.fr dependency   | High       | High   | P0       |
-| R-002 | FTP deployment no longer viable                | High       | High   | P0       |
-| R-003 | JavaFX tied to JDK 8 assumptions               | High       | High   | P1       |
-| R-004 | JAXB generation / runtime mismatch             | Medium     | High   | P1       |
-| R-005 | Live provider tests are non-deterministic      | High       | Medium | P1       |
-| R-006 | Provider endpoints obsolete or renamed         | High       | Medium | P1       |
-| R-007 | Auto-update pulls unexpected old artifacts     | Medium     | High   | P1       |
-| R-008 | yt-dlp migration changes download behavior     | Medium     | Medium | P2       |
-| R-009 | GitHub Pages layout mismatches updater         | Medium     | High   | P1       |
-| R-010 | Intra-reactor version range excludes SNAPSHOTs | High       | High   | P0       |
-| R-011 | maven-jaxb-plugin missing pinned version       | Medium     | Medium | P1       |
+| ID    | Title                                                           | Likelihood | Impact | Priority |
+|-------|-----------------------------------------------------------------|------------|--------|----------|
+| R-001 | Legacy Maven repository / free.fr dependency                    | High       | High   | P0       |
+| R-002 | FTP deployment no longer viable                                 | High       | High   | P0       |
+| R-003 | JavaFX tied to JDK 8 assumptions                                | High       | High   | P1       |
+| R-004 | JAXB generation / runtime mismatch                              | Medium     | High   | P1       |
+| R-005 | Live provider tests are non-deterministic                       | High       | Medium | P1       |
+| R-006 | Provider endpoints obsolete or renamed                          | High       | Medium | P1       |
+| R-007 | Auto-update pulls unexpected old artifacts                      | Medium     | High   | P1       |
+| R-008 | yt-dlp migration changes download behavior                      | Medium     | Medium | P2       |
+| R-009 | GitHub Pages layout mismatches updater                          | Medium     | High   | P1       |
+| R-010 | Intra-reactor version range excludes SNAPSHOTs (mitigated)      | Low        | Low    | P3       |
+| R-011 | maven-jaxb-plugin missing pinned version (mitigated)            | Low        | Low    | P3       |
+| R-012 | Plugin tester version mismatch blocks compile                   | High       | Medium | P1       |
 
 ---
 
@@ -120,6 +121,8 @@ or accepted.
   during dependency collection.
 - Mitigation: Replace the range with `${project.version}` for
   intra-reactor coordinates in HBTV-002. No code change; POM only.
+- Status: Mitigated in HBTV-002 by replacing the `api` and `framework`
+  root dependencyManagement versions with `${project.version}`.
 
 ## R-011 — `maven-jaxb-plugin` missing pinned version
 
@@ -130,3 +133,20 @@ or accepted.
 - Mitigation: Pin the plugin version (e.g. the last known-working
   `1.1.1`) in HBTV-002 so JAXB generation stays deterministic. No
   source change.
+- Status: Mitigated in HBTV-002 by pinning
+  `com.sun.tools.xjc.maven2:maven-jaxb-plugin` to `1.1.1` in
+  `application/core/pom.xml`.
+
+## R-012 — Plugin tester version mismatch blocks compile
+
+- Description: Plugin modules declare test-scope dependencies on
+  `com.dabi.habitv:plugin-tester:4.1.0`, while the project version is
+  `4.1.0-SNAPSHOT` and the reactor artifact is
+  `com.dabi.habitv:plugin-tester:4.1.0-SNAPSHOT`. During
+  `mvn -B -ntp -DskipTests compile`, Maven fails at `plugins/6play`
+  while resolving the `plugin-tester:4.1.0` descriptor from the blocked
+  legacy HTTP repository.
+- Mitigation: Dedicated POM-only follow-up to align plugin test-harness
+  versions to reactor coordinates (for example `${project.version}`) and
+  confirm whether `plugin-tester` should stay aggregated in
+  `plugins/pom.xml`.

--- a/fwk/api/pom.xml
+++ b/fwk/api/pom.xml
@@ -3,7 +3,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>api</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/fwk/framework/pom.xml
+++ b/fwk/framework/pom.xml
@@ -4,12 +4,13 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>framework</artifactId>
 	<packaging>jar</packaging>
 	<name>framework</name>
-	<version>4.1.0-SNASPHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<scm>
 		<connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/fwk/framework</connection>

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/RetrieverUtils.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/RetrieverUtils.java
@@ -53,17 +53,11 @@ public final class RetrieverUtils {
 		try {
 			HttpURLConnection hc = (HttpURLConnection) openConnection(url, proxy);
 			prepareConnection(timeOut, hc);
-			
-			boolean redirect = false;
 
-			// normally, 3xx is redirect
 			int status = hc.getResponseCode();
-			if (status != HttpURLConnection.HTTP_OK) {	
-				if (status == HttpURLConnection.HTTP_MOVED_TEMP
+			boolean redirect = status == HttpURLConnection.HTTP_MOVED_TEMP
 					|| status == HttpURLConnection.HTTP_MOVED_PERM
-						|| status == HttpURLConnection.HTTP_SEE_OTHER)
-				redirect = true;
-			}
+					|| status == HttpURLConnection.HTTP_SEE_OTHER;
 
 			if (redirect) {
 				// get redirect url from "location" header field
@@ -71,11 +65,52 @@ public final class RetrieverUtils {
 				// open the new connnection again
 				hc = (HttpURLConnection) new URL(newUrl).openConnection();
 				prepareConnection(timeOut, hc);
+				status = hc.getResponseCode();
 			}
-			
+
+			if (status >= HTTP_ERROR_THRESHOLD) {
+				throw new TechnicalException(buildHttpErrorMessage(url, status, hc));
+			}
+
 			return hc.getInputStream();
 		} catch (final IOException e) {
 			throw new TechnicalException(e);
+		}
+	}
+
+	private static final int HTTP_ERROR_THRESHOLD = 400;
+	private static final int MAX_ERROR_BODY_LENGTH = 1024;
+
+	private static String buildHttpErrorMessage(final String url, final int status, final HttpURLConnection hc) {
+		final String body = readErrorBody(hc);
+		final String suffix = (body == null || body.isEmpty()) ? "" : " - response body: " + body;
+		return "HTTP " + status + " for URL: " + url + suffix;
+	}
+
+	private static String readErrorBody(final HttpURLConnection hc) {
+		final InputStream err = hc.getErrorStream();
+		if (err == null) {
+			return null;
+		}
+		try {
+			final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			final byte[] buf = new byte[512];
+			int read;
+			int total = 0;
+			while (total < MAX_ERROR_BODY_LENGTH && (read = err.read(buf)) != -1) {
+				final int toWrite = Math.min(read, MAX_ERROR_BODY_LENGTH - total);
+				baos.write(buf, 0, toWrite);
+				total += toWrite;
+			}
+			return baos.toString(FrameworkConf.UTF8).replaceAll("\\s+", " ").trim();
+		} catch (final IOException ignored) {
+			return null;
+		} finally {
+			try {
+				err.close();
+			} catch (final IOException ignored) {
+				// best effort
+			}
 		}
 	}
 

--- a/fwk/pom.xml
+++ b/fwk/pom.xml
@@ -4,11 +4,17 @@
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>fwk</artifactId>
 	<packaging>pom</packaging>
 
 	<name>fwk habiTv</name>
+
+	<modules>
+		<module>api</module>
+		<module>framework</module>
+	</modules>
 
 </project>

--- a/plugins/6play/pom.xml
+++ b/plugins/6play/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>6play</artifactId>
 	<name>6play</name>

--- a/plugins/RSS/pom.xml
+++ b/plugins/RSS/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>RSS</artifactId>
 	<name>RSS</name>

--- a/plugins/adobeHDS/pom.xml
+++ b/plugins/adobeHDS/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>plugins</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>adobeHDS</artifactId>
 	<name>adobeHDS</name>

--- a/plugins/aria2/pom.xml
+++ b/plugins/aria2/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>aria2</artifactId>
 	<name>aria2</name>

--- a/plugins/arte/pom.xml
+++ b/plugins/arte/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>arte</artifactId>
 	<name>arte</name>

--- a/plugins/beinsport/pom.xml
+++ b/plugins/beinsport/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>beinsport</artifactId>
 	<name>beinsport</name>

--- a/plugins/canalPlus/pom.xml
+++ b/plugins/canalPlus/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>canalPlus</artifactId>
 	<name>canalPlus</name>

--- a/plugins/clubic/pom.xml
+++ b/plugins/clubic/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>clubic</artifactId>
 	<name>clubic</name>

--- a/plugins/cmd/pom.xml
+++ b/plugins/cmd/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>cmd</artifactId>
 	<name>cmd</name>

--- a/plugins/curl/pom.xml
+++ b/plugins/curl/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>curl</artifactId>
 	<name>curl</name>

--- a/plugins/email/pom.xml
+++ b/plugins/email/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>email</artifactId>
 	<name>email</name>

--- a/plugins/ffmpeg/pom.xml
+++ b/plugins/ffmpeg/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>ffmpeg</artifactId>
 	<name>ffmpeg</name>

--- a/plugins/file/pom.xml
+++ b/plugins/file/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>file</artifactId>
 	<name>file</name>

--- a/plugins/footyroom/pom.xml
+++ b/plugins/footyroom/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>footyroom</artifactId>
 	<version>4.1.1-SNAPSHOT</version>

--- a/plugins/globalnews/pom.xml
+++ b/plugins/globalnews/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>globalnews</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/plugins/lequipe/pom.xml
+++ b/plugins/lequipe/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>lequipe</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/plugins/mlssoccer/pom.xml
+++ b/plugins/mlssoccer/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mlssoccer</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/plugins/plugin-tester/pom.xml
+++ b/plugins/plugin-tester/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>plugin-tester</artifactId>
 	<packaging>jar</packaging>

--- a/plugins/pluzz/pom.xml
+++ b/plugins/pluzz/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>pluzz</artifactId>
 	<name>pluzz</name>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -3,7 +3,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>plugins</artifactId>
 	<packaging>pom</packaging>

--- a/plugins/rtmpDump/pom.xml
+++ b/plugins/rtmpDump/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>rtmpDump</artifactId>
 	<name>rtmpDump</name>

--- a/plugins/sfr/pom.xml
+++ b/plugins/sfr/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>sfr</artifactId>
 	<version>4.1.0-SNAPSHOT</version>

--- a/plugins/wat/pom.xml
+++ b/plugins/wat/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>wat</artifactId>
 	<name>wat</name>

--- a/plugins/youtube/pom.xml
+++ b/plugins/youtube/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>com.dabi.habitv</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<scm>

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
@@ -15,7 +15,24 @@ public final class YoutubeConf {
 	public static final long MAX_HUNG_TIME = 300000L;
 	public static final String DEFAULT_WINDOWS_EXE = "youtube-dl.exe";
 	public static final String DEFAULT_LINUX_BIN_PATH = "youtube-dl";
+
+	public static final String API_KEY_SYSTEM_PROPERTY = "habitv.youtube.api.key";
+	public static final String API_KEY_ENV_VAR = "HABITV_YOUTUBE_API_KEY";
+	// Shared fallback shipped with habiTv. Likely rate-limited or revoked;
+	// override via -D habitv.youtube.api.key=... or the HABITV_YOUTUBE_API_KEY env var.
 	public static final String API_KEY = "AIzaSyCg3WitBUQl5ifC2QygQaZUPOSRMKfSD5E";
 	public static final String BASE_URL = "https://www.youtube.com";
+
+	public static String getApiKey() {
+		String key = System.getProperty(API_KEY_SYSTEM_PROPERTY);
+		if (key != null && !key.isEmpty()) {
+			return key;
+		}
+		key = System.getenv(API_KEY_ENV_VAR);
+		if (key != null && !key.isEmpty()) {
+			return key;
+		}
+		return API_KEY;
+	}
 
 }

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginManager.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginManager.java
@@ -54,7 +54,7 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 
 	private Set<EpisodeDTO> findEpisodeTop(CategoryDTO category, Map<String, String> params) {
 		String url = "https://www.googleapis.com/youtube/v3/search?part=snippet&order=viewCount&type=video";
-		url = addParam(url, params, "key", YoutubeConf.API_KEY);
+		url = addParam(url, params, "key", YoutubeConf.getApiKey());
 		String days = params.get(DAYS);
 		if (days != null) {
 			String publishedAfter = dateFormat.format(DateUtils.addDays(new Date(), -Integer.valueOf(days)));
@@ -86,8 +86,8 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 	}
 
 	private Set<EpisodeDTO> findEpisodePlaylist(CategoryDTO category, Map<String, String> params) {
-		String url = "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&order=viewCount&type=video";
-		url = addParam(url, params, "key", YoutubeConf.API_KEY);
+		String url = "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet";
+		url = addParam(url, params, "key", YoutubeConf.getApiKey());
 		url = addParam(url, params, PLAYLIST_ID);
 		url = addParam(url, params, MAX_RESULTS, "50");
 		return findEpisodesFromUrl(category, url);

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,12 @@
 
 	<name>Parent habiTv</name>
 
+	<modules>
+		<module>fwk</module>
+		<module>application</module>
+		<module>plugins</module>
+	</modules>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>api</artifactId>
-			<version>[4.1,4.2)</version>
+			<version>${project.version}</version>
 		</dependency>	
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>framework</artifactId>
-			<version>[4.1,4.2)</version>
+			<version>${project.version}</version>
 		</dependency>			
 
 		<dependency>


### PR DESCRIPTION
## Why

A user report (`habiTv.log`) showed the YouTube plugin failing repeatedly with:

```
com.dabi.habitv.api.plugin.exception.TechnicalException: java.io.IOException:
  Server returned HTTP response code: 403 for URL:
  https://www.googleapis.com/youtube/v3/playlistItems?...&key
```

Two problems combined:

1. The YouTube Data API key is **hardcoded and shipped with habiTv**, so every user shares one key. It is now rate-limited / disabled and returns 403.
2. `RetrieverUtils` discards Google's error response body, so the log only shows the HTTP status — users cannot tell whether the failure is `quotaExceeded`, `accessNotConfigured`, `keyInvalid`, etc.

A side bug visible in the log URL: `maxResults=50` appears twice because both the base URL literal and `addParam(... MAX_RESULTS, "50")` add it.

## Changes

- **`YoutubeConf`** — new `getApiKey()` that resolves, in order:
  1. system property `habitv.youtube.api.key` (`-Dhabitv.youtube.api.key=...`)
  2. env var `HABITV_YOUTUBE_API_KEY`
  3. existing hardcoded fallback (kept for backward compatibility)
- **`YoutubePluginManager`** — call `getApiKey()`; clean up the `playlistItems` URL to remove the duplicated `maxResults=50` and the `order`/`type` params that the playlistItems endpoint silently ignores (those are `search`-endpoint params).
- **`RetrieverUtils.getInputStreamFromUrl`** — for `status >= 400`, read `getErrorStream()` (truncated to 1 KB, whitespace-collapsed) and throw a `TechnicalException` whose message includes the URL, status code, and response body. Lets users immediately see Google's actual error reason.

## Test plan

- [ ] Run habiTv without setting any env var/property — behaves exactly as before (still hits the shipped key, still 403 if Google has revoked it, but now the log shows Google's reason text instead of a bare 403).
- [ ] Set `HABITV_YOUTUBE_API_KEY=<your-key>` and re-run — plugin should use the user's key and succeed against a valid playlist.
- [ ] Set `-Dhabitv.youtube.api.key=<your-key>` on the JVM command line — same result; system property wins over env var.
- [ ] Verify the playlistItems URL in the log no longer contains a duplicated `maxResults=50`.
- [ ] Trigger an unrelated 4xx/5xx from another plugin and confirm the exception message now includes the response body (this is a framework-wide improvement).


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2qNLGfsK5TXAgG9fudBk5)_