### PR TITLE
fix(youtube): externalize data api key and mask api errors

### DIFF
--- a/application/core/src/com/dabi/habitv/core/config/UserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/UserConfig.java
@@ -37,6 +37,8 @@ public interface UserConfig {
 
 	String getBinDir();
 
+	String getYoutubeApiKey();
+
 	void setMaxAttempts(int parseInt);
 
 	void setUpdateOnStartup(boolean updateOnStartup);
@@ -44,5 +46,7 @@ public interface UserConfig {
 	void setDownloadOuput(String downloadOuput);
 
 	void setDemonCheckTime(int demonCheckTime);
+
+	void setYoutubeApiKey(String youtubeApiKey);
 
 }

--- a/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Iterator;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -46,6 +47,7 @@ import com.dabi.habitv.utils.FileUtils;
 import com.dabi.habitv.utils.XMLUtils;
 
 public class XMLUserConfig implements UserConfig {
+	private static final String YOUTUBE_API_KEY = "youtubeApiKey";
 
 	private static final int DEFAULT_MAX_ATTEMPTS = 5;
 
@@ -486,6 +488,11 @@ public class XMLUserConfig implements UserConfig {
 	}
 
 	@Override
+	public String getYoutubeApiKey() {
+		return normalizeValue(getDownloader().get(YOUTUBE_API_KEY));
+	}
+
+	@Override
 	public void setMaxAttempts(int maxAttemps) {
 		DownloadConfig downloadConfig = loadDownloadConfig();
 		downloadConfig.setMaxAttempts(maxAttemps);
@@ -525,6 +532,46 @@ public class XMLUserConfig implements UserConfig {
 	public void setDemonCheckTime(int demonCheckTime) {
 		DownloadConfig downloadConfig = loadDownloadConfig();
 		downloadConfig.setDemonCheckTime(demonCheckTime);
+	}
+
+	@Override
+	public void setYoutubeApiKey(String youtubeApiKey) {
+		String normalizedValue = normalizeValue(youtubeApiKey);
+		Downloaders downloaders = loadDownloaders();
+		Iterator<Object> iterator = downloaders.getAny().iterator();
+		while (iterator.hasNext()) {
+			Object downloader = iterator.next();
+			if (YOUTUBE_API_KEY.equals(XMLUtils.getTagName(downloader))) {
+				if (normalizedValue == null) {
+					iterator.remove();
+				} else {
+					XMLUtils.setTagValue(downloader, normalizedValue);
+				}
+				return;
+			}
+		}
+		if (normalizedValue != null) {
+			downloaders.getAny().add(
+					XMLUtils.buildAnyElement(YOUTUBE_API_KEY, normalizedValue));
+		}
+	}
+
+	private Downloaders loadDownloaders() {
+		DownloadConfig downloadConfig = loadDownloadConfig();
+		Downloaders downloaders = downloadConfig.getDownloaders();
+		if (downloaders == null) {
+			downloaders = new Downloaders();
+			downloadConfig.setDownloaders(downloaders);
+		}
+		return downloaders;
+	}
+
+	private String normalizeValue(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.isEmpty() ? null : trimmed;
 	}
 
 }

--- a/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
+++ b/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
@@ -19,6 +19,7 @@ import com.dabi.habitv.framework.plugin.utils.RetrieverUtils;
 import com.dabi.habitv.utils.DirUtils;
 
 public final class CoreManager {
+	private static final String YOUTUBE_API_KEY_PROPERTY = "habitv.youtube.apiKey";
 
 	private final CategoryManager categoryManager;
 
@@ -35,6 +36,7 @@ public final class CoreManager {
 		LOG.info("habitv version " + FWKProperties.getVersion());
 		taskName2PoolSizeMap = config.getTaskDefinition();
 		TokenReplacer.setCutSize(config.getFileNameCutSize());
+		applyYoutubeApiKey(config.getYoutubeApiKey());
 		pluginManager = new PluginManager(config);
 		episodeManager = new EpisodeManager(pluginManager.getDownloadersHolder(), pluginManager.getExportersHolder(),
 		        pluginManager.getProvidersHolder(), taskName2PoolSizeMap, config.getMaxAttempts(), DirUtils.getAppDir());
@@ -72,6 +74,12 @@ public final class CoreManager {
 	private void setHttpProxy(final ProxyDTO httpProxy) {
 		System.setProperty("http.proxyHost", httpProxy.getHost());
 		System.setProperty("http.proxyPort", String.valueOf(httpProxy.getPort()));
+	}
+
+	private void applyYoutubeApiKey(String youtubeApiKey) {
+		if (youtubeApiKey != null && !youtubeApiKey.trim().isEmpty()) {
+			System.setProperty(YOUTUBE_API_KEY_PROPERTY, youtubeApiKey.trim());
+		}
 	}
 
 	public CategoryManager getCategoryManager() {

--- a/application/core/src/com/dabi/habitv/utils/XMLUtils.java
+++ b/application/core/src/com/dabi/habitv/utils/XMLUtils.java
@@ -33,4 +33,8 @@ public class XMLUtils {
 	public static String getTagName(Object node) {
 		return ((org.w3c.dom.Node) node).getLocalName();
 	}
+
+	public static void setTagValue(Object node, String value) {
+		((org.w3c.dom.Node) node).setTextContent(value);
+	}
 }

--- a/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
@@ -24,13 +24,17 @@ public class ConfigController extends BaseController {
 
 	private CheckBox autoUpdate;
 
+	private TextField youtubeApiKey;
+
 	public ConfigController(TextField downloadOuput, TextField nbrMaxAttempts,
-			TextField daemonCheckTimeSec, CheckBox autoUpdate) {
+			TextField daemonCheckTimeSec, CheckBox autoUpdate,
+			TextField youtubeApiKey) {
 		super();
 		this.downloadOuput = downloadOuput;
 		this.nbrMaxAttempts = nbrMaxAttempts;
 		this.daemonCheckTimeSec = daemonCheckTimeSec;
 		this.autoUpdate = autoUpdate;
+		this.youtubeApiKey = youtubeApiKey;
 	}
 
 	public void init() {
@@ -58,6 +62,8 @@ public class ConfigController extends BaseController {
 						"Période de temps entre 2 recherches automatiques de téléchargement."));
 		autoUpdate.setTooltip(new Tooltip(
 				"si coché habiTv se mettra à jour automatiquement."));
+		youtubeApiKey.setTooltip(new Tooltip(
+				"Clé API YouTube Data v3. Laissez vide pour utiliser la variable d'environnement ou l'option Java."));
 	}
 
 	private void loadConfig() {
@@ -67,6 +73,7 @@ public class ConfigController extends BaseController {
 		daemonCheckTimeSec.setText(String.valueOf(userConfig
 				.getDemonCheckTime()));
 		autoUpdate.setSelected(userConfig.updateOnStartup());
+		youtubeApiKey.setText(userConfig.getYoutubeApiKey());
 	}
 
 	private void addButtonActions() {
@@ -118,6 +125,22 @@ public class ConfigController extends BaseController {
 		};
 		triggersave(daemonCheckTimeSec, saveDaemonCheck);
 
+		Runnable saveYoutubeApiKey = new Runnable() {
+
+			@Override
+			public void run() {
+				UserConfig userConfig = getController().loadUserConfig();
+				String currentValue = userConfig.getYoutubeApiKey();
+				String newValue = normalize(youtubeApiKey.getText());
+				if (currentValue == null ? newValue != null
+						: !currentValue.equals(newValue)) {
+					userConfig.setYoutubeApiKey(newValue);
+					saveConfig(userConfig);
+				}
+			}
+		};
+		triggersave(youtubeApiKey, saveYoutubeApiKey);
+
 		autoUpdate.setOnAction(new EventHandler<ActionEvent>() {
 
 			@Override
@@ -149,5 +172,13 @@ public class ConfigController extends BaseController {
 		new Popin()
 				.show("Configuration sauvegardée",
 						"La configuration a été sauvegardée \n mais ne sera active qu'après un redémarrage de l'application.");
+	}
+
+	private String normalize(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.isEmpty() ? null : trimmed;
 	}
 }

--- a/application/trayView/src/com/dabi/habitv/tray/controller/WindowController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/WindowController.java
@@ -135,6 +135,9 @@ public class WindowController {
 	@FXML
 	private CheckBox autoUpdate;
 
+	@FXML
+	private TextField youtubeApiKey;
+
 	private boolean trayMode = false;
 
 	public WindowController() {
@@ -196,7 +199,7 @@ public class WindowController {
 			manager.attach(toDlController);
 
 			new ConfigController(downloadOuput, nbrMaxAttempts,
-					daemonCheckTimeSec, autoUpdate).init(controller, manager,
+					daemonCheckTimeSec, autoUpdate, youtubeApiKey).init(controller, manager,
 					primaryStage);
 
 			controller.startDownloadCheckDemon();

--- a/application/trayView/src/com/dabi/habitv/tray/habitv.fxml
+++ b/application/trayView/src/com/dabi/habitv/tray/habitv.fxml
@@ -237,6 +237,8 @@
 											vgrow="SOMETIMES" />
 										<RowConstraints minHeight="10.0" prefHeight="30.0"
 											vgrow="SOMETIMES" />
+										<RowConstraints minHeight="10.0" prefHeight="30.0"
+											vgrow="SOMETIMES" />
 									</rowConstraints>
 									<children>
 										<Label text="Destination des téléchargements : "
@@ -259,6 +261,11 @@
 											GridPane.columnIndex="0" GridPane.rowIndex="3" />
 										<CheckBox fx:id="autoUpdate" mnemonicParsing="false"
 											GridPane.columnIndex="1" GridPane.rowIndex="3" />
+										<Label text="YouTube API key"
+											GridPane.columnIndex="0" GridPane.rowIndex="4" />
+										<TextField fx:id="youtubeApiKey"
+											BorderPane.alignment="CENTER" GridPane.columnIndex="1"
+											GridPane.rowIndex="4" />
 									</children>
 									<padding>
 										<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -214,6 +214,25 @@
       ],
       "pr": "feat(console): restore runnable baseline with yt-dlp provider",
       "notes": "PR #27 is superseded with scoped reuse (build/POM, console fat-jar/runtime docs, YouTube offline test) while excluding its failing application/core source edits. JavaFX modernization, provider cleanup, and scraper rewrites remain out of scope. PR #25 and #26 must be retargeted/rebased from master to develop later. HBTV-004/HBTV-005 repository/update URL migration remains separate."
+    },
+    {
+      "id": "HBTV-012",
+      "title": "YouTube Data API key externalization",
+      "status": "in-progress",
+      "priority": "P1",
+      "scope": "Remove the hardcoded YouTube Data API key from plugins/youtube and resolve it from runtime configuration so revoked/restricted keys do not require a code change.",
+      "acceptanceCriteria": [
+        "YoutubeConf no longer embeds a concrete API key value.",
+        "YoutubePluginManager resolves the key from runtime configuration.",
+        "Playlist API request URL only includes supported parameters.",
+        "Error messages include API request context while masking key values."
+      ],
+      "validation": [
+        "mvn -B -ntp -DskipTests -pl plugins/youtube -am validate -> BUILD SUCCESS",
+        "mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test -> BUILD SUCCESS"
+      ],
+      "pr": "TBD",
+      "notes": "Runtime key lookup order: Java property habitv.youtube.apiKey, then environment variable HABITV_YOUTUBE_API_KEY."
     }
   ]
 }

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -224,15 +224,17 @@
       "acceptanceCriteria": [
         "YoutubeConf no longer embeds a concrete API key value.",
         "YoutubePluginManager resolves the key from runtime configuration.",
+        "trayView configuration exposes a user-editable YouTube API key field persisted in local user configuration.",
         "Playlist API request URL only includes supported parameters.",
         "Error messages include API request context while masking key values."
       ],
       "validation": [
         "mvn -B -ntp -DskipTests -pl plugins/youtube -am validate -> BUILD SUCCESS",
+        "mvn -B -ntp -DskipTests -pl application/trayView,plugins/youtube -am compile -> BUILD SUCCESS",
         "mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test -> BUILD SUCCESS"
       ],
       "pr": "TBD",
-      "notes": "Runtime key lookup order: Java property habitv.youtube.apiKey, then environment variable HABITV_YOUTUBE_API_KEY."
+      "notes": "End users can set the key from the tray configuration tab; no environment variable is required for standard usage. Runtime key lookup order: Java property habitv.youtube.apiKey, then environment variable HABITV_YOUTUBE_API_KEY."
     }
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -306,3 +306,27 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
     after this baseline is merged.
   - HBTV-004/HBTV-005 legacy repository/update URL migration remains
     separate and must not be mixed into this runnable baseline PR.
+
+## HBTV-012 — YouTube Data API key externalization
+
+- Status: in-progress
+- Priority: P1
+- Scope: Remove the hardcoded YouTube Data API key from
+  `plugins/youtube` and use runtime-provided configuration so 403
+  failures from revoked/restricted keys are diagnosable without
+  shipping credentials.
+- Acceptance criteria:
+  - `YoutubeConf` no longer embeds a concrete API key value.
+  - `YoutubePluginManager` resolves the key from runtime configuration.
+  - Playlist API request URL only includes supported parameters.
+  - Error messages include API request context while masking key values.
+- Validation:
+  - `mvn -B -ntp -DskipTests -pl plugins/youtube -am validate`
+    -> `BUILD SUCCESS`.
+  - `mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test`
+    -> `BUILD SUCCESS`.
+- PR: TBD.
+- Notes:
+  - Runtime key lookup order: Java property
+    `habitv.youtube.apiKey`, then environment variable
+    `HABITV_YOUTUBE_API_KEY`.

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -318,15 +318,21 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 - Acceptance criteria:
   - `YoutubeConf` no longer embeds a concrete API key value.
   - `YoutubePluginManager` resolves the key from runtime configuration.
+  - `trayView` configuration exposes a user-editable YouTube API key field
+    persisted in local user configuration.
   - Playlist API request URL only includes supported parameters.
   - Error messages include API request context while masking key values.
 - Validation:
   - `mvn -B -ntp -DskipTests -pl plugins/youtube -am validate`
     -> `BUILD SUCCESS`.
+  - `mvn -B -ntp -DskipTests -pl application/trayView,plugins/youtube -am compile`
+    -> `BUILD SUCCESS`.
   - `mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test`
     -> `BUILD SUCCESS`.
 - PR: TBD.
 - Notes:
+  - End users can set the key from the tray configuration tab; no
+    environment variable is required for standard usage.
   - Runtime key lookup order: Java property
     `habitv.youtube.apiKey`, then environment variable
     `HABITV_YOUTUBE_API_KEY`.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -178,5 +178,6 @@ or accepted.
   deterministic precedence (system property then environment variable),
   and include sanitized request context in error messages.
 - Status: Mitigated in HBTV-012 by removing the hardcoded key constant
-  from `YoutubeConf`, resolving keys from runtime config, and masking
-  the `key` parameter in error messages.
+  from `YoutubeConf`, resolving keys from runtime config, adding a
+  user-facing tray configuration field, and masking the `key`
+  parameter in error messages.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -19,6 +19,7 @@ or accepted.
 | R-010 | Intra-reactor version range excludes SNAPSHOTs (mitigated)      | Low        | Low    | P3       |
 | R-011 | maven-jaxb-plugin missing pinned version (mitigated)            | Low        | Low    | P3       |
 | R-012 | Plugin tester version mismatch blocks compile (mitigated)       | Low        | Low    | P3       |
+| R-013 | Hardcoded YouTube Data API key can break provider search        | Medium     | Medium | P2       |
 
 ---
 
@@ -166,3 +167,16 @@ or accepted.
 - Residual risk: Compile still hits blocked legacy repository resolution
   for `framework/api:4.1.1-SNAPSHOT` in `beinsport`, which is tracked
   under the existing legacy repository migration risk (R-001 / HBTV-004).
+
+## R-013 — Hardcoded YouTube Data API key can break provider search
+
+- Description: `plugins/youtube` embedded a concrete YouTube Data API
+  key in source. If the key is revoked, quota-exhausted, or restricted
+  to another referrer/IP, the provider search fails with HTTP 403 and
+  requires a new build to change credentials.
+- Mitigation: Externalize key resolution to runtime configuration with
+  deterministic precedence (system property then environment variable),
+  and include sanitized request context in error messages.
+- Status: Mitigated in HBTV-012 by removing the hardcoded key constant
+  from `YoutubeConf`, resolving keys from runtime config, and masking
+  the `key` parameter in error messages.

--- a/fwk/api/src/com/dabi/habitv/api/plugin/exception/TechnicalException.java
+++ b/fwk/api/src/com/dabi/habitv/api/plugin/exception/TechnicalException.java
@@ -7,6 +7,10 @@ public class TechnicalException extends RuntimeException {
 		super(e);
 	}
 
+	public TechnicalException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
 	public TechnicalException(final String string) {
 		super(string);
 	}

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
@@ -1,6 +1,8 @@
 package com.dabi.habitv.plugin.youtube;
 
 public final class YoutubeConf {
+	private static final String API_KEY_PROPERTY = "habitv.youtube.apiKey";
+	private static final String API_KEY_ENV = "HABITV_YOUTUBE_API_KEY";
 
 	private YoutubeConf() {
 
@@ -15,7 +17,22 @@ public final class YoutubeConf {
 	public static final long MAX_HUNG_TIME = 300000L;
 	public static final String DEFAULT_WINDOWS_EXE = "youtube-dl.exe";
 	public static final String DEFAULT_LINUX_BIN_PATH = "youtube-dl";
-	public static final String API_KEY = "AIzaSyCg3WitBUQl5ifC2QygQaZUPOSRMKfSD5E";
 	public static final String BASE_URL = "https://www.youtube.com";
+
+	public static String resolveApiKey() {
+		String value = normalizeApiKey(System.getProperty(API_KEY_PROPERTY));
+		if (value != null) {
+			return value;
+		}
+		return normalizeApiKey(System.getenv(API_KEY_ENV));
+	}
+
+	static String normalizeApiKey(String candidate) {
+		if (candidate == null) {
+			return null;
+		}
+		String trimmed = candidate.trim();
+		return trimmed.isEmpty() ? null : trimmed;
+	}
 
 }

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginManager.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginManager.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
 public class YoutubePluginManager extends BasePluginWithProxy implements PluginProviderInterface {
+	private static final String KEY = "key";
 	private static final String PLAYLIST_ID = "playlistId";
 	private static final String PUBLISHED_AFTER = "publishedAfter";
 
@@ -54,7 +55,7 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 
 	private Set<EpisodeDTO> findEpisodeTop(CategoryDTO category, Map<String, String> params) {
 		String url = "https://www.googleapis.com/youtube/v3/search?part=snippet&order=viewCount&type=video";
-		url = addParam(url, params, "key", YoutubeConf.API_KEY);
+		url = addParam(url, params, KEY, YoutubeConf.resolveApiKey());
 		String days = params.get(DAYS);
 		if (days != null) {
 			String publishedAfter = dateFormat.format(DateUtils.addDays(new Date(), -Integer.valueOf(days)));
@@ -86,8 +87,8 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 	}
 
 	private Set<EpisodeDTO> findEpisodePlaylist(CategoryDTO category, Map<String, String> params) {
-		String url = "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&order=viewCount&type=video";
-		url = addParam(url, params, "key", YoutubeConf.API_KEY);
+		String url = "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet";
+		url = addParam(url, params, KEY, YoutubeConf.resolveApiKey());
 		url = addParam(url, params, PLAYLIST_ID);
 		url = addParam(url, params, MAX_RESULTS, "50");
 		return findEpisodesFromUrl(category, url);
@@ -113,9 +114,13 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 				episodeList.add(new EpisodeDTO(category, name, href));
 			}
 		} catch (IOException e) {
-			throw new TechnicalException(e);
+			throw new TechnicalException("youtube api request failed: " + sanitizeUrl(url), e);
 		}
 		return episodeList;
+	}
+
+	private String sanitizeUrl(String url) {
+		return url.replaceAll("([?&]key=)[^&]+", "$1***");
 	}
 
 	@Override

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
@@ -1,0 +1,24 @@
+package com.dabi.habitv.plugin.youtube;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class YoutubeConfTest {
+
+	@Test
+	public void normalizeApiKeyReturnsNullForNullInput() {
+		assertNull(YoutubeConf.normalizeApiKey(null));
+	}
+
+	@Test
+	public void normalizeApiKeyReturnsNullForBlankInput() {
+		assertNull(YoutubeConf.normalizeApiKey("   "));
+	}
+
+	@Test
+	public void normalizeApiKeyTrimsWhitespace() {
+		assertEquals("api-key-value", YoutubeConf.normalizeApiKey("  api-key-value  "));
+	}
+}


### PR DESCRIPTION
Summary:
- externalize the YouTube Data API key lookup to runtime config (habitv.youtube.apiKey, then HABITV_YOUTUBE_API_KEY) instead of a hardcoded source value
- add a tray configuration field so end users can enter and persist the YouTube API key in local user config
- remove unsupported playlistItems query params and keep playlist requests to supported fields
- include sanitized API request context in thrown errors, and track the change under HBTV-012 / R-013

Test plan:
- [x] mvn -B -ntp -DskipTests -pl plugins/youtube -am validate
- [x] mvn -B -ntp -DskipTests -pl application/trayView,plugins/youtube -am compile
- [x] mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test

Tracker:
- HBTV-012