### PR TITLE
docs: record modernization status and next steps

### DIFF
--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -4,6 +4,38 @@
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync.",
   "statusValues": ["proposed", "in-progress", "blocked", "done", "deferred"],
   "priorityValues": ["P0", "P1", "P2", "P3"],
+  "modernizationStatus": [
+    {
+      "date": "2026-05-17",
+      "title": "Modernization status - 2026-05-17",
+      "javaBaseline": "Java 8 (1.8) remains the supported baseline for now.",
+      "currentPriority": [
+        "Merge PR #30.",
+        "Review/merge PR #29.",
+        "Close or supersede PR #26 if #29 fully replaces it.",
+        "Retarget/rebase PR #25 onto develop.",
+        "Start HBTV-004 execution: quarantine legacy runtime calls.",
+        "Start HBTV-005 publication layout for GitHub Pages/habitv-repo."
+      ],
+      "prReadiness": [
+        "PR #30 targets develop and only changes packaging-module compiler source/target from 7 to 1.8.",
+        "PR #29 targets develop and carries YouTube API-key externalization work for follow-up review.",
+        "PR #26 still targets master and appears superseded by PR #29 for YouTube API-key handling; do not merge as-is.",
+        "PR #25 targets master and must be retargeted/rebased to develop before merge consideration."
+      ],
+      "validationOnDevelop": [
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS",
+        "mvn -B -ntp -DskipTests compile -> BUILD FAILURE",
+        "First real blocker: plugins/beinsport cannot resolve com.dabi.habitv:framework/api:4.1.1-SNAPSHOT because maven-default-http-blocker rejects http://dabiboo.free.fr/repository."
+      ],
+      "knownBlockers": [
+        "Legacy HTTP Maven/runtime repository references.",
+        "Plugin runtime health degraded.",
+        "JavaFX/trayView remains a fragile Java 8 area.",
+        "Provider plugins need quarantine before rewrite."
+      ]
+    }
+  ],
   "items": [
     {
       "id": "HBTV-000",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -9,6 +9,38 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 
 ---
 
+## Modernization status - 2026-05-17
+
+- Java baseline: Java 8 (`1.8`) remains the supported baseline for now.
+- Current priority order:
+  1. Merge PR #30.
+  2. Review/merge PR #29.
+  3. Close or supersede PR #26 if #29 fully replaces it.
+  4. Retarget/rebase PR #25 onto `develop`.
+  5. Start HBTV-004 execution: quarantine legacy runtime calls.
+  6. Start HBTV-005 publication layout for GitHub Pages/habitv-repo.
+- PR readiness snapshot:
+  - PR #30 targets `develop` and only updates packaging-module Java compiler
+    level from `7` to `1.8`.
+  - PR #29 targets `develop` and carries the YouTube API-key externalization
+    work; it should be reviewed next against #26.
+  - PR #26 still targets `master` and appears superseded by #29 for YouTube
+    API-key handling; do not merge #26 as-is.
+  - PR #25 targets `master` and must be retargeted/rebased to `develop` before
+    merge consideration.
+- Validation on current `develop`:
+  - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS`.
+  - `mvn -B -ntp -DskipTests compile` -> `BUILD FAILURE`.
+  - First real blocker: `plugins/beinsport` cannot resolve
+    `com.dabi.habitv:framework/api:4.1.1-SNAPSHOT` because Maven blocks the
+    legacy HTTP repository `http://dabiboo.free.fr/repository`
+    (`maven-default-http-blocker`).
+- Known blockers:
+  - Legacy HTTP Maven/runtime repository references.
+  - Plugin runtime health degraded.
+  - JavaFX/trayView remains a fragile Java 8 area.
+  - Provider plugins need quarantine before rewrite.
+
 ## HBTV-000 — Restart from master governance bootstrap
 
 - Status: in-progress


### PR DESCRIPTION
## Summary
- Records the current modernization status after Java 8 baseline and YouTube/API-key PRs.
- Documents the safe merge order for open PRs.
- Keeps the next execution steps focused on legacy repository quarantine and publication migration.

## Current priority
1. Merge PR #30.
2. Review and merge PR #29 if it supersedes PR #26.
3. Close or retarget PR #26.
4. Retarget/rebase PR #25 onto `develop`.
5. Start HBTV-004 runtime quarantine.
6. Start HBTV-005 GitHub Pages publication layout.

## Validation
- Commands run:
  - `mvn -B -ntp -DskipTests validate`
  - `mvn -B -ntp -DskipTests compile`
- Exact result:
  - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS`
  - `mvn -B -ntp -DskipTests compile` -> `BUILD FAILURE`
- First real blocker:
  - `plugins/beinsport` fails dependency resolution for `com.dabi.habitv:framework:4.1.1-SNAPSHOT` and `com.dabi.habitv:api:4.1.1-SNAPSHOT` because Maven blocks `http://dabiboo.free.fr/repository` via `maven-default-http-blocker`.

## Out of scope
- No Java version upgrade beyond 1.8.
- No provider/plugin rewrite.
- No Maven repository migration code.
- No JavaFX modernization.
- No unrelated formatting.

## Checklist
- [ ] Linear history preserved.
- [ ] English used for branch, commit, comments, and PR text.
- [ ] Documentation only.
- [ ] No generated files committed.
- [ ] No secrets or local paths committed.