### PR TITLE
build: align own-version plugin internal dependencies

### DIFF
--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -214,6 +214,25 @@
       ],
       "pr": "feat(console): restore runnable baseline with yt-dlp provider",
       "notes": "PR #27 is superseded with scoped reuse (build/POM, console fat-jar/runtime docs, YouTube offline test) while excluding its failing application/core source edits. JavaFX modernization, provider cleanup, and scraper rewrites remain out of scope. PR #25 and #26 must be retargeted/rebased from master to develop later. HBTV-004/HBTV-005 repository/update URL migration remains separate."
+    },
+    {
+      "id": "HBTV-012",
+      "title": "Own-version plugin internal dependency alignment",
+      "status": "done",
+      "priority": "P0",
+      "scope": "Fix own-version plugin module dependency resolution so shared internal reactor dependencies (com.dabi.habitv:api, com.dabi.habitv:framework) resolve to the parent/reactor version instead of plugin-local artifact versions.",
+      "acceptanceCriteria": [
+        "Root dependencyManagement does not force own-version plugins to request non-reactor internal coordinates such as framework/api:4.1.1-SNAPSHOT.",
+        "mvn -B -ntp -DskipTests validate succeeds from root.",
+        "mvn -B -ntp -DskipTests compile succeeds from root.",
+        "maven-default-http-blocker no longer appears for framework/api:4.1.1-SNAPSHOT descriptor resolution."
+      ],
+      "validation": [
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS (33 modules)",
+        "mvn -B -ntp -DskipTests compile -> BUILD SUCCESS (33 modules)"
+      ],
+      "pr": "build: align own-version plugin internal dependencies",
+      "notes": "Cause: own-version plugin modules (beinsport, footyroom, pluzz, ffmpeg) inherited ${project.version} for shared internal dependencies, which interpolated to plugin-local versions (4.1.1-SNAPSHOT/4.1.2-SNAPSHOT) instead of reactor 4.1.0-SNAPSHOT. Fix: use ${project.parent.version} for shared internal dependencyManagement coordinates. Local compilation no longer requires http://dabiboo.free.fr/repository for these internal artifacts. Scope is Maven dependency alignment only; obsolete provider endpoints and runtime plugin availability remain out of scope."
     }
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -306,3 +306,37 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
     after this baseline is merged.
   - HBTV-004/HBTV-005 legacy repository/update URL migration remains
     separate and must not be mixed into this runnable baseline PR.
+
+## HBTV-012 — Own-version plugin internal dependency alignment
+
+- Status: done
+- Priority: P0
+- Scope: Fix own-version plugin module dependency resolution so shared
+  internal reactor dependencies (`com.dabi.habitv:api`,
+  `com.dabi.habitv:framework`) resolve to the parent/reactor version
+  instead of each plugin module's own artifact version.
+- Acceptance criteria:
+  - Root dependencyManagement does not force own-version plugins to
+    request non-reactor internal coordinates such as
+    `framework/api:4.1.1-SNAPSHOT`.
+  - `mvn -B -ntp -DskipTests validate` succeeds from the root.
+  - `mvn -B -ntp -DskipTests compile` succeeds from the root.
+  - `maven-default-http-blocker` no longer appears for
+    `framework/api:4.1.1-SNAPSHOT` descriptor resolution.
+- Validation:
+  - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS` (33 modules).
+  - `mvn -B -ntp -DskipTests compile` -> `BUILD SUCCESS` (33 modules).
+- PR: build: align own-version plugin internal dependencies.
+- Notes:
+  - Cause: own-version plugin modules (`beinsport`, `footyroom`,
+    `pluzz`, `ffmpeg`) inherited `${project.version}` for shared
+    internal dependencies, which interpolated to plugin-local versions
+    (`4.1.1-SNAPSHOT` / `4.1.2-SNAPSHOT`) instead of reactor version
+    `4.1.0-SNAPSHOT`.
+  - Fix: use `${project.parent.version}` for shared internal
+    dependencyManagement coordinates so reactor modules resolve
+    consistently.
+  - Local compilation no longer requires
+    `http://dabiboo.free.fr/repository` for these internal artifacts.
+  - Scope is Maven dependency alignment only; obsolete provider
+    endpoints and runtime plugin availability remain out of scope.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -32,10 +32,15 @@ or accepted.
 - Mitigation: Plan migration to a controlled static repository
   (HBTV-004 / HBTV-005). Until then, document the dependency and
   do not rely on it in CI.
-- Status update (HBTV-011): Confirmed unchanged. Scoped `compile` and
-  `package` still fail at `plugins/beinsport` while resolving
-  `framework/api:4.1.1-SNAPSHOT` through blocked
-  `http://dabiboo.free.fr/repository`.
+- Status update (HBTV-012): Mitigated for local reactor compilation of
+  internal shared dependencies. Root dependencyManagement now maps
+  `com.dabi.habitv:api` and `com.dabi.habitv:framework` to
+  `${project.parent.version}`, so own-version plugin modules no longer
+  request plugin-local coordinates (`4.1.1-SNAPSHOT` / `4.1.2-SNAPSHOT`)
+  from blocked `http://dabiboo.free.fr/repository`.
+- Residual risk: Legacy repository migration is still required for
+  external publication/runtime update concerns and remains tracked under
+  HBTV-004/HBTV-005; this fix is Maven dependency alignment only.
 
 ## R-002 — FTP deployment no longer viable
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>api</artifactId>
-			<version>${project.version}</version>
+			<version>${project.parent.version}</version>
 		</dependency>	
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>framework</artifactId>
-			<version>${project.version}</version>
+			<version>${project.parent.version}</version>
 		</dependency>			
 
 		<dependency>


### PR DESCRIPTION
Summary:
- Fixed own-version plugin modules so shared internal Habitv dependencies resolve from the Maven reactor instead of the legacy HTTP repository.
- Prevented modules such as beinsport from requesting non-existing framework/api versions like 4.1.1-SNAPSHOT.
- Documented the Maven alignment rule and current validation status.

Validation:
- mvn -B -ntp -DskipTests validate
- mvn -B -ntp -DskipTests compile

Notes:
- This PR is limited to Maven dependency alignment.
- It does not modernize Java, replace provider endpoints, or remove obsolete plugins.
- The legacy dabiboo HTTP repository remains a migration target but must not be required for local compilation.