### PR TITLE
build: align JDT compliance with Java 8

### DIFF
--- a/application/habiTv-linux/pom.xml
+++ b/application/habiTv-linux/pom.xml
@@ -29,8 +29,8 @@
 		<jdk.home>/usr/lib/jvm/jdk1.7.0_45</jdk.home>
 		<javafx.runtime.lib.jar>${jdk.home}/jre/lib/ext/jfxrt.jar</javafx.runtime.lib.jar>
 		<javafx.tools.ant.jar>${jdk.home}/lib/ant-javafx.jar</javafx.tools.ant.jar>
-		<maven.compiler.source>7</maven.compiler.source>
-		<maven.compiler.target>7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>

--- a/application/habiTv-windows/pom.xml
+++ b/application/habiTv-windows/pom.xml
@@ -21,8 +21,8 @@
 		<jdk.home>D:/app/apps/dev/java/jdk1.7.0_55</jdk.home>
 		<javafx.runtime.lib.jar>${jdk.home}/jre/lib/ext/jfxrt.jar</javafx.runtime.lib.jar>
 		<javafx.tools.ant.jar>${jdk.home}/lib/ant-javafx.jar</javafx.tools.ant.jar>
-		<maven.compiler.source>7</maven.compiler.source>
-		<maven.compiler.target>7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
   <repositories>


### PR DESCRIPTION
## Summary
Fixes remaining committed Java 1.7 compliance settings that caused Cursor/JDT to import modules as JavaSE-1.7.
Keeps the project on Java 8.
Does not migrate to newer Java versions.

## Validation
- `git grep -n -E "JavaSE-1\\.7|1\\.7|<source>7</source>|<target>7</target>|<source>1\\.7</source>|<target>1\\.7</target>|maven\\.compiler\\.source|maven\\.compiler\\.target|org\\.eclipse\\.jdt\\.core\\.compiler" -- .`
  - Found build-impacting Java 1.7 settings only in:
    - `application/habiTv-linux/pom.xml` (`maven.compiler.source/target=7`)
    - `application/habiTv-windows/pom.xml` (`maven.compiler.source/target=7`)
  - No committed Eclipse/JDT metadata entries with `JavaSE-1.7` were found.
- `mvn -B -ntp help:effective-pom -Doutput=target/effective-pom.xml`
  - SUCCESS
- `git grep -n -E "<source>1\\.7</source>|<target>1\\.7</target>|<source>7</source>|<target>7</target>|JavaSE-1\\.7" target/effective-pom.xml || true`
  - No matches
- `mvn -B -ntp -DskipTests validate`
  - SUCCESS
- `mvn -B -ntp -DskipTests compile`
  - FAILURE in `beinsport` due to blocked HTTP repository metadata resolution (`maven-default-http-blocker`), unrelated to Java compliance settings.

## Notes
If Cursor still shows Java 1.7 diagnostics after this PR, the remaining issue is local IDE cache/import state.

## Out of scope
- Java 11/17/21 migration
- Plugin/provider fixes
- Maven repository migration
- YouTube API changes
- Formatting-only cleanup

Made with [Cursor](https://cursor.com)