### PR TITLE
build: align packaging modules with Java 8 baseline

### DIFF
--- a/application/habiTv-linux/pom.xml
+++ b/application/habiTv-linux/pom.xml
@@ -29,8 +29,8 @@
 		<jdk.home>/usr/lib/jvm/jdk1.7.0_45</jdk.home>
 		<javafx.runtime.lib.jar>${jdk.home}/jre/lib/ext/jfxrt.jar</javafx.runtime.lib.jar>
 		<javafx.tools.ant.jar>${jdk.home}/lib/ant-javafx.jar</javafx.tools.ant.jar>
-		<maven.compiler.source>7</maven.compiler.source>
-		<maven.compiler.target>7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>

--- a/application/habiTv-windows/pom.xml
+++ b/application/habiTv-windows/pom.xml
@@ -21,8 +21,8 @@
 		<jdk.home>D:/app/apps/dev/java/jdk1.7.0_55</jdk.home>
 		<javafx.runtime.lib.jar>${jdk.home}/jre/lib/ext/jfxrt.jar</javafx.runtime.lib.jar>
 		<javafx.tools.ant.jar>${jdk.home}/lib/ant-javafx.jar</javafx.tools.ant.jar>
-		<maven.compiler.source>7</maven.compiler.source>
-		<maven.compiler.target>7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
   <repositories>


### PR DESCRIPTION
## Summary
- Replaces obsolete Java 1.7 compiler settings in packaging modules with Java 1.8.
- Keeps the project aligned with the root Java 8 baseline.
- Limits the change to build-impacting Maven compiler configuration only.

## Files changed
- application/habiTv-linux/pom.xml
- application/habiTv-windows/pom.xml

## Validation
- `mvn -B -ntp -DskipTests validate`

## Notes
- This PR does not migrate the project beyond Java 8.
- This PR does not address unrelated legacy Maven HTTP repository blockers.
- Documentation-only Java 1.7 references were intentionally left unchanged unless they affected compilation.