### PR TITLE
build: standardize static repository workspace layout

### DIFF
--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -114,10 +114,11 @@
         "Plan for signing / integrity (HTTPS, checksums) documented."
       ],
       "validation": [
-        "Plan reviewed in PR"
+        "mvn -B -ntp -DskipTests validate",
+        "mvn -B -ntp -DskipTests deploy with temporary file:// target"
       ],
-      "pr": "TBD",
-      "notes": "Pairs with HBTV-004 and Phase 4 of docs/dev-plan.md."
+      "pr": "build/standard-cross-os-static-repo-layout (pending)",
+      "notes": "Pairs with HBTV-004 and Phase 4 of docs/dev-plan.md; adds cross-OS deploy scripts and standard side-by-side workspace layout under $HOME/dev."
     },
     {
       "id": "HBTV-006",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -163,9 +163,13 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
   - Directory layout documented.
   - Migration path for `UPDATE_URL` documented.
   - Plan for signing / integrity (HTTPS, checksums) documented.
-- Validation: Plan reviewed in PR.
-- PR: TBD.
-- Notes: Pairs with HBTV-004 and Phase 4 of `docs/dev-plan.md`.
+- Validation:
+  - `mvn -B -ntp -DskipTests validate`
+  - `mvn -B -ntp -DskipTests deploy` with temporary `file://` target
+- PR: build/standard-cross-os-static-repo-layout (pending).
+- Notes: Pairs with HBTV-004 and Phase 4 of `docs/dev-plan.md`; adds
+  cross-OS deploy scripts and standard side-by-side workspace layout
+  under `$HOME/dev`.
 
 ## HBTV-006 — Provider / plugin inventory
 

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -1,0 +1,84 @@
+## Recommended cross-OS workspace
+
+```text
+$HOME/dev/
+  habitv/
+  habitv-repo/
+```
+
+## Windows setup
+
+```powershell
+mkdir "$HOME\dev"
+cd "$HOME\dev"
+git clone https://github.com/Mika3578/habitv.git
+git clone https://github.com/Mika3578/habitv-repo.git
+cd habitv
+.\scripts\static-repo\deploy-static-repo.ps1
+```
+
+## Linux/macOS setup
+
+```sh
+mkdir -p "$HOME/dev"
+cd "$HOME/dev"
+git clone https://github.com/Mika3578/habitv.git
+git clone https://github.com/Mika3578/habitv-repo.git
+cd habitv
+./scripts/static-repo/deploy-static-repo.sh
+```
+
+## Override path
+
+Windows:
+
+```powershell
+.\scripts\static-repo\deploy-static-repo.ps1 -StaticRepoPath "D:\repositories\habitv-repo"
+```
+
+Linux/macOS:
+
+```sh
+./scripts/static-repo/deploy-static-repo.sh "/opt/repositories/habitv-repo"
+```
+
+## Environment variable override
+
+Windows PowerShell:
+
+```powershell
+$env:HABITV_STATIC_REPO_LOCAL_PATH="D:\repositories\habitv-repo"
+```
+
+Linux/macOS:
+
+```sh
+export HABITV_STATIC_REPO_LOCAL_PATH="/opt/repositories/habitv-repo"
+```
+
+## Public URLs
+
+- Maven: https://mika3578.github.io/habitv-repo/maven/
+- Tools: https://mika3578.github.io/habitv-repo/tools/
+- Manifests: https://mika3578.github.io/habitv-repo/manifests/
+
+## Static repository content layout
+
+```text
+habitv-repo/
+  maven/
+    com/
+      dabi/
+        habitv/
+          ...
+  tools/
+    yt-dlp/
+    ffmpeg/
+    aria2/
+    curl/
+    rtmpdump/
+  manifests/
+    plugins.json
+    tools.json
+  README.md
+```

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,6 @@
         <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk</developerConnection>
     </scm>	
 	
-	<distributionManagement>
-		<repository>
-			<id>ftp-repository</id>
-			<url>ftp://ftpperso.free.fr/repository</url>
-		</repository>	
-  </distributionManagement>	
-	
 	<repositories>
 		<repository>
 			<id>dabi-repo</id>
@@ -161,14 +154,6 @@
 				<filtering>true</filtering>
 			</resource>			
 		</resources>	
-		<extensions>
-		<!-- Enabling the use of FTP -->
-			<extension>
-				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-ftp</artifactId>
-				<version>1.0-beta-6</version>
-			</extension>
-		</extensions>		
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
 			<plugin>

--- a/scripts/static-repo/deploy-static-repo.ps1
+++ b/scripts/static-repo/deploy-static-repo.ps1
@@ -1,0 +1,160 @@
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$StaticRepoPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    $scriptDirectory = Split-Path -Parent $PSCommandPath
+    return (Resolve-Path (Join-Path $scriptDirectory "..\..")).Path
+}
+
+function Resolve-StaticRepoPath {
+    param(
+        [string]$ExplicitPath,
+        [string]$RepoRootPath
+    )
+
+    $candidates = @()
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitPath)) {
+        $candidates += @{
+            Label = "argument -StaticRepoPath"
+            Path = $ExplicitPath
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:HABITV_STATIC_REPO_LOCAL_PATH)) {
+        $candidates += @{
+            Label = "environment HABITV_STATIC_REPO_LOCAL_PATH"
+            Path = $env:HABITV_STATIC_REPO_LOCAL_PATH
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($HOME)) {
+        $candidates += @{
+            Label = "standard home workspace"
+            Path = (Join-Path $HOME "dev/habitv-repo")
+        }
+    }
+
+    $siblingDefault = Join-Path (Split-Path -Parent $RepoRootPath) "habitv-repo"
+    $candidates += @{
+        Label = "sibling fallback ../habitv-repo"
+        Path = $siblingDefault
+    }
+
+    foreach ($candidate in $candidates) {
+        try {
+            $resolved = (Resolve-Path -Path $candidate.Path -ErrorAction Stop).Path
+            if (Test-Path -Path $resolved -PathType Container) {
+                Write-Host ("Using static repository path from {0}: {1}" -f $candidate.Label, $resolved)
+                return $resolved
+            }
+        }
+        catch {
+            continue
+        }
+    }
+
+    $setupMessage = @(
+        "Unable to resolve habitv-repo checkout.",
+        "Resolution order:",
+        "  1. -StaticRepoPath",
+        "  2. HABITV_STATIC_REPO_LOCAL_PATH",
+        "  3. $HOME/dev/habitv-repo",
+        "  4. ../habitv-repo",
+        "Expected standard layout:",
+        "  $HOME/dev/habitv",
+        "  $HOME/dev/habitv-repo"
+    ) -join [Environment]::NewLine
+
+    throw $setupMessage
+}
+
+function Assert-GitCheckout {
+    param(
+        [string]$RepoPath
+    )
+
+    & git -C $RepoPath rev-parse --is-inside-work-tree *> $null
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Path is not a Git checkout: {0}" -f $RepoPath)
+    }
+}
+
+function Assert-HabitvRepoRemote {
+    param(
+        [string]$RepoPath
+    )
+
+    $remoteUrl = (& git -C $RepoPath remote get-url origin).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Unable to read origin remote for {0}" -f $RepoPath)
+    }
+
+    if ($remoteUrl -notmatch 'Mika3578/habitv-repo(?:\.git)?$') {
+        throw ("Static repository origin must target Mika3578/habitv-repo. Found: {0}" -f $remoteUrl)
+    }
+}
+
+function Convert-ToFileUrlPath {
+    param(
+        [string]$PathValue
+    )
+
+    return ($PathValue -replace "\\", "/")
+}
+
+$repoRoot = Get-RepoRoot
+$resolvedStaticRepoPath = Resolve-StaticRepoPath -ExplicitPath $StaticRepoPath -RepoRootPath $repoRoot
+
+if (-not (Test-Path -Path $resolvedStaticRepoPath -PathType Container)) {
+    throw ("Static repository path does not exist: {0}" -f $resolvedStaticRepoPath)
+}
+
+Assert-GitCheckout -RepoPath $resolvedStaticRepoPath
+Assert-HabitvRepoRemote -RepoPath $resolvedStaticRepoPath
+
+$resolvedStaticRepoMavenPath = Join-Path $resolvedStaticRepoPath "maven"
+if (-not (Test-Path -Path $resolvedStaticRepoMavenPath -PathType Container)) {
+    New-Item -Path $resolvedStaticRepoMavenPath -ItemType Directory | Out-Null
+}
+
+$fileUrlPath = Convert-ToFileUrlPath -PathValue $resolvedStaticRepoMavenPath
+$deployRepository = "habitv-static-repo::default::file:///$fileUrlPath"
+
+Write-Host ("Deploying Maven artifacts to: {0}" -f $deployRepository)
+Push-Location $repoRoot
+try {
+    & mvn -B -ntp -DskipTests deploy "-DaltDeploymentRepository=$deployRepository"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Maven deploy failed."
+    }
+}
+finally {
+    Pop-Location
+}
+
+& git -C $resolvedStaticRepoPath add .
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to stage static repository changes."
+}
+
+& git -C $resolvedStaticRepoPath diff --cached --quiet
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "No artifact changes to publish."
+    exit 0
+}
+
+& git -C $resolvedStaticRepoPath commit -m "repo: publish Habitv Maven artifacts"
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to commit static repository changes."
+}
+
+& git -C $resolvedStaticRepoPath push
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to push static repository changes."
+}

