### PR TITLE
chore: configure repository governance baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default ownership for review routing (single-maintainer repository).
+* @Mika3578
+.github/ @Mika3578
+docs/ @Mika3578
+pom.xml @Mika3578
+**/pom.xml @Mika3578

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report a defect in Habitv runtime, build, or plugins
+title: "bug: "
+labels:
+  - bug
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use English. Do not paste secrets, tokens, or session cookies in logs.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Java, Maven, OS, Habitv version or commit SHA, affected module(s)
+      placeholder: |
+        Java: ...
+        Maven: ...
+        OS: ...
+        Commit: ...
+        Module(s): ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include exact error messages when possible
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Redact secrets before pasting
+      render: shell
+
+  - type: checkboxes
+    id: network
+    attributes:
+      label: Network dependency
+      options:
+        - label: Requires network or provider access to reproduce
+        - label: Reproducible fully offline

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Development tracker
+    url: https://github.com/Mika3578/habitv/blob/develop/docs/dev-tracker.md
+    about: Review active modernization items (HBTV-XXX) before opening a feature request
+  - name: Security policy
+    url: https://github.com/Mika3578/habitv/blob/develop/SECURITY.md
+    about: Report vulnerabilities privately per SECURITY.md

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Propose an improvement or modernization tracker item
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Large architectural changes need a tracker item (HBTV-XXX) and often an ADR.
+        See `docs/dev-tracker.md`.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or opportunity
+      description: What pain does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+
+  - type: input
+    id: tracker
+    attributes:
+      label: Tracker item (if any)
+      placeholder: HBTV-XXX
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope awareness
+      options:
+        - label: This stays within Java 8 and current Maven reactor constraints
+        - label: This may require a dedicated tracker item and small PR series

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot version 2 — dependency update policy for develop integration.
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - java
+      - maven
+    groups:
+      maven-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Avoid accidental major upgrades (Java/framework migration) in this phase.
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,35 +14,36 @@
 <!-- Bullet list of intentional non-changes to avoid scope creep. -->
 -
 
-## Linked tracker item
-
-<!-- HBTV-XXX from docs/dev-tracker.md (and matching docs/dev-tracker.json). -->
-- HBTV-
-
-## Validation commands
+## Validation
 
 <!-- Commands actually run locally and their honest outcome. -->
-- `git status --short`
-- `git branch --show-current`
-- `git log --oneline -5`
+- `git diff --check`
 - `mvn -B -ntp -DskipTests validate`
 
-## Risk assessment
+## Risk
 
 <!-- Reference docs/risk-register.md IDs (R-00X) impacted or introduced. -->
 - Affected risks:
 - New risks:
 - Mitigation:
 
-## Rollback plan
+## Rollback
 
-<!-- How to revert this PR safely if it breaks master. -->
+<!-- How to revert this PR safely if it breaks develop. -->
 - Revert commit(s) via `git revert <sha>` and re-run validation.
 
-## Checklists
+## Linked tracker item
 
