### PR TITLE
chore: remove legacy DabiBoo repository wiring

### DIFF
--- a/application/core/src/com/dabi/habitv/core/config/HabitTvConf.java
+++ b/application/core/src/com/dabi/habitv/core/config/HabitTvConf.java
@@ -13,7 +13,12 @@ public interface HabitTvConf {
 
 	String CONF_FILE = "configuration.xml";	
 
-	String STAT_URL = "http://dabiboo.free.fr/cpt.php";
+	String STAT_ENABLED_PROPERTY = "habitv.stat.enabled";
+
+	String STAT_URL_PROPERTY = "habitv.stat.url";
+
+	// Telemetry endpoint is disabled by default and requires explicit opt-in.
+	String STAT_URL_DISABLED = "";
 	
 	String LOG_FILE = "habiTv.log"; 
 

--- a/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
+++ b/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
@@ -46,11 +46,20 @@ public final class CoreManager {
 	}
 
 	private void stat() {
+		if (!Boolean.getBoolean(HabitTvConf.STAT_ENABLED_PROPERTY)) {
+			LOG.debug("Startup telemetry ping is disabled.");
+			return;
+		}
+		final String statUrl = System.getProperty(HabitTvConf.STAT_URL_PROPERTY, HabitTvConf.STAT_URL_DISABLED);
+		if (statUrl == null || statUrl.trim().isEmpty()) {
+			LOG.warn("Startup telemetry ping is enabled but no URL is configured.");
+			return;
+		}
 		new Thread() {
 
 			@Override
 			public void run() {
-				RetrieverUtils.getUrlContent(HabitTvConf.STAT_URL, null);
+				RetrieverUtils.getUrlContent(statUrl, null);
 			}
 
 		}.start();

--- a/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
+++ b/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
@@ -42,10 +42,20 @@ public class UpdateManager {
 	}
 
 	public void process() {
+		if (!Boolean.getBoolean(FrameworkConf.UPDATE_ENABLED_PROPERTY)) {
+			LOG.debug("Plugin update check is disabled.");
+			return;
+		}
+		final String updateSite = System.getProperty(
+				FrameworkConf.UPDATE_URL_PROPERTY, site);
+		if (updateSite == null || updateSite.trim().isEmpty()) {
+			LOG.warn("Plugin update check is enabled but no update URL is configured.");
+			return;
+		}
 		try {
 			LOG.info("Checking plugin updates...");
 			String[] toUpdate = RetrieverUtils.getUrlContent(
-					site + "/plugins.txt", null).split("\\r\\n");
+					updateSite + "/plugins.txt", null).split("\\r\\n");
 			updatePublisher.addNews(new UpdatePluginEvent(
 					UpdatePluginStateEnum.STARTING_ALL, toUpdate.length));
 			final Updater updater = new JarUpdater(pluginFolder, groupId,

--- a/application/habiTv-linux/pom.xml
+++ b/application/habiTv-linux/pom.xml
@@ -8,18 +8,20 @@
 	<artifactId>habiTv-linux</artifactId>
 	<packaging>jar</packaging>
 	<name>habiTv-linux</name>
-	<scm>
-		<connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/application/habiTv-linux</connection>
-		<developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/application/habiTv-linux</developerConnection>
-	</scm>
-	
-  <repositories>
-    <repository>
-      <id>dabi-repo</id>
-      <name>dabi-repo</name>
-      <url>http://dabiboo.free.fr/repository</url>
-    </repository>
-  </repositories>  	
+
+<repositories>
+		<repository>
+			<id>habitv-static-repo</id>
+			<name>Habitv public static artifact repository</name>
+			<url>https://mika3578.github.io/habitv-repo/repository</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>  	
 	
 	<properties>
 		<habitv.version>4.1.0</habitv.version>

--- a/application/habiTv-windows/pom.xml
+++ b/application/habiTv-windows/pom.xml
@@ -7,12 +7,9 @@
 	</parent>
 	<artifactId>habiTv-windows</artifactId>
 	<packaging>jar</packaging>
-	<name>habiTv-windows</name>	
-	 <scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/application/habiTv-windows</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/application/habiTv-windows</developerConnection>
-    </scm>
-	<properties>
+	<name>habiTv-windows</name>
+
+<properties>
 		<habitv.version>4.1.0</habitv.version>
 		<package.version>4.1.0</package.version>
 		<exec.mainClass>com.dabi.habitv.packaging.HabiTvFxRunner</exec.mainClass>
@@ -26,12 +23,18 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
   <repositories>
-    <repository>
-      <id>dabi-repo</id>
-      <name>dabi-repo</name>
-      <url>http://dabiboo.free.fr/repository</url>
-    </repository>
-  </repositories>  
+		<repository>
+			<id>habitv-static-repo</id>
+			<name>Habitv public static artifact repository</name>
+			<url>https://mika3578.github.io/habitv-repo/repository</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>  
 	<dependencies>
 		<dependency>
 			<groupId>javafx</groupId>

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -108,3 +108,24 @@ supersede older ones rather than rewriting them in place.
   remain explicit. PR #25 and PR #26 must be retargeted/rebased to
   `develop` (or recreated as scoped follow-ups) after this baseline
   lands.
+
+## ADR-0007 — Remove active legacy DabiBoo/SVN wiring from build and runtime paths
+
+- Status: Accepted
+- Date: 2026-05-17
+- Context: Active code and Maven metadata still referenced legacy
+  endpoints (`dabiboo.free.fr`, `scm:svn` on Assembla, and
+  `cpt.php` telemetry). These endpoints are either unavailable or no
+  longer acceptable for modern secure/reproducible builds.
+- Decision: Replace active Maven repository base URL with
+  `https://mika3578.github.io/habitv-repo/repository`, replace/remove
+  active SVN/Assembla SCM metadata in POMs in favor of GitHub SCM
+  metadata inheritance, disable startup telemetry by default behind
+  `habitv.stat.enabled` / `habitv.stat.url`, and disable runtime plugin
+  updates by default behind `habitv.update.enabled` with optional
+  `habitv.update.url` (defaulting to the GitHub Pages base when enabled).
+- Consequences: Build/runtime wiring no longer depends on legacy
+  DabiBoo/free.fr/SVN endpoints. `FindArtifactUtils` still expects
+  Apache-style HTML directory indexes; do not enable updates until HBTV-005
+  publishes verified static `index.html` or manifest files on GitHub Pages.
+  Functional Maven/publication cutover remains a separate HBTV-005 item.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -89,7 +89,7 @@
     {
       "id": "HBTV-004",
       "title": "Legacy repository URL migration (execution)",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P0",
       "scope": "Remove active DabiBoo/free.fr/SVN/Assembla Maven and runtime wiring; replace SCM with GitHub; disable stat/update network calls by default; point Maven repository at habitv-repo GitHub Pages base.",
       "acceptanceCriteria": [

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -88,19 +88,23 @@
     },
     {
       "id": "HBTV-004",
-      "title": "Legacy repository URL migration plan",
-      "status": "proposed",
-      "priority": "P1",
-      "scope": "Plan migration of <scm> (SVN/Assembla), Maven <repository> (http://dabiboo.free.fr/repository), <distributionManagement> (ftp://ftpperso.free.fr/repository), and runtime telemetry/update URLs.",
+      "title": "Legacy repository URL migration (execution)",
+      "status": "in-progress",
+      "priority": "P0",
+      "scope": "Remove active DabiBoo/free.fr/SVN/Assembla Maven and runtime wiring; replace SCM with GitHub; disable stat/update network calls by default; point Maven repository at habitv-repo GitHub Pages base.",
       "acceptanceCriteria": [
-        "Document target URLs and transition steps.",
-        "Identify code call sites in FrameworkConf.java, HabitTvConf.java, UpdateManager.java, FindArtifactUtils.java, CoreManager.java."
+        "Active POM/runtime references to dabiboo.free.fr, subversion.assembla.com, scm:svn, and cpt.php are removed.",
+        "Root repository uses https://mika3578.github.io/habitv-repo/repository.",
+        "Telemetry is opt-in via habitv.stat.enabled and habitv.stat.url.",
+        "Plugin updates are opt-in via habitv.update.enabled and optional habitv.update.url."
       ],
       "validation": [
-        "Plan reviewed in PR; no code changes in this item"
+        "git grep legacy URL pattern -> documentation/history only",
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS (33 modules)",
+        "mvn -B -ntp -DskipTests compile -> BUILD SUCCESS (33 modules)"
       ],
-      "pr": "TBD",
-      "notes": "Pairs with HBTV-005."
+      "pr": "chore: remove legacy DabiBoo repository wiring (#36)",
+      "notes": "Execution supersedes PR #25 plan-only work. Publication cutover and updater HTML index contract remain HBTV-005; do not enable habitv.update.enabled until static index.html or manifest layout is verified."
     },
     {
       "id": "HBTV-005",
@@ -238,7 +242,7 @@
     {
       "id": "HBTV-013",
       "title": "YouTube Data API key externalization",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P1",
       "scope": "Remove the hardcoded YouTube Data API key from plugins/youtube and resolve it from runtime configuration so revoked/restricted keys do not require a code change.",
       "acceptanceCriteria": [
@@ -253,8 +257,8 @@
         "mvn -B -ntp -DskipTests -pl application/trayView,plugins/youtube -am compile -> BUILD SUCCESS",
         "mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test -> BUILD SUCCESS"
       ],
-      "pr": "TBD",
-      "notes": "End users can set the key from the tray configuration tab; no environment variable is required for standard usage. Runtime key lookup order: Java property habitv.youtube.apiKey, then environment variable HABITV_YOUTUBE_API_KEY."
+      "pr": "fix: externalize data api key and mask api errors (#29)",
+      "notes": "End users can set the key from the tray configuration tab. Runtime key lookup order: Java property habitv.youtube.apiKey, then environment variable HABITV_YOUTUBE_API_KEY."
     }
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -132,25 +132,37 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 - PR: N/A (settings change, not code).
 - Notes: Done by repo owner; tracked here for visibility.
 
-## HBTV-004 — Legacy repository URL migration plan
+## HBTV-004 — Legacy repository URL migration (execution)
 
-- Status: proposed
-- Priority: P1
-- Scope: Plan migration of `<scm>` (SVN/Assembla), Maven
-  `<repository>` (`http://dabiboo.free.fr/repository`),
-  `<distributionManagement>` (`ftp://ftpperso.free.fr/repository`),
-  and runtime telemetry/update URLs.
+- Status: in-progress
+- Priority: P0
+- Scope: Remove active legacy DabiBoo/free.fr/SVN/Assembla wiring from
+  Maven POMs and runtime paths; replace SCM metadata with GitHub;
+  disable startup telemetry and plugin update checks by default;
+  point Maven `<repository>` at the public `habitv-repo` GitHub Pages
+  base when publication is available.
 - Acceptance criteria:
-  - Document target URLs and transition steps.
-  - Identify code call sites in
-    `fwk/framework/.../FrameworkConf.java`,
-    `application/core/.../HabitTvConf.java`,
-    `application/core/.../UpdateManager.java`,
-    `fwk/framework/.../FindArtifactUtils.java`,
-    `application/core/.../CoreManager.java`.
-- Validation: Plan reviewed in PR; no code changes in this item.
-- PR: TBD.
-- Notes: Pairs with HBTV-005.
+  - Active POM/runtime references to `dabiboo.free.fr`,
+    `subversion.assembla.com`, `scm:svn`, and `cpt.php` are removed.
+  - Root and packaging POM repository wiring uses
+    `https://mika3578.github.io/habitv-repo/repository`.
+  - Runtime telemetry ping is opt-in only (`habitv.stat.enabled=true`)
+    and requires explicit URL configuration (`habitv.stat.url`).
+  - Runtime plugin updates are opt-in only
+    (`habitv.update.enabled=true`) with optional `habitv.update.url`.
+- Validation:
+  - `git grep -n -I -E "dabiboo|free\.fr|ftpperso|subversion\.assembla|scm:svn|cpt\.php" -- .`
+    -> matches only documentation/history, no active code/POM endpoints.
+  - `mvn -B -ntp -DskipTests validate` -> `BUILD SUCCESS` (33 modules).
+  - `mvn -B -ntp -DskipTests compile` -> `BUILD SUCCESS` (33 modules).
+- PR: chore: remove legacy DabiBoo repository wiring (#36).
+- Notes:
+  - Execution supersedes the documentation-only plan in PR #25.
+  - Functional publication cutover remains blocked under HBTV-005 until
+    `habitv-repo` serves `/repository` with Apache-style directory
+    listings (`FindArtifactUtils` parses HTML `<a>` indexes).
+  - Do not enable `habitv.update.enabled` until static `index.html`
+    files or an equivalent manifest layout are verified.
 
 ## HBTV-005 — Runtime updater publication plan
 
@@ -347,7 +359,7 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 
 ## HBTV-013 — YouTube Data API key externalization
 
-- Status: in-progress
+- Status: done
 - Priority: P1
 - Scope: Remove the hardcoded YouTube Data API key from
   `plugins/youtube` and use runtime-provided configuration so 403
@@ -367,7 +379,7 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
     -> `BUILD SUCCESS`.
   - `mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test`
     -> `BUILD SUCCESS`.
-- PR: TBD.
+- PR: fix: externalize data api key and mask api errors (#29).
 - Notes:
   - End users can set the key from the tray configuration tab; no
     environment variable is required for standard usage.

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -134,7 +134,7 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
 
 ## HBTV-004 — Legacy repository URL migration (execution)
 
-- Status: in-progress
+- Status: done
 - Priority: P0
 - Scope: Remove active legacy DabiBoo/free.fr/SVN/Assembla wiring from
   Maven POMs and runtime paths; replace SCM metadata with GitHub;
@@ -157,6 +157,8 @@ Status legend: `proposed`, `in-progress`, `blocked`, `done`,
   - `mvn -B -ntp -DskipTests compile` -> `BUILD SUCCESS` (33 modules).
 - PR: chore: remove legacy DabiBoo repository wiring (#36).
 - Notes:
+  - Detailed call-site inventory and updater contract:
+    `docs/hbtv-004-url-migration-plan.md` (from PR #25, preserved here).
   - Execution supersedes the documentation-only plan in PR #25.
   - Functional publication cutover remains blocked under HBTV-005 until
     `habitv-repo` serves `/repository` with Apache-style directory

--- a/docs/hbtv-004-url-migration-plan.md
+++ b/docs/hbtv-004-url-migration-plan.md
@@ -1,0 +1,282 @@
+# HBTV-004 ÔÇö Legacy URL migration plan
+
+Plan-only document for migrating Habitv away from legacy
+SVN/Assembla, plain-HTTP `dabiboo.free.fr`, FTP `ftpperso.free.fr`,
+and embedded telemetry/update URLs. No code or POM is changed in
+this PR. Implementation will be split across follow-up PRs listed
+in section 5.
+
+This document pairs with `docs/hbtv-005-publication-layout.md`
+(future) and supersedes the rough notes in
+`docs/audit-master-baseline.md` lines 54-84 by enumerating exact
+call sites and a sequenced migration plan.
+
+## 1. Inventory of legacy references
+
+### 1.1 SCM blocks (SVN / Assembla) ÔÇö 23 POMs
+
+Root:
+
+- `pom.xml:21-24` ÔÇö `scm:svn:http://subversion.assembla.com/svn/habitv/trunk`
+
+Framework:
+
+- `fwk/api/pom.xml`
+- `fwk/framework/pom.xml`
+
+Packaging (out of reactor, HBTV-008):
+
+- `application/habiTv-linux/pom.xml`
+- `application/habiTv-windows/pom.xml`
+
+Plugins (18 of 22 + `plugin-tester`):
+
+- `plugins/RSS/pom.xml`
+- `plugins/adobeHDS/pom.xml`
+- `plugins/aria2/pom.xml`
+- `plugins/arte/pom.xml`
+- `plugins/beinsport/pom.xml`
+- `plugins/canalPlus/pom.xml`
+- `plugins/clubic/pom.xml`
+- `plugins/cmd/pom.xml`
+- `plugins/curl/pom.xml`
+- `plugins/email/pom.xml` (also points at `plugins/RSS` by
+  copy/paste ÔÇö fix in the same change set)
+- `plugins/ffmpeg/pom.xml`
+- `plugins/file/pom.xml`
+- `plugins/lequipe/pom.xml`
+- `plugins/pluzz/pom.xml`
+- `plugins/rtmpDump/pom.xml`
+- `plugins/sfr/pom.xml`
+- `plugins/wat/pom.xml`
+- `plugins/youtube/pom.xml`
+
+Plugins without `<scm>` block today (intentionally left as-is until
+the global swap):
+
+- `plugins/footyroom`, `plugins/globalnews`, `plugins/mlssoccer`,
+  `plugins/6play`.
+
+### 1.2 Maven `<repository>` (HTTP `dabiboo.free.fr`) ÔÇö 3 POMs
+
+- `pom.xml:33-39`
+- `application/habiTv-linux/pom.xml:20`
+- `application/habiTv-windows/pom.xml:32`
+
+All three declare the same id `dabi-repo` pointing at
+`http://dabiboo.free.fr/repository`. Plain HTTP, third-party
+hosting, blocked by Maven 3.9+ default mirror policy.
+
+### 1.3 `<distributionManagement>` FTP ÔÇö 1 POM
+
+- `pom.xml:26-31` ÔÇö `ftp://ftpperso.free.fr/repository`
+- `pom.xml:159-166` ÔÇö `<extension>` `wagon-ftp:1.0-beta-6`
+
+FTP is unencrypted, free.fr personal hosting is deprecated, and the
+extension is from 2009.
+
+### 1.4 Runtime URL constants ÔÇö 2 constants
+
+| Constant     | File:line                                                                 | Purpose       |
+|--------------|---------------------------------------------------------------------------|---------------|
+| `UPDATE_URL` | `fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java:21`       | Artifact resolution for the in-app updater |
+| `STAT_URL`   | `application/core/src/com/dabi/habitv/core/config/HabitTvConf.java:16`   | Telemetry ping on startup |
+
+### 1.5 Runtime call sites
+
+- `application/core/src/com/dabi/habitv/core/updater/UpdateManager.java:40`
+  ÔÇö constructor passes `FrameworkConf.UPDATE_URL` to the
+  `UpdateManager` instance.
+- `application/core/src/com/dabi/habitv/core/updater/UpdateManager.java:48`
+  ÔÇö `RetrieverUtils.getUrlContent(site + "/plugins.txt", null)`.
+- `fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtils.java:56`
+  ÔÇö builds `${UPDATE_URL}/${groupIdPath}/${artifactId}` and
+  recursively lists directory contents via Jsoup.
+- `application/core/src/com/dabi/habitv/core/mgr/CoreManager.java:46-55`
+  ÔÇö `stat()` fires a background thread on construction that calls
+  `RetrieverUtils.getUrlContent(HabitTvConf.STAT_URL, null)`.
+
+### 1.6 Tests that hit the legacy hosts
+
+- `application/core/test/com/dabi/habitv/core/updater/TestListHttp.java:30-37`
+  ÔÇö calls `FindArtifactUtils.findLastVersionUrl(...)`, which hits
+  the live `UPDATE_URL`.
+- `fwk/framework/test/com/dabi/habitv/framework/plugin/utils/TestUrl.java:10`
+  ÔÇö `RetrieverUtils.getTitleByUrl("http://www.beinsports.fr")`,
+  out of scope for HBTV-004 but tracked under R-005.
+
+### 1.7 Adjacent legacy traces (not in scope, recorded for context)
+
+- `application/consoleView/config.xml:57,84` ÔÇö sample `curl`
+  commands with hardcoded freebox FTP credentials
+  (`ftp://freebox:4688@hd1.freebox.fr/...`). Sample file, not
+  executed. Tracked as new risk R-013.
+- `plugins/email/test/com/dabi/habitv/plugin/email/MessageReceiverTest.java:14,19`
+  and
+  `plugins/email/test/com/dabi/habitv/plugin/email/EmailPluginManagerTest.java:29`
+  ÔÇö hardcoded Gmail credentials `testhabitv` / `HabiTV410`.
+  Tracked as new risk R-013.
+
+## 2. Updater contract (reverse-engineered from FindArtifactUtils)
+
+The current updater relies on an Apache-style `mod_autoindex` HTTP
+server. Any replacement host must serve compatible HTML or the
+updater stops discovering new artifacts.
+
+Required URL shapes:
+
+```
+${UPDATE_URL}/plugins.txt
+${UPDATE_URL}/${groupId-with-slashes}/${artifactId}/
+${UPDATE_URL}/${groupId-with-slashes}/${artifactId}/${version}/
+```
+
+Required HTML shape (per directory):
+
+- `<a href="X.Y.Z/">X.Y.Z</a>` for version directories.
+- `<a href="artifactId-X.Y.Z.jar">...</a>` for files.
+- Entries with text `Parent Directory`, `Name`, `Last modified`,
+  `Size`, `Description` are filtered out (Apache autoindex
+  headers).
+
+Selection rules:
+
+- `AlphanumComparator` is used to pick the highest version that
+  starts with `${coreVersionMajor.Minor}` (e.g. `4.1`).
+- `autoriseSnapshot` toggles whether versions containing
+  `SNAPSHOT` are eligible.
+
+This constraint is the main driver for HBTV-005 hosting choice.
+
+## 3. Target URLs (proposal)
+
+### 3.1 SCM
+
+```
+scm:git:https://github.com/Mika3578/habitv.git
+scm:git:git@github.com:Mika3578/habitv.git (developerConnection)
+```
+
+For per-module POMs, append the module path segment as a `<tag>`
+or leave only the root coordinates. Recommend dropping the
+per-module `<scm>` blocks entirely (Maven inherits from parent);
+keep only the root and the two `habiTv-linux/-windows` packaging
+modules that currently parent outside the reactor.
+
+### 3.2 Maven `<repository>`
+
+Replace `http://dabiboo.free.fr/repository` with the static repo
+defined in HBTV-005. Working assumption:
+
+```
+https://mika3578.github.io/habitv-repo/maven/
+```
+
+Until HBTV-005 stands up the host, this repository declaration can
+be removed entirely (no current dependency is resolved through it
+once R-010 was fixed in HBTV-002).
+
+### 3.3 `<distributionManagement>`
+
+Drop the FTP block and the `wagon-ftp` extension. Replace with a
+documented publication workflow under HBTV-005 (GitHub Actions
+pushing to the static repo).
+
+### 3.4 Runtime `UPDATE_URL`
+
+Switch to the same HTTPS static repo:
+
+```
+https://mika3578.github.io/habitv-repo/
+```
+
+### 3.5 Runtime `STAT_URL`
+
+Two options, decision deferred to ADR-0008:
+
+- Remove telemetry entirely. Simplest, no privacy surface.
+- Keep it behind an opt-in flag (default off) and migrate to an
+  HTTPS endpoint under Habitv control.
+
+## 4. Feature flag plan (quarantine before swap)
+
+Goal: stop network pings to the legacy hosts in dev/CI builds
+before any URL is changed. This avoids leaking dev traffic to a
+third-party host during the migration.
+
+Proposed properties (default `false`, opt-in via system property
+or environment):
+
+| Property                 | Effect                                       |
+|--------------------------|----------------------------------------------|
+| `habitv.stat.enabled`    | Gate `CoreManager.stat()` background thread. |
+| `habitv.update.enabled`  | Gate `UpdateManager.process()` entirely.     |
+
+Packaging POMs and release scripts should set both to `true` for
+production builds. Local development and CI leave them at `false`.
+
+`TestListHttp.java` should be tagged `@Ignore` with a comment
+pointing at R-005 (live network) once the gates are added; a
+follow-up under HBTV-002 quarantines live tests behind an opt-in
+profile.
+
+## 5. PR sequencing
+
+All PRs below are scoped to one tracker item each.
+
+| #  | Branch                                          | Tracker | Scope summary                                                                                          |
+|----|-------------------------------------------------|---------|--------------------------------------------------------------------------------------------------------|
+| 1  | `claude/analyze-audit-jrczu`                    | HBTV-004 | This document + tracker / risk / decision updates. Plan only, no code or POM.                          |
+| 2  | `runtime/quarantine-stat-url`                   | HBTV-004 | Add `habitv.stat.enabled` gate in `CoreManager.stat()`. URL constant unchanged.                        |
+| 3  | `runtime/quarantine-update-url`                 | HBTV-004 | Add `habitv.update.enabled` gate in `UpdateManager.process()`. URL constant unchanged.                 |
+| 4  | `build/replace-scm-urls`                        | HBTV-004 | Swap 23 `<scm>` SVN blocks to GitHub. Fix `plugins/email` copy/paste pointing at `plugins/RSS`.       |
+| 5  | `build/remove-ftp-distribution-management`      | HBTV-004 | Drop `<distributionManagement>` FTP and `wagon-ftp` extension from `pom.xml`.                          |
+| 6  | `build/replace-maven-repository-url`            | HBTV-005 | Swap 3 `<repository>` HTTP blocks to HTTPS target. Requires HBTV-005 host live.                        |
+| 7  | `runtime/swap-update-stat-urls`                 | HBTV-005 | Update `FrameworkConf.UPDATE_URL` and `HabitTvConf.STAT_URL` to the HTTPS targets.                     |
+
+Validation per PR: `mvn -B -ntp -DskipTests validate` plus the
+narrower commands the touched files imply (compile for code PRs,
+tests opt-in only).
+
+Order rationale:
+
+- PRs 2 and 3 must land first; they cut the silent traffic so the
+  later POM swaps cannot regress dev behavior.
+- PR 4 (SCM) is fully orthogonal and can land any time.
+- PR 5 (FTP) is safe because no one publishes through it today.
+- PRs 6 and 7 depend on HBTV-005 (publication host live + layout
+  validated against `FindArtifactUtils` semantics).
+
+## 6. Risks introduced or surfaced
+
+See `docs/risk-register.md`:
+
+- R-013 ÔÇö Hardcoded Gmail and freebox credentials in tests and
+  sample config.
+- R-014 ÔÇö GitHub Pages does not serve autoindex natively; updater
+  contract breaks unless `index.html` files are generated.
+- R-015 ÔÇö `CoreManager.stat()` pings a third-party host on every
+  startup in development builds.
+
+## 7. Decisions referenced
+
+See `docs/decision-log.md`:
+
+- ADR-0004 (Proposed) ÔÇö `habitv-repo` as future static artifact
+  repository. To be confirmed or superseded once HBTV-005 lands.
+- ADR-0008 (Proposed) ÔÇö Quarantine network pings at startup in
+  development builds via opt-in properties.
+- ADR-0009 (Proposed) ÔÇö Publish via GitHub Pages with generated
+  `index.html` to remain compatible with `FindArtifactUtils`.
+
+## 8. Out of scope for this document
+
+- HBTV-005 layout details (directory naming, signature plan,
+  publication automation). Covered by
+  `docs/hbtv-005-publication-layout.md` (future PR).
+- HBTV-008 packaging / JavaFX cleanup of `habiTv-linux`,
+  `habiTv-windows`.
+- HBTV-006 provider inventory.
+- HBTV-007 yt-dlp migration.
+- R-005 / R-013 remediation (live-network tests, credential
+  cleanup) ÔÇö recorded but executed in dedicated PRs.

--- a/docs/hbtv-004-url-migration-plan.md
+++ b/docs/hbtv-004-url-migration-plan.md
@@ -1,23 +1,31 @@
-# HBTV-004 ÔÇö Legacy URL migration plan
+# HBTV-004 - Legacy URL migration plan
 
-Plan-only document for migrating Habitv away from legacy
-SVN/Assembla, plain-HTTP `dabiboo.free.fr`, FTP `ftpperso.free.fr`,
-and embedded telemetry/update URLs. No code or POM is changed in
-this PR. Implementation will be split across follow-up PRs listed
-in section 5.
+**Document status:** Preserved historical planning and reference material
+imported from PR #25 (`claude/analyze-audit-jrczu`). It records the legacy
+inventory and sequenced plan as understood before execution.
 
-This document pairs with `docs/hbtv-005-publication-layout.md`
-(future) and supersedes the rough notes in
-`docs/audit-master-baseline.md` lines 54-84 by enumerating exact
-call sites and a sequenced migration plan.
+**Execution:** PR #36 (`chore/remove-legacy-dabiboo-repository`) implements
+HBTV-004 wiring removal on `develop`. That PR changes active POM and runtime
+constants; this file is not a plan-only PR description.
 
-## 1. Inventory of legacy references
+**Out of scope here (HBTV-005 and later):** GitHub Pages publication layout,
+static `index.html` generation for updater discovery, manifest automation, and
+full updater contract validation against a live host.
 
-### 1.1 SCM blocks (SVN / Assembla) ÔÇö 23 POMs
+This document pairs with `docs/hbtv-005-publication-layout.md` (future) and
+supersedes the rough notes in `docs/audit-master-baseline.md` lines 54-84 by
+enumerating exact call sites and the original sequenced migration plan.
+
+## 1. Inventory of legacy references (pre-PR #36 baseline)
+
+The tables below describe the repository **before** PR #36. They are kept for
+audit traceability, not as the current wiring state.
+
+### 1.1 SCM blocks (SVN / Assembla) - 23 POMs
 
 Root:
 
-- `pom.xml:21-24` ÔÇö `scm:svn:http://subversion.assembla.com/svn/habitv/trunk`
+- `pom.xml:21-24` - `scm:svn:http://subversion.assembla.com/svn/habitv/trunk`
 
 Framework:
 
@@ -40,8 +48,8 @@ Plugins (18 of 22 + `plugin-tester`):
 - `plugins/clubic/pom.xml`
 - `plugins/cmd/pom.xml`
 - `plugins/curl/pom.xml`
-- `plugins/email/pom.xml` (also points at `plugins/RSS` by
-  copy/paste ÔÇö fix in the same change set)
+- `plugins/email/pom.xml` (also pointed at `plugins/RSS` by copy/paste -
+  fixed in the same change set)
 - `plugins/ffmpeg/pom.xml`
 - `plugins/file/pom.xml`
 - `plugins/lequipe/pom.xml`
@@ -51,31 +59,31 @@ Plugins (18 of 22 + `plugin-tester`):
 - `plugins/wat/pom.xml`
 - `plugins/youtube/pom.xml`
 
-Plugins without `<scm>` block today (intentionally left as-is until
+Plugins without `<scm>` block at planning time (intentionally left as-is until
 the global swap):
 
 - `plugins/footyroom`, `plugins/globalnews`, `plugins/mlssoccer`,
   `plugins/6play`.
 
-### 1.2 Maven `<repository>` (HTTP `dabiboo.free.fr`) ÔÇö 3 POMs
+### 1.2 Maven `<repository>` (HTTP `dabiboo.free.fr`) - 3 POMs
 
 - `pom.xml:33-39`
 - `application/habiTv-linux/pom.xml:20`
 - `application/habiTv-windows/pom.xml:32`
 
-All three declare the same id `dabi-repo` pointing at
-`http://dabiboo.free.fr/repository`. Plain HTTP, third-party
-hosting, blocked by Maven 3.9+ default mirror policy.
+All three declared the same id `dabi-repo` pointing at
+`http://dabiboo.free.fr/repository`. Plain HTTP, third-party hosting, blocked
+by Maven 3.9+ default mirror policy.
 
-### 1.3 `<distributionManagement>` FTP ÔÇö 1 POM
+### 1.3 `<distributionManagement>` FTP - 1 POM
 
-- `pom.xml:26-31` ÔÇö `ftp://ftpperso.free.fr/repository`
-- `pom.xml:159-166` ÔÇö `<extension>` `wagon-ftp:1.0-beta-6`
+- `pom.xml:26-31` - `ftp://ftpperso.free.fr/repository`
+- `pom.xml:159-166` - `<extension>` `wagon-ftp:1.0-beta-6`
 
-FTP is unencrypted, free.fr personal hosting is deprecated, and the
-extension is from 2009.
+FTP is unencrypted, free.fr personal hosting is deprecated, and the extension
+is from 2009.
 
-### 1.4 Runtime URL constants ÔÇö 2 constants
+### 1.4 Runtime URL constants - 2 constants
 
 | Constant     | File:line                                                                 | Purpose       |
 |--------------|---------------------------------------------------------------------------|---------------|
@@ -85,43 +93,42 @@ extension is from 2009.
 ### 1.5 Runtime call sites
 
 - `application/core/src/com/dabi/habitv/core/updater/UpdateManager.java:40`
-  ÔÇö constructor passes `FrameworkConf.UPDATE_URL` to the
-  `UpdateManager` instance.
+  - constructor passes `FrameworkConf.UPDATE_URL` to the `UpdateManager`
+  instance.
 - `application/core/src/com/dabi/habitv/core/updater/UpdateManager.java:48`
-  ÔÇö `RetrieverUtils.getUrlContent(site + "/plugins.txt", null)`.
+  - `RetrieverUtils.getUrlContent(site + "/plugins.txt", null)`.
 - `fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtils.java:56`
-  ÔÇö builds `${UPDATE_URL}/${groupIdPath}/${artifactId}` and
-  recursively lists directory contents via Jsoup.
+  - builds `${UPDATE_URL}/${groupIdPath}/${artifactId}` and recursively lists
+  directory contents via Jsoup.
 - `application/core/src/com/dabi/habitv/core/mgr/CoreManager.java:46-55`
-  ÔÇö `stat()` fires a background thread on construction that calls
+  - `stat()` fired a background thread on construction that called
   `RetrieverUtils.getUrlContent(HabitTvConf.STAT_URL, null)`.
 
 ### 1.6 Tests that hit the legacy hosts
 
 - `application/core/test/com/dabi/habitv/core/updater/TestListHttp.java:30-37`
-  ÔÇö calls `FindArtifactUtils.findLastVersionUrl(...)`, which hits
-  the live `UPDATE_URL`.
+  - called `FindArtifactUtils.findLastVersionUrl(...)`, which hit the live
+  `UPDATE_URL`.
 - `fwk/framework/test/com/dabi/habitv/framework/plugin/utils/TestUrl.java:10`
-  ÔÇö `RetrieverUtils.getTitleByUrl("http://www.beinsports.fr")`,
-  out of scope for HBTV-004 but tracked under R-005.
+  - `RetrieverUtils.getTitleByUrl("http://www.beinsports.fr")`, out of scope
+  for HBTV-004 but tracked under R-005.
 
 ### 1.7 Adjacent legacy traces (not in scope, recorded for context)
 
-- `application/consoleView/config.xml:57,84` ÔÇö sample `curl`
-  commands with hardcoded freebox FTP credentials
-  (`ftp://freebox:4688@hd1.freebox.fr/...`). Sample file, not
-  executed. Tracked as new risk R-013.
+- `application/consoleView/config.xml:57,84` - sample `curl` commands with
+  hardcoded freebox FTP credentials (`ftp://freebox:4688@hd1.freebox.fr/...`).
+  Sample file, not executed. Tracked as new risk R-013.
 - `plugins/email/test/com/dabi/habitv/plugin/email/MessageReceiverTest.java:14,19`
   and
   `plugins/email/test/com/dabi/habitv/plugin/email/EmailPluginManagerTest.java:29`
-  ÔÇö hardcoded Gmail credentials `testhabitv` / `HabiTV410`.
-  Tracked as new risk R-013.
+  - hardcoded Gmail credentials `testhabitv` / `HabiTV410`. Tracked as new
+  risk R-013.
 
 ## 2. Updater contract (reverse-engineered from FindArtifactUtils)
 
-The current updater relies on an Apache-style `mod_autoindex` HTTP
-server. Any replacement host must serve compatible HTML or the
-updater stops discovering new artifacts.
+The updater relies on an Apache-style `mod_autoindex` HTTP server. Any
+replacement host must serve compatible HTML or the updater stops discovering
+new artifacts.
 
 Required URL shapes:
 
@@ -135,148 +142,144 @@ Required HTML shape (per directory):
 
 - `<a href="X.Y.Z/">X.Y.Z</a>` for version directories.
 - `<a href="artifactId-X.Y.Z.jar">...</a>` for files.
-- Entries with text `Parent Directory`, `Name`, `Last modified`,
-  `Size`, `Description` are filtered out (Apache autoindex
-  headers).
+- Entries with text `Parent Directory`, `Name`, `Last modified`, `Size`,
+  `Description` are filtered out (Apache autoindex headers).
 
 Selection rules:
 
-- `AlphanumComparator` is used to pick the highest version that
-  starts with `${coreVersionMajor.Minor}` (e.g. `4.1`).
-- `autoriseSnapshot` toggles whether versions containing
-  `SNAPSHOT` are eligible.
+- `AlphanumComparator` is used to pick the highest version that starts with
+  `${coreVersionMajor.Minor}` (e.g. `4.1`).
+- `autoriseSnapshot` toggles whether versions containing `SNAPSHOT` are
+  eligible.
 
 This constraint is the main driver for HBTV-005 hosting choice.
 
-## 3. Target URLs (proposal)
+## 3. Target URLs
 
-### 3.1 SCM
+### 3.1 SCM (executed in PR #36)
 
 ```
 scm:git:https://github.com/Mika3578/habitv.git
 scm:git:git@github.com:Mika3578/habitv.git (developerConnection)
 ```
 
-For per-module POMs, append the module path segment as a `<tag>`
-or leave only the root coordinates. Recommend dropping the
-per-module `<scm>` blocks entirely (Maven inherits from parent);
-keep only the root and the two `habiTv-linux/-windows` packaging
-modules that currently parent outside the reactor.
+Per-module `<scm>` blocks were removed or aligned with the parent; see PR #36
+for the final POM set.
 
-### 3.2 Maven `<repository>`
+### 3.2 Maven `<repository>` (executed base URL)
 
-Replace `http://dabiboo.free.fr/repository` with the static repo
-defined in HBTV-005. Working assumption:
+**Original planning note (PR #25):** assumed a future path such as
+`https://mika3578.github.io/habitv-repo/maven/`.
 
-```
-https://mika3578.github.io/habitv-repo/maven/
-```
-
-Until HBTV-005 stands up the host, this repository declaration can
-be removed entirely (no current dependency is resolved through it
-once R-010 was fixed in HBTV-002).
-
-### 3.3 `<distributionManagement>`
-
-Drop the FTP block and the `wagon-ftp` extension. Replace with a
-documented publication workflow under HBTV-005 (GitHub Actions
-pushing to the static repo).
-
-### 3.4 Runtime `UPDATE_URL`
-
-Switch to the same HTTPS static repo:
+**Executed in PR #36:** active `<repository>` URLs and runtime discovery use the
+GitHub Pages base path:
 
 ```
-https://mika3578.github.io/habitv-repo/
+https://mika3578.github.io/habitv-repo/repository
 ```
+
+HBTV-005 may later split Maven, tools, and manifests under separate prefixes
+(see `docs/static-repository-deploy.md`). That layout work is not part of PR
+#36.
+
+### 3.3 `<distributionManagement>` (executed in PR #36)
+
+FTP `distributionManagement` and the `wagon-ftp` extension were removed.
+Publication automation remains under HBTV-005.
+
+### 3.4 Runtime `UPDATE_URL` (executed in PR #36)
+
+```
+https://mika3578.github.io/habitv-repo/repository
+```
+
+Runtime plugin updates remain **disabled by default** in PR #36; enabling them
+for production builds is a separate packaging/release decision.
 
 ### 3.5 Runtime `STAT_URL`
 
 Two options, decision deferred to ADR-0008:
 
 - Remove telemetry entirely. Simplest, no privacy surface.
-- Keep it behind an opt-in flag (default off) and migrate to an
-  HTTPS endpoint under Habitv control.
+- Keep it behind an opt-in flag (default off) and migrate to an HTTPS endpoint
+  under Habitv control.
+
+PR #36 disables stat/update network calls by default; see `CoreManager` and
+`UpdateManager` gating in that PR.
 
 ## 4. Feature flag plan (quarantine before swap)
 
-Goal: stop network pings to the legacy hosts in dev/CI builds
-before any URL is changed. This avoids leaking dev traffic to a
-third-party host during the migration.
+Goal: stop network pings to legacy hosts in dev/CI builds before any URL is
+changed. PR #36 implements default-off gating for stat and update processing.
 
-Proposed properties (default `false`, opt-in via system property
-or environment):
+Proposed properties (default `false`, opt-in via system property or
+environment):
 
 | Property                 | Effect                                       |
 |--------------------------|----------------------------------------------|
 | `habitv.stat.enabled`    | Gate `CoreManager.stat()` background thread. |
 | `habitv.update.enabled`  | Gate `UpdateManager.process()` entirely.     |
 
-Packaging POMs and release scripts should set both to `true` for
-production builds. Local development and CI leave them at `false`.
+Packaging POMs and release scripts may set both to `true` for production
+builds. Local development and CI leave them at `false`.
 
-`TestListHttp.java` should be tagged `@Ignore` with a comment
-pointing at R-005 (live network) once the gates are added; a
-follow-up under HBTV-002 quarantines live tests behind an opt-in
-profile.
+`TestListHttp.java` should be tagged `@Ignore` with a comment pointing at R-005
+(live network) once the gates are added; a follow-up under HBTV-002
+quarantines live tests behind an opt-in profile.
 
-## 5. PR sequencing
+## 5. PR sequencing (original plan vs execution)
 
-All PRs below are scoped to one tracker item each.
+The table below is the **original** split from PR #25. PR #36 consolidates
+most build/runtime wiring removal; remaining rows are follow-ups.
 
-| #  | Branch                                          | Tracker | Scope summary                                                                                          |
-|----|-------------------------------------------------|---------|--------------------------------------------------------------------------------------------------------|
-| 1  | `claude/analyze-audit-jrczu`                    | HBTV-004 | This document + tracker / risk / decision updates. Plan only, no code or POM.                          |
-| 2  | `runtime/quarantine-stat-url`                   | HBTV-004 | Add `habitv.stat.enabled` gate in `CoreManager.stat()`. URL constant unchanged.                        |
-| 3  | `runtime/quarantine-update-url`                 | HBTV-004 | Add `habitv.update.enabled` gate in `UpdateManager.process()`. URL constant unchanged.                 |
-| 4  | `build/replace-scm-urls`                        | HBTV-004 | Swap 23 `<scm>` SVN blocks to GitHub. Fix `plugins/email` copy/paste pointing at `plugins/RSS`.       |
-| 5  | `build/remove-ftp-distribution-management`      | HBTV-004 | Drop `<distributionManagement>` FTP and `wagon-ftp` extension from `pom.xml`.                          |
-| 6  | `build/replace-maven-repository-url`            | HBTV-005 | Swap 3 `<repository>` HTTP blocks to HTTPS target. Requires HBTV-005 host live.                        |
-| 7  | `runtime/swap-update-stat-urls`                 | HBTV-005 | Update `FrameworkConf.UPDATE_URL` and `HabitTvConf.STAT_URL` to the HTTPS targets.                     |
+| #  | Branch / PR                                      | Tracker | Status / scope summary                                                                                |
+|----|--------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------|
+| 1  | PR #25 (`claude/analyze-audit-jrczu`)            | HBTV-004 | **Done (plan only).** This document + tracker/risk/decision updates.                                  |
+| -  | PR #36 (`chore/remove-legacy-dabiboo-repository`)| HBTV-004 | **Execution PR.** SCM swap, remove FTP/dabiboo wiring, HTTPS repo URL, default-off stat/update.       |
+| 2  | `runtime/quarantine-stat-url`                    | HBTV-004 | Largely covered by PR #36 default-off stat gate.                                                      |
+| 3  | `runtime/quarantine-update-url`                  | HBTV-004 | Largely covered by PR #36 default-off update gate.                                                    |
+| 4  | `build/replace-scm-urls`                         | HBTV-004 | Covered by PR #36.                                                                                    |
+| 5  | `build/remove-ftp-distribution-management`         | HBTV-004 | Covered by PR #36.                                                                                    |
+| 6  | `build/replace-maven-repository-url`             | HBTV-005 | Host layout and publication; `/repository` base set in PR #36.                                        |
+| 7  | `runtime/swap-update-stat-urls`                  | HBTV-005 | HTTPS constants set in PR #36; live updater validation depends on HBTV-005 index/manifest work.       |
 
-Validation per PR: `mvn -B -ntp -DskipTests validate` plus the
-narrower commands the touched files imply (compile for code PRs,
-tests opt-in only).
+Validation per execution PR: `mvn -B -ntp -DskipTests validate` and `compile`
+plus narrower commands implied by touched files (tests opt-in only).
 
-Order rationale:
+Order rationale (historical):
 
-- PRs 2 and 3 must land first; they cut the silent traffic so the
-  later POM swaps cannot regress dev behavior.
-- PR 4 (SCM) is fully orthogonal and can land any time.
-- PR 5 (FTP) is safe because no one publishes through it today.
-- PRs 6 and 7 depend on HBTV-005 (publication host live + layout
-  validated against `FindArtifactUtils` semantics).
+- Quarantine gates before or with URL swaps to avoid dev traffic to legacy hosts.
+- SCM and FTP removal are orthogonal to hosting layout.
+- HBTV-005 depends on publication host live and layout compatible with
+  `FindArtifactUtils` semantics.
 
 ## 6. Risks introduced or surfaced
 
 See `docs/risk-register.md`:
 
-- R-013 ÔÇö Hardcoded Gmail and freebox credentials in tests and
-  sample config.
-- R-014 ÔÇö GitHub Pages does not serve autoindex natively; updater
-  contract breaks unless `index.html` files are generated.
-- R-015 ÔÇö `CoreManager.stat()` pings a third-party host on every
-  startup in development builds.
+- R-013 - Hardcoded Gmail and freebox credentials in tests and sample config.
+- R-014 - GitHub Pages does not serve autoindex natively; updater contract
+  breaks unless `index.html` files are generated.
+- R-015 - `CoreManager.stat()` pinged a third-party host on every startup in
+  development builds (mitigated by PR #36 default-off gate).
 
 ## 7. Decisions referenced
 
 See `docs/decision-log.md`:
 
-- ADR-0004 (Proposed) ÔÇö `habitv-repo` as future static artifact
-  repository. To be confirmed or superseded once HBTV-005 lands.
-- ADR-0008 (Proposed) ÔÇö Quarantine network pings at startup in
-  development builds via opt-in properties.
-- ADR-0009 (Proposed) ÔÇö Publish via GitHub Pages with generated
-  `index.html` to remain compatible with `FindArtifactUtils`.
+- ADR-0004 (Proposed) - `habitv-repo` as future static artifact repository.
+  Confirmed base path `/repository` for PR #36; full layout under HBTV-005.
+- ADR-0008 (Proposed) - Quarantine network pings at startup in development
+  builds via opt-in properties (implemented default-off in PR #36).
+- ADR-0009 (Proposed) - Publish via GitHub Pages with generated `index.html`
+  to remain compatible with `FindArtifactUtils`.
 
 ## 8. Out of scope for this document
 
-- HBTV-005 layout details (directory naming, signature plan,
-  publication automation). Covered by
-  `docs/hbtv-005-publication-layout.md` (future PR).
-- HBTV-008 packaging / JavaFX cleanup of `habiTv-linux`,
-  `habiTv-windows`.
+- HBTV-005 layout details (directory naming, signature plan, publication
+  automation). Covered by `docs/hbtv-005-publication-layout.md` (future PR).
+- HBTV-008 packaging / JavaFX cleanup of `habiTv-linux`, `habiTv-windows`.
 - HBTV-006 provider inventory.
 - HBTV-007 yt-dlp migration.
-- R-005 / R-013 remediation (live-network tests, credential
-  cleanup) ÔÇö recorded but executed in dedicated PRs.
+- R-005 / R-013 remediation (live-network tests, credential cleanup) - recorded
+  but executed in dedicated PRs.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -42,6 +42,11 @@ or accepted.
 - Residual risk: Legacy repository migration is still required for
   external publication/runtime update concerns and remains tracked under
   HBTV-004/HBTV-005; this fix is Maven dependency alignment only.
+- Status update (HBTV-004): Active Maven repository wiring no longer
+  references `http://dabiboo.free.fr/repository` in active POM paths.
+  Functional publication cutover remains blocked under HBTV-005 until
+  `https://mika3578.github.io/habitv-repo/repository` is published with
+  a layout compatible with local reactor builds.
 
 ## R-002 — FTP deployment no longer viable
 
@@ -51,6 +56,8 @@ or accepted.
   the password mechanism would expose credentials.
 - Mitigation: Remove FTP deploy in HBTV-004 / HBTV-005 and replace
   with a documented static publication workflow.
+- Status update (HBTV-004): Active packaging POMs no longer declare
+  `ftp://ftpperso.free.fr/repository` distributionManagement blocks.
 
 ## R-003 — JavaFX tied to JDK 8 assumptions
 
@@ -98,8 +105,13 @@ or accepted.
   `FrameworkConf.UPDATE_URL` (`http://dabiboo.free.fr/repository`)
   at runtime. Running a dev build can pull whatever happens to
   be on that host (or fail noisily if it is down).
-- Mitigation: Plan a feature flag / env override in HBTV-005 to
-  disable updates in development. Until then, document the risk.
+- Mitigation: Disable updates by default; require explicit opt-in before
+  any runtime fetch (`habitv.update.enabled`, optional `habitv.update.url`).
+- Status update (HBTV-004): `UpdateManager` returns immediately unless
+  `habitv.update.enabled=true`. The default target base URL constant is
+  `https://mika3578.github.io/habitv-repo/repository` (legacy DabiBoo
+  removed). Do not enable updates until HBTV-005 publishes Apache-style
+  directory indexes or an equivalent manifest layout.
 
 ## R-008 — yt-dlp migration can change download behavior
 
@@ -123,6 +135,12 @@ or accepted.
 - Mitigation: HBTV-005 defines the layout explicitly and validates
   it against `FindArtifactUtils.findLastVersionUrl` semantics
   before cutting over.
+- Status update (HBTV-004/HBTV-005): `FindArtifactUtils` parses HTML
+  directory listings via anchor tags (Apache `mod_autoindex` shape).
+  GitHub Pages does not provide that listing by default. Runtime updates
+  stay disabled (`habitv.update.enabled` defaults false) until static
+  `index.html` files or manifests are published and verified under
+  HBTV-005. Keep this risk at P1 until cutover validation completes.
 
 ## R-010 — Intra-reactor version range `[4.1,4.2)` excludes SNAPSHOTs
 

--- a/docs/runtime-quickstart.md
+++ b/docs/runtime-quickstart.md
@@ -128,6 +128,8 @@ plugin itself is fully wired (see
 `plugins/youtube/test/.../YoutubePluginDownloaderCmdTest.java`); the
 limitation is purely network policy of the runtime environment.
 
-The startup telemetry ping to `http://dabiboo.free.fr/cpt.php` will
-log a `403` warning in restricted environments. This is non-fatal and
-does not affect downloads.
+Startup telemetry and plugin update checks are disabled by default.
+Enable only when needed: `-Dhabitv.stat.enabled=true`
+`-Dhabitv.stat.url=...` and/or `-Dhabitv.update.enabled=true`
+(optional `-Dhabitv.update.url=...`). Do not enable updates until
+HBTV-005 publishes verified static directory indexes.

--- a/fwk/api/pom.xml
+++ b/fwk/api/pom.xml
@@ -11,12 +11,7 @@
 	<packaging>jar</packaging>
 	<name>api</name>
 
-	 <scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/fwk/api</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/fwk/api</developerConnection>
-    </scm>		
-	
-	<dependencies>
+<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/fwk/framework/pom.xml
+++ b/fwk/framework/pom.xml
@@ -12,12 +12,7 @@
 	<name>framework</name>
 	<version>4.1.0-SNAPSHOT</version>
 
-	<scm>
-		<connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/fwk/framework</connection>
-		<developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/fwk/framework</developerConnection>
-	</scm>
-
-	<dependencies>
+<dependencies>
 		<dependency>
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>

--- a/fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java
@@ -18,6 +18,11 @@ public interface FrameworkConf {
 
 	Integer TIME_OUT_MS = 30000;
 
+	String UPDATE_ENABLED_PROPERTY = "habitv.update.enabled";
+
+	String UPDATE_URL_PROPERTY = "habitv.update.url";
+
+	/** Target static repository base when updates are explicitly enabled. */
 	String UPDATE_URL = "https://mika3578.github.io/habitv-repo/repository";
 
 	String GROUP_ID = "com.dabi.habitv";

--- a/fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java
@@ -18,7 +18,7 @@ public interface FrameworkConf {
 
 	Integer TIME_OUT_MS = 30000;
 
-	String UPDATE_URL = "http://dabiboo.free.fr/repository";
+	String UPDATE_URL = "https://mika3578.github.io/habitv-repo/repository";
 
 	String GROUP_ID = "com.dabi.habitv";
 

--- a/plugins/RSS/pom.xml
+++ b/plugins/RSS/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>RSS</artifactId>
 	<name>RSS</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/RSS</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/RSS</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/adobeHDS/pom.xml
+++ b/plugins/adobeHDS/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>adobeHDS</artifactId>
 	<name>adobeHDS</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/adobeHDS</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/adobeHDS</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/aria2/pom.xml
+++ b/plugins/aria2/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>aria2</artifactId>
 	<name>aria2</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/aria2</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/aria2</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/arte/pom.xml
+++ b/plugins/arte/pom.xml
@@ -12,12 +12,7 @@
 	<name>arte</name>
 	<version>4.1.0-SNAPSHOT</version>
 
-	<scm>
-		<connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/arte</connection>
-		<developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/arte</developerConnection>
-	</scm>
-
-	<dependencies>
+<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/plugins/beinsport/pom.xml
+++ b/plugins/beinsport/pom.xml
@@ -12,12 +12,7 @@
 	<name>beinsport</name>
 	<version>4.1.1-SNAPSHOT</version>
 
-	<scm>
-		<connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/beinsport</connection>
-		<developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/beinsport</developerConnection>
-	</scm>
-
-	<dependencies>
+<dependencies>
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
@@ -25,10 +20,12 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>framework</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>api</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>

--- a/plugins/canalPlus/pom.xml
+++ b/plugins/canalPlus/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>canalPlus</artifactId>
 	<name>canalPlus</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/canalPlus</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/canalPlus</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/clubic/pom.xml
+++ b/plugins/clubic/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>clubic</artifactId>
 	<name>clubic</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/clubic</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/clubic</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/cmd/pom.xml
+++ b/plugins/cmd/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>cmd</artifactId>
 	<name>cmd</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/cmd</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/cmd</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/curl/pom.xml
+++ b/plugins/curl/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>curl</artifactId>
 	<name>curl</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/curl</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/curl</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/email/pom.xml
+++ b/plugins/email/pom.xml
@@ -12,12 +12,7 @@
 	<name>email</name>
 	<version>4.1.0-SNAPSHOT</version>
 
-	<scm>
-		<connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/RSS</connection>
-		<developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/RSS</developerConnection>
-	</scm>
-
-	<dependencies>
+<dependencies>
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>

--- a/plugins/ffmpeg/pom.xml
+++ b/plugins/ffmpeg/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>ffmpeg</artifactId>
 	<name>ffmpeg</name>
 	<version>4.1.2-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/ffmpeg</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/ffmpeg</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
@@ -31,6 +26,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>framework</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/plugins/file/pom.xml
+++ b/plugins/file/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>file</artifactId>
 	<name>file</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/file</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/file</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/footyroom/pom.xml
+++ b/plugins/footyroom/pom.xml
@@ -30,6 +30,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>framework</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/plugins/lequipe/pom.xml
+++ b/plugins/lequipe/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>lequipe</artifactId>
 	<version>4.1.0-SNAPSHOT</version>
 	<name>lequipe</name>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/lequipe</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/lequipe</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/pluzz/pom.xml
+++ b/plugins/pluzz/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>pluzz</artifactId>
 	<name>pluzz</name>
 	<version>4.1.1-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/pluzz</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/pluzz</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
@@ -31,6 +26,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>framework</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/plugins/rtmpDump/pom.xml
+++ b/plugins/rtmpDump/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>rtmpDump</artifactId>
 	<name>rtmpDump</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/rtmpDump</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/rtmpDump</developerConnection>
-    </scm>	
-	
-	<dependencies>
+
+<dependencies>
 			<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/sfr/pom.xml
+++ b/plugins/sfr/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>sfr</artifactId>
 	<version>4.1.0-SNAPSHOT</version>
 	<name>sfr</name>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/sfr</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/sfr</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/wat/pom.xml
+++ b/plugins/wat/pom.xml
@@ -10,13 +10,8 @@
 	<artifactId>wat</artifactId>
 	<name>wat</name>
 	<version>4.1.0-SNAPSHOT</version>
-	
-	<scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/wat</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/wat</developerConnection>
-    </scm>
-	
-	<dependencies>
+
+<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>

--- a/plugins/youtube/pom.xml
+++ b/plugins/youtube/pom.xml
@@ -9,12 +9,7 @@
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<scm>
-		<connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/youtube</connection>
-		<developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk/plugins/youtube</developerConnection>
-	</scm>
-
-	<artifactId>youtube</artifactId>
+<artifactId>youtube</artifactId>
 	<name>youtube</name>
 	<version>4.1.0-SNAPSHOT</version>
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,15 +19,22 @@
 	</properties>
 
 	 <scm>
-        <connection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk</connection>
-        <developerConnection>scm:svn:http://subversion.assembla.com/svn/habitv/trunk</developerConnection>
+        <connection>scm:git:https://github.com/Mika3578/habitv.git</connection>
+        <developerConnection>scm:git:https://github.com/Mika3578/habitv.git</developerConnection>
+        <url>https://github.com/Mika3578/habitv</url>
     </scm>	
 	
 	<repositories>
 		<repository>
-			<id>dabi-repo</id>
-			<name>dabi-repo</name>
-			<url>http://dabiboo.free.fr/repository</url>
+			<id>habitv-static-repo</id>
+			<name>Habitv public static artifact repository</name>
+			<url>https://mika3578.github.io/habitv-repo/repository</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</repository>
 	</repositories>	
 


### PR DESCRIPTION
## Summary

- Replaces active legacy DabiBoo Maven repository wiring with the public GitHub Pages static repository base URL.
- Removes active SVN/Assembla SCM metadata from Maven POMs; inherits GitHub SCM at the root.
- Disables startup telemetry (`habitv.stat.enabled`) and plugin updates (`habitv.update.enabled`) by default.
- Documents Apache autoindex dependency in `FindArtifactUtils`; runtime updates must stay off until HBTV-005 publishes verified static indexes.
- Preserves PR #25 planning doc as `docs/hbtv-004-url-migration-plan.md`.

## Validation

- Branch: `chore/remove-legacy-dabiboo-repository`
- `git status --short` (after commits): clean except untracked `.vscode/`
- `git grep -n -I -E "dabiboo|free\.fr|ftpperso|subversion\.assembla|scm:svn|cpt\.php" -- .`
  - Matches only `docs/*` (audit, tracker, risk, decision log, dev-plan, runtime-quickstart, hbtv-004 plan). No active `pom.xml`, Java constants, or scripts.
- `mvn -B -ntp -DskipTests validate` -> **BUILD SUCCESS** (33 modules)
- `mvn -B -ntp -DskipTests compile` -> **BUILD SUCCESS** (33 modules)

## GitHub Pages / autoindex risk

`FindArtifactUtils` parses HTML directory listings (Apache `mod_autoindex`-style `<a href=".../">` links). GitHub Pages does **not** provide that by default. `FrameworkConf.UPDATE_URL` documents the future `habitv-repo` base, but `UpdateManager` exits unless `-Dhabitv.update.enabled=true`. Do not enable updates until HBTV-005 publishes per-directory `index.html` or an equivalent manifest and validates discovery.

## Checklist

- [x] Linear history preserved (rebased onto latest `develop`)
- [x] English used for branch, commits, comments, docs, and PR text
- [x] No Java upgrade
- [x] No provider rewrite
- [x] No GitHub Packages
- [x] No secrets, tokens, generated files, or local paths committed
- [x] HBTV-004 tracker/risk/decision docs updated; HBTV-005 remains separate
- [x] HBTV-006 not started

## Tracker

- HBTV-004: **done** (wiring removal + quarantine)
- HBTV-005: **proposed** (publication layout + static indexes)
- HBTV-006: **proposed** (provider inventory only)