--- a/scripts/static-repo/deploy-static-repo.sh
+++ b/scripts/static-repo/deploy-static-repo.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env sh
+set -eu
+
+get_repo_root() {
+  script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+  CDPATH= cd -- "$script_dir/../.." && pwd
+}
+
+print_resolution_help_and_fail() {
+  cat <<'EOF' >&2
+Unable to resolve habitv-repo checkout.
+Resolution order:
+  1. first script argument
+  2. HABITV_STATIC_REPO_LOCAL_PATH
+  3. $HOME/dev/habitv-repo
+  4. ../habitv-repo
+Expected standard layout:
+  $HOME/dev/habitv
+  $HOME/dev/habitv-repo
+EOF
+  exit 1
+}
+
+resolve_static_repo_path() {
+  explicit_path=${1-}
+  repo_root=${2}
+  sibling_default=$(dirname "$repo_root")/habitv-repo
+
+  if [ -n "$explicit_path" ] && [ -d "$explicit_path" ]; then
+    CDPATH= cd -- "$explicit_path" && pwd
+    return
+  fi
+
+  if [ -n "${HABITV_STATIC_REPO_LOCAL_PATH-}" ] && [ -d "${HABITV_STATIC_REPO_LOCAL_PATH}" ]; then
+    CDPATH= cd -- "$HABITV_STATIC_REPO_LOCAL_PATH" && pwd
+    return
+  fi
+
+  if [ -n "${HOME-}" ] && [ -d "$HOME/dev/habitv-repo" ]; then
+    CDPATH= cd -- "$HOME/dev/habitv-repo" && pwd
+    return
+  fi
+
+  if [ -d "$sibling_default" ]; then
+    CDPATH= cd -- "$sibling_default" && pwd
+    return
+  fi
+
+  print_resolution_help_and_fail
+}
+
+assert_git_checkout() {
+  repo_path=$1
+  if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Path is not a Git checkout: $repo_path" >&2
+    exit 1
+  fi
+}
+
+assert_habitv_repo_remote() {
+  repo_path=$1
+  remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null || true)
+  if [ -z "$remote_url" ]; then
+    echo "Unable to read origin remote for $repo_path" >&2
+    exit 1
+  fi
+
+  case "$remote_url" in
+    *Mika3578/habitv-repo|*Mika3578/habitv-repo.git) ;;
+    *)
+      echo "Static repository origin must target Mika3578/habitv-repo. Found: $remote_url" >&2
+      exit 1
+      ;;
+  esac
+}
+
+repo_root=$(get_repo_root)
+resolved_static_repo_path=$(resolve_static_repo_path "${1-}" "$repo_root")
+
+if [ ! -d "$resolved_static_repo_path" ]; then
+  echo "Static repository path does not exist: $resolved_static_repo_path" >&2
+  exit 1
+fi
+
+assert_git_checkout "$resolved_static_repo_path"
+assert_habitv_repo_remote "$resolved_static_repo_path"
+
+resolved_static_repo_maven_path="$resolved_static_repo_path/maven"
+mkdir -p "$resolved_static_repo_maven_path"
+
+echo "Deploying Maven artifacts to: habitv-static-repo::default::file:///$resolved_static_repo_maven_path"
+mvn -B -ntp -DskipTests deploy \
+  "-DaltDeploymentRepository=habitv-static-repo::default::file:///$resolved_static_repo_maven_path"
+
+git -C "$resolved_static_repo_path" add .
+if git -C "$resolved_static_repo_path" diff --cached --quiet; then
+  echo "No artifact changes to publish."
+  exit 0
+fi
+
+git -C "$resolved_static_repo_path" commit -m "repo: publish Habitv Maven artifacts"
+git -C "$resolved_static_repo_path" push


### PR DESCRIPTION
## Summary
- Documents a standard cross-OS side-by-side workspace layout under `$HOME/dev`.
- Keeps the static repository deployment path configurable.
- Updates deploy scripts to resolve the local `habitv-repo` checkout from an argument, environment variable, standard home workspace, or sibling checkout.
- Avoids hardcoded OS-specific paths.

## Recommended layout

$HOME/dev/
  habitv/
  habitv-repo/

## Public URLs
- Maven: https://mika3578.github.io/habitv-repo/maven/
- Tools: https://mika3578.github.io/habitv-repo/tools/
- Manifests: https://mika3578.github.io/habitv-repo/manifests/

## Validation
- [ ] mvn -B -ntp -DskipTests validate
- [ ] mvn -B -ntp -DskipTests deploy with temporary file:// target
- [ ] PowerShell script resolves `$HOME/dev/habitv-repo`
- [ ] shell script resolves `$HOME/dev/habitv-repo`
- [ ] explicit path override works
- [ ] environment variable override works
- [ ] no OS-specific absolute path is hardcoded

## Out of scope
- GitHub Packages
- Java migration
- Provider/plugin modernization
- yt-dlp migration
- Runtime plugin rewrite