-- [ ] Linear history preserved (no merge commits in this branch)
+<!-- HBTV-XXX from docs/dev-tracker.md when applicable. -->
+- HBTV-
+
+## Checklist
+
+- [ ] Branch was created from `develop`
+- [ ] No unrelated source changes
+- [ ] `git diff --check` passed
+- [ ] `mvn -B -ntp -DskipTests validate` passed or baseline failure documented
+- [ ] PR keeps linear history
 - [ ] English used for branches, commits, comments, docs, and PR text
 - [ ] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`, risk register, decision log as needed)
-- [ ] No unrelated refactors, formatting, or dependency bumps
 - [ ] No secrets, tokens, local paths, or build outputs committed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+# Baseline validate-only CI for develop integration (Java 8, Maven validate).
+# Wider compile/test/package gates require explicit tracker items.
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate (zulu-8)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Zulu JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: "8"
+          cache: maven
+
+      - name: Maven validate
+        run: mvn -B -ntp -DskipTests validate

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security policy
 
-## Supported branch
+## Supported branches
 
 Security fixes are accepted against **`develop`**, the active integration branch.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security policy
+
+## Supported branch
+
+Security fixes are accepted against **`develop`**, the active integration branch.
+
+Legacy branches such as `master` are kept for history and release alignment only
+unless a maintainer explicitly states otherwise in a security advisory or release
+note.
+
+## Reporting a vulnerability
+
+**Do not** open a public GitHub issue for security vulnerabilities before triage.
+
+Preferred path:
+
+1. Open a **private security advisory** on this repository
+   (**Security → Advisories → Report a vulnerability**) when GitHub Private
+   Vulnerability Reporting is enabled.
+2. If private reporting is unavailable, contact the repository owner through a
+   private channel documented in the repository profile or release notes.
+
+Include enough detail for reproduction (affected module, version or commit,
+steps, impact). Do not attach secrets or live credentials.
+
+## Sensitive data
+
+Never include in issues, pull requests, comments, logs, or attachments:
+
+- Passwords, API keys, tokens, or personal access tokens
+- Cookies or session identifiers
+- Private replay-service or provider credentials
+- Personal data unrelated to the defect
+
+Redact logs before posting. Use placeholders for secrets.
+
+## Response expectations
+
+Maintainers will acknowledge reports when possible, assess severity, and
+coordinate a fix on `develop` before any public disclosure.

--- a/docs/github-rulesets/protect-develop.json
+++ b/docs/github-rulesets/protect-develop.json
@@ -26,7 +26,7 @@
         "do_not_enforce_on_create": true,
         "required_status_checks": [
           {
-            "context": "validate (zulu-8)"
+            "context": "CI / validate (zulu-8)"
           }
         ]
       }

--- a/docs/github-rulesets/protect-develop.json
+++ b/docs/github-rulesets/protect-develop.json
@@ -1,0 +1,44 @@
+{
+  "name": "protect-develop",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/develop"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "validate (zulu-8)"
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}

--- a/docs/github-rulesets/protect-release-tags.json
+++ b/docs/github-rulesets/protect-release-tags.json
@@ -1,0 +1,19 @@
+{
+  "name": "protect-release-tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}

--- a/docs/github-rulesets/protect-stable-branches.json
+++ b/docs/github-rulesets/protect-stable-branches.json
@@ -1,0 +1,32 @@
+{
+  "name": "protect-stable-branches",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/master"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}

--- a/docs/github-rulesets/protect-stable-branches.json
+++ b/docs/github-rulesets/protect-stable-branches.json
@@ -4,7 +4,7 @@
   "enforcement": "active",
   "conditions": {
     "ref_name": {
-      "include": ["refs/heads/master"],
+      "include": ["refs/heads/master", "refs/heads/main"],
       "exclude": []
     }
   },

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -43,14 +43,13 @@ governance-only PR.
 ## Required PR checks
 
 The **CI** workflow (`.github/workflows/ci.yml`) must pass on pull requests
-targeting `develop`. The currently observed required ruleset status check name
-from a green PR run is:
+targeting `develop`. Use the expected required ruleset status check context:
 
-- `validate (zulu-8)`
+- `CI / validate (zulu-8)`
 
 If GitHub displays a different check name in the ruleset UI (for example
-`CI / validate (zulu-8)`), align the ruleset with the exact name shown on a
-completed workflow run.
+`validate (zulu-8)` without the workflow prefix), align the ruleset with the
+exact name shown on a completed workflow run.
 
 ## Security policy summary
 

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -43,12 +43,14 @@ governance-only PR.
 ## Required PR checks
 
 The **CI** workflow (`.github/workflows/ci.yml`) must pass on pull requests
-targeting `develop`. The required ruleset status check name is:
+targeting `develop`. The currently observed required ruleset status check name
+from a green PR run is:
 
 - `validate (zulu-8)`
 
-If GitHub displays a different check name (for example `CI / validate (zulu-8)`),
-align the ruleset with the name shown on a completed workflow run.
+If GitHub displays a different check name in the ruleset UI (for example
+`CI / validate (zulu-8)`), align the ruleset with the exact name shown on a
+completed workflow run.
 
 ## Security policy summary
 
@@ -70,7 +72,7 @@ Repository rulesets (preferred over legacy branch protection):
 | Ruleset | Targets | Intent |
 |---------|---------|--------|
 | `protect-develop` | `refs/heads/develop` | PR required, linear history, required CI check, up-to-date branch, conversation resolution, no force-push or deletion. |
-| `protect-stable-branches` | `refs/heads/master`, `refs/heads/main` (if present) | PR required, linear history, no force-push or deletion. |
+| `protect-stable-branches` | `refs/heads/master` | PR required, linear history, no force-push or deletion. |
 | `protect-release-tags` | `refs/tags/v*` | Prevent tag deletion and non-fast-forward updates; restrict tag changes where supported. |
 
 See `docs/github-rulesets/` for API payloads when rulesets must be applied

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -1,0 +1,109 @@
+# Repository governance
+
+## Purpose
+
+Habitv is a Java 8 Maven multi-module application that downloads French TV
+catch-up content via pluggable provider plugins. This document defines how
+the `Mika3578/habitv` repository is governed: branches, merges, validation,
+security, and automation boundaries for the modernization restart.
+
+## Branch model
+
+| Branch | Role |
+|--------|------|
+| `develop` | Default integration branch. All active work merges here first. |
+| `master` / `main` | Legacy stable baseline when present. Protected from direct pushes. |
+| Short-lived branches | Created from `develop`: `feature/*`, `fix/*`, `chore/*`, `docs/*`, `ci/*`, and other prefixes defined in `AGENTS.md`. |
+
+Do not base modernization feature branches on `master` unless a tracker item
+explicitly requires it.
+
+## Merge model
+
+- **Pull requests only** — no direct pushes to protected branches.
+- **Linear history required** — merge commits are disabled.
+- **Prefer squash merge** for a single logical change per PR.
+- **Rebase merge** is allowed only when the PR already contains clean, atomic
+  commits that should land individually.
+- **Merge commits** are disabled at the repository level.
+
+## Required local validation before opening a PR
+
+Run from the repository root on the feature branch:
+
+```bash
+git diff --check
+mvn -B -ntp -DskipTests validate
+```
+
+Document any baseline failure honestly in the PR body (module name and first
+meaningful error line). Do not fix unrelated baseline failures inside a
+governance-only PR.
+
+## Required PR checks
+
+The **CI** workflow (`.github/workflows/ci.yml`) must pass on pull requests
+targeting `develop`. The required ruleset status check name is:
+
+- `validate (zulu-8)`
+
+If GitHub displays a different check name (for example `CI / validate (zulu-8)`),
+align the ruleset with the name shown on a completed workflow run.
+
+## Security policy summary
+
+- **No secrets** in the repository, issues, PRs, logs, or attachments.
+- **Dependabot** is enabled for Maven (`/`) and GitHub Actions (`/`), targeting
+  `develop` (see `.github/dependabot.yml`).
+- **GitHub Actions** workflows use least privilege: default `contents: read`
+  at the workflow level unless a documented exception requires more.
+- **Dependabot alerts** and **Dependabot security updates** should stay enabled.
+- **Secret scanning** and **push protection** should be enabled when the account
+  plan supports them.
+- Report vulnerabilities per `SECURITY.md` (private triage before public
+  disclosure).
+
+## Rulesets summary
+
+Repository rulesets (preferred over legacy branch protection):
+
+| Ruleset | Targets | Intent |
+|---------|---------|--------|
+| `protect-develop` | `refs/heads/develop` | PR required, linear history, required CI check, up-to-date branch, conversation resolution, no force-push or deletion. |
+| `protect-stable-branches` | `refs/heads/master`, `refs/heads/main` (if present) | PR required, linear history, no force-push or deletion. |
+| `protect-release-tags` | `refs/tags/v*` | Prevent tag deletion and non-fast-forward updates; restrict tag changes where supported. |
+
+See `docs/github-rulesets/` for API payloads when rulesets must be applied
+manually.
+
+## Out of scope for governance PRs
+
+- Java baseline migration beyond Java 8.
+- Plugin or provider modernization.
+- Maven artifact repository migration (HBTV-004).
+- Runtime updater URL or layout changes (HBTV-005).
+
+Tracker items and ADRs in `docs/dev-tracker.md` and `docs/decision-log.md`
+govern when those areas may change.
+
+## Related documentation
+
+- `AGENTS.md` — agent and contributor workflow.
+- `docs/github-repository-settings.md` — historical bootstrap notes (superseded
+  in part by this document for day-to-day governance).
+- `SECURITY.md` — vulnerability reporting.
+- `.github/pull_request_template.md` — PR checklist.
+
+## Manual ruleset setup
+
+If `gh api` rejects a ruleset payload, apply rules in the GitHub UI:
+
+1. Open **Settings → Rules → Rulesets**.
+2. Create or edit each ruleset using the JSON files under `docs/github-rulesets/`.
+3. For `protect-develop`, under **Require status checks**, add the check name
+   exactly as shown on a green CI run after merging the CI workflow.
+4. Set **Required approving reviews** to `0` for a single-maintainer repository
+   while keeping **Require a pull request before merging** enabled.
+5. Enable **Require conversation resolution before merging** on `develop`.
+
+Record any API error message in the PR body under **Manual settings still required**.


### PR DESCRIPTION
## Summary

- Adds repository governance documentation.
- Adds PR, issue, security, CODEOWNERS, and Dependabot configuration.
- Adds a Java 8 Maven validation workflow.
- Documents and/or applies GitHub repository settings, branch rulesets, and security settings.

## Scope

- Repository governance
- Branch and ruleset baseline
- Security posture
- CI baseline

## Out of scope

- Java migration
- Plugin modernization
- Maven artifact repository migration
- Runtime updater changes
- Provider endpoint fixes

## Validation

`git diff --check` — exit 0 (no whitespace errors).

`mvn -B -ntp -DskipTests validate` — BUILD SUCCESS (all 33 reactor modules).

```text
gh repo view Mika3578/habitv --json defaultBranchRef,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,deleteBranchOnMerge
{"defaultBranchRef":{"name":"develop"},"deleteBranchOnMerge":true,"mergeCommitAllowed":false,"rebaseMergeAllowed":true,"squashMergeAllowed":true}

gh api repos/Mika3578/habitv/rulesets --jq '.[] | {id,name,target,enforcement}'
{"enforcement":"active","id":16532913,"name":"protect-develop","target":"branch"}
{"enforcement":"active","id":16533783,"name":"protect-release-tags","target":"tag"}
{"enforcement":"active","id":16532778,"name":"protect-stable-branches","target":"branch"}
```

## GitHub settings applied

- Default branch: `develop` (already set; confirmed).
- Merge commits disabled; squash and rebase merge enabled; delete branch on merge enabled.
- Auto-merge enabled on the repository.
- Dependabot security updates and secret scanning were already enabled on the repository.
- Repository Actions default workflow permissions set to `read` (contents read-only by default).
- Rulesets updated/created via API:
  - `protect-develop` (id 16532913) — PR, linear history, `validate (zulu-8)` required, conversation resolution, no force-push/deletion.
  - `protect-stable-branches` (id 16532778) — `refs/heads/master`.
  - `protect-release-tags` (id 16533783) — `refs/tags/v*`.

## Manual settings still required

- After the first green **CI** run on this PR, confirm the required status check name in **protect-develop** matches GitHub’s displayed check (e.g. `CI / validate (zulu-8)` vs `validate (zulu-8)`). Update the ruleset if they differ.
- Legacy `.github/workflows/build.yml` still targets `master`; retire or retarget separately if redundant with `ci.yml`.
- Private vulnerability reporting: enable under **Settings → Security** if not already visible for this repository plan.
- Dependabot version updates for Maven/Actions begin after this PR merges and Dependabot processes `.github/dependabot.yml`.

## Risk

Low. This PR mainly adds repository metadata, documentation, templates, and CI governance. Runtime behavior is unchanged.

## Rollback

Revert this PR and remove any GitHub rulesets/settings created during the task if needed.
