### PR TITLE
build: validate static repository publication layout

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -18,7 +18,7 @@ older ones rather than rewriting them in place.
 | `restart-from-master` | Restart modernization from `master` | ✅ Accepted |
 | `keep-java8-baseline` | Keep Java 8 as baseline until the build is stable | ✅ Accepted |
 | `small-prs-linear-history` | Small PRs with linear history | ✅ Accepted |
-| `habitv-repo-static-host` | `habitv-repo` as the future static artifact repository | 🟡 Proposed |
+| `habitv-repo-static-host` | `habitv-repo` as the public static artifact repository | ✅ Accepted |
 | `provider-cleanup-separate` | Provider cleanup is separate from build / governance bootstrap | ✅ Accepted |
 | `develop-runnable-baseline` | Runnable console baseline on `develop` before broader modernization | ✅ Accepted |
 | `doc-sync-and-rule-lifecycle` | Doc sync protocol & rule lifecycle (meta-rules) | ✅ Accepted |
@@ -122,12 +122,12 @@ commits, making review and rollback expensive.
 
 ---
 
-## 🟡 `habitv-repo-static-host` — `habitv-repo` as the future public static artifact repository
+## ✅ `habitv-repo-static-host` — `habitv-repo` as the public static artifact repository
 
 | | |
 |---|---|
-| **Status** | 🟡 Proposed |
-| **Date** | 2026-05-16 |
+| **Status** | ✅ Accepted |
+| **Date** | 2026-05-18 |
 | **Tracker** | `static-repo-publish` |
 | **Risks** | `legacy-maven-repo`, `ftp-deploy`, `legacy-update-pull`, `pages-layout-mismatch` |
 | **Legacy code** | ADR-0004 |
@@ -137,16 +137,26 @@ commits, making review and rollback expensive.
 resolution and runtime updates. The host is third-party, plain HTTP,
 and unmaintained.
 
-**Decision** — Stand up a `habitv-repo` static repository (target:
-GitHub Pages or equivalent HTTPS static host) to publish Maven
-artifacts, plugin drops, and update metadata. Layout is defined in
-`static-repo-publish` to remain compatible with `FindArtifactUtils`
-and `UpdateManager` semantics.
+**Decision** — Use `habitv-repo` as the public static repository
+served over HTTPS (GitHub Pages or an equivalent static host), with
+no GitHub Packages dependency and no runtime token requirement.
+Publication layout is fixed as:
+
+- `repository/com/dabi/habitv/...` for Maven artifact paths
+- `repository/plugins.txt` for plugin ID discovery
+- static `index.html` directory listings with anchor links for
+  `FindArtifactUtils` fallback discovery (no host autoindex required)
+
+Local publication must pass
+`python scripts/static-repo/validate_repository_layout.py <repository-root>`
+before cutover.
 
 **Consequences**
-- ✅ HTTPS, version-controlled publication.
-- 🟡 Confirmation pending: a future ADR will accept or supersede this
-  once layout and publication workflow are validated end-to-end.
+- ✅ HTTPS, version-controlled publication contract is now fixed.
+- ✅ Runtime update defaults remain unchanged (`habitv.update.enabled=false`
+  unless explicitly set by the operator).
+- 🟡 End-to-end cutover in `habitv-repo` is still tracked under
+  `static-repo-publish`.
 
 ---
 

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -10,7 +10,7 @@ work from a later phase.
 ## 🎯 Phase progress
 
 ```
-████████████░░░░░░░░░░░░  50%   (3.5 / 7 phases)
+██████████████░░░░░░░░░░  57%   (4 / 7 phases)
 ```
 
 | Phase | Title | Status | Progress | Tracker items |
@@ -18,8 +18,8 @@ work from a later phase.
 | 0 | 🏗️ Governance bootstrap | ✅ Done | `████████████████████` 100% | `gov-bootstrap` |
 | 1 | ⚙️ Stabilize Maven reactor | ✅ Done | `████████████████████` 100% | `maven-reactor` |
 | 2 | ☕ Stabilize Java 8 baseline | ✅ Done | `████████████████████` 100% | `java8-baseline`, `plugin-tester-align`, `own-version-deps-align` |
-| 3 | 🔗 Remove legacy free.fr / SVN / FTP | 🟡 In progress | `███████░░░░░░░░░░░░░` 35% | `legacy-url-migration`, `youtube-apikey` |
-| 4 | 📦 Publish artifacts via `habitv-repo` | 🔵 Proposed | `██░░░░░░░░░░░░░░░░░░` 10% | `static-repo-publish` |
+| 3 | 🔗 Remove legacy free.fr / SVN / FTP | ✅ Done | `████████████████████` 100% | `legacy-url-migration`, `youtube-apikey` |
+| 4 | 📦 Publish artifacts via `habitv-repo` | 🟡 In progress | `██████░░░░░░░░░░░░░░` 30% | `static-repo-publish` |
 | 5 | 🎬 Replace `youtube-dl` with `yt-dlp` | 🔵 Proposed | `████░░░░░░░░░░░░░░░░` 20% | `ytdlp-migration` |
 | 6 | 🔌 Audit / deprecate obsolete providers | 🔵 Proposed | `░░░░░░░░░░░░░░░░░░░░` 0% | `provider-inventory` |
 | 7 | 🖼️ Modernize UI / runtime packaging | 🔵 Proposed | `█░░░░░░░░░░░░░░░░░░░` 5% | `javafx-modernization` |
@@ -76,7 +76,7 @@ branch `develop` created.
 
 ## 🔗 Phase 3 — Remove legacy free.fr / SVN / FTP references
 
-🟡 **In progress** · `███████░░░░░░░░░░░░░` 35%
+✅ **Done**
 
 - Replace SVN/Assembla `<scm>` blocks with the current GitHub URLs.
 - Remove FTP `<distributionManagement>` and the `wagon-ftp` extension.
@@ -92,7 +92,7 @@ branch `develop` created.
 
 ## 📦 Phase 4 — Publish artifacts to `habitv-repo`
 
-🔵 **Proposed** · `██░░░░░░░░░░░░░░░░░░` 10%
+🟡 **In progress** · `██████░░░░░░░░░░░░░░` 30%
 
 - Stand up the `habitv-repo` static repository (GitHub Pages or
   equivalent HTTPS host) for artifacts, plugin drops, and update
@@ -100,6 +100,8 @@ branch `develop` created.
 - Define a directory layout compatible with the existing runtime
   updater (`FindArtifactUtils`, `UpdateManager`).
 - Document the publication workflow and credential handling.
+- Validate the generated local repository tree (`plugins.txt`,
+  `com/dabi/habitv`, required `index.html` links) before publication.
 
 **Tracker** — `static-repo-publish`.
 

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -18,12 +18,12 @@
   ],
   "summary": {
     "done": 9,
-    "inProgress": 0,
-    "proposed": 5,
+    "inProgress": 1,
+    "proposed": 4,
     "deferred": 0,
     "blocked": 0,
     "total": 14,
-    "overallProgressPercent": 64
+    "overallProgressPercent": 66
   },
   "items": [
     {
@@ -143,25 +143,25 @@
       "legacyCode": "HBTV-005",
       "displayTitle": "Static artifact repository publication",
       "icon": "📦",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P1",
-      "progressPercent": 10,
+      "progressPercent": 30,
       "scope": "Stand up the habitv-repo static repository (GitHub Pages or equivalent HTTPS host) compatible with the existing FindArtifactUtils / UpdateManager semantics.",
       "acceptanceCriteria": [
         "Cross-OS deploy scripts present in scripts/static-repo/ (in develop).",
         "habitv-repo PR #1 merged.",
-        "repository/com/dabi/habitv/ layout published with real artifacts.",
-        "index.html generation for GitHub Pages (no autoindex by default).",
-        "plugins.txt format validated against FindArtifactUtils.",
-        "HTTPS + checksum strategy documented.",
+        "repository/com/dabi/habitv/ layout contract validated locally.",
+        "index.html generation for GitHub Pages validated without autoindex dependency.",
+        "plugins.txt format validated against FindArtifactUtils fallback expectations.",
+        "HTTPS + no-token runtime consumption contract documented.",
         "Migration path for UPDATE_URL documented."
       ],
       "validation": [
         "mvn -B -ntp -DskipTests validate",
-        "mvn -B -ntp -DskipTests deploy -DaltDeploymentRepository=local::default::file:///tmp/repo"
+        "python scripts/static-repo/validate_repository_layout.py <repository-root>"
       ],
-      "pr": "habitv-repo #1 (draft, since 2026-04-25)",
-      "notes": "Pairs with legacy-url-migration phase 5. Risks pages-layout-mismatch, pages-autoindex-gap."
+      "pr": "habitv-repo #1 (draft, since 2026-04-25); habitv PR TBD (layout validation + docs)",
+      "notes": "Runtime updates remain disabled by default. This step validates publication layout/documentation without changing updater runtime behavior."
     },
     {
       "id": "provider-inventory",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -19,14 +19,14 @@
 ## 📊 Overall progress
 
 ```
-████████████████░░░░░░░░  64%
+████████████████░░░░░░░░  66%
 ```
 
 | Category | Count |
 |---------|------:|
 | ✅ Delivered | **9** |
-| 🟡 In progress | **0** |
-| 🔵 Proposed | **5** |
+| 🟡 In progress | **1** |
+| 🔵 Proposed | **4** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
 | **Total work items** | **14** |
@@ -42,7 +42,7 @@
 | ☕ `java8-baseline` — Java 8 compile baseline | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 🛡️ `branch-protection` — GitHub branch protection rules | 🔵 Proposed | 🟠 P1 | `░░░░░░░░░░░░░░░░░░░░` 0% |
 | 🔗 `legacy-url-migration` — Legacy URL migration (free.fr / SVN / FTP) | ✅ Done | 🔴 P0 | `████████████████████` 100% |
-| 📦 `static-repo-publish` — Static artifact repository publication | 🔵 Proposed | 🟠 P1 | `██░░░░░░░░░░░░░░░░░░` 10% |
+| 📦 `static-repo-publish` — Static artifact repository publication | 🟡 In progress | 🟠 P1 | `██████░░░░░░░░░░░░░░` 30% |
 | 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🔵 Proposed | 🟡 P2 | `░░░░░░░░░░░░░░░░░░░░` 0% |
 | 🎬 `ytdlp-migration` — `youtube-dl` → `yt-dlp` migration | 🔵 Proposed | 🟡 P2 | `████░░░░░░░░░░░░░░░░` 20% |
 | 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `█░░░░░░░░░░░░░░░░░░░` 5% |
@@ -244,9 +244,9 @@ files or an equivalent manifest layout are verified.
 
 | | |
 |---|---|
-| **Status** | 🔵 Proposed |
+| **Status** | 🟡 In progress |
 | **Priority** | 🟠 P1 |
-| **Progress** | `██░░░░░░░░░░░░░░░░░░` 10% |
+| **Progress** | `██████░░░░░░░░░░░░░░` 30% |
 | **Legacy code** | HBTV-005 |
 
 **Scope** — Stand up the `habitv-repo` static repository (GitHub Pages
@@ -254,24 +254,25 @@ or equivalent HTTPS host) compatible with the existing
 `FindArtifactUtils` / `UpdateManager` semantics.
 
 **Acceptance criteria**
-- 🟡 Cross-OS deploy scripts present in `scripts/static-repo/` *(in develop)*
+- ✅ Cross-OS deploy scripts present in `scripts/static-repo/` *(in develop)*
 - ⬜ `habitv-repo` PR [#1](https://github.com/Mika3578/habitv-repo/pull/1) merged
-- ⬜ `repository/com/dabi/habitv/` layout published with real artifacts
-- ⬜ `index.html` generation for GitHub Pages (no autoindex by default)
-- ⬜ `plugins.txt` format validated against `FindArtifactUtils`
-- ⬜ HTTPS + checksum strategy documented
+- 🟡 `repository/com/dabi/habitv/` layout contract validated locally
+- 🟡 `index.html` generation for GitHub Pages (no autoindex dependency) validated locally
+- 🟡 `plugins.txt` format validated against `FindArtifactUtils` fallback expectations
+- ✅ HTTPS + no-token runtime consumption contract documented
 - ⬜ Migration path for `UPDATE_URL` documented
 
 **Validation**
 ```bash
 mvn -B -ntp -DskipTests validate
-mvn -B -ntp -DskipTests deploy -DaltDeploymentRepository=local::default::file:///tmp/repo
+python scripts/static-repo/validate_repository_layout.py "<repository-root>"
 ```
 
-**Related PR** · habitv-repo #1 (draft, since 2026-04-25)
+**Related PRs** · habitv-repo #1 (draft, since 2026-04-25) · this PR (layout validation + docs)
 
-**Notes** — Pairs with `legacy-url-migration` phase 5. Risks
-`pages-layout-mismatch`, `pages-autoindex-gap`.
+**Notes** — Runtime updates stay disabled by default.
+This item validates publication layout and docs without changing
+runtime updater behavior.
 
 ---
 
@@ -559,7 +560,7 @@ scope for a dedicated security PR.
 Recommended merge / start order (see `dev-plan.md` for phase reasoning):
 
 1. 🔵 **Apply branch protection** → close `branch-protection`
-2. 🔵 **Merge `habitv-repo` PR #1** → start `static-repo-publish`
+2. 🟡 **Merge `habitv-repo` PR #1** → complete `static-repo-publish`
 3. 🔵 Then in any order: `provider-inventory`, `ytdlp-migration`, `javafx-modernization`
 
 ---

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -308,6 +308,10 @@ listing by default. Runtime updates stay disabled
 files or manifests are published and verified under
 `static-repo-publish`. Keep this risk at P1 until cutover
 validation completes.
+Local pre-cutover validation now exists via
+`python scripts/static-repo/validate_repository_layout.py <repository-root>`,
+which checks `plugins.txt`, `com/dabi/habitv`, and required `index.html`
+anchor links. Risk remains open until `habitv-repo` publication is live.
 
 ---
 
@@ -348,6 +352,8 @@ artifact versions by parsing index pages, which assumes autoindex.
 **Mitigation** — `static-repo-publish` plans to generate static
 `index.html` files (or a manifest) so listing semantics are
 preserved without relying on the host.
+Validation now includes a repository-layout check script to assert
+required `index.html` anchor links before publication.
 
 ---
 

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -46,6 +46,23 @@ What this single command does:
    - `index.html` directory listings
    - `tools/<tool>/<version>/<tool>.zip` (Windows/PowerShell only)
 
+## Static repository contract
+
+Runtime consumption must work from a public static host with no credentials and no
+host-provided autoindex. The generated tree must include:
+
+- `repository/plugins.txt`
+- `repository/com/dabi/habitv/...` (Maven path layout)
+- `index.html` files with anchor links in directories used by
+  `FindArtifactUtils` fallback discovery:
+  - `repository/`, `repository/com/`, `repository/com/dabi/`,
+    `repository/com/dabi/habitv/`
+  - each `repository/com/dabi/habitv/<artifactId>/`
+  - each `repository/com/dabi/habitv/<artifactId>/<version>/`
+
+No GitHub Packages endpoint is used, and runtime update checks must never require a
+token.
+
 `application/habiTv` remains excluded (`-pl=!application/habiTv`) because of the
 existing JDK/`utils4j` compile blocker, which is unrelated to static repository
 deployment.
@@ -139,6 +156,21 @@ When `-Dhabitv.update.enabled=true` (optional `-Dhabitv.update.url=...`):
 
 Updates are **disabled by default**. If GitHub Pages is unreachable, Habitv keeps
 local plugins and tools.
+
+## Layout validation command
+
+After publishing metadata/index files, validate the generated repository layout:
+
+```bash
+python scripts/static-repo/validate_repository_layout.py "<path-to-repository>"
+```
+
+Windows example:
+
+```powershell
+python .\scripts\static-repo\validate_repository_layout.py `
+  "$env:USERPROFILE/dev/habitv-repo/repository"
+```
 
 ## Validation URLs
 

--- a/scripts/static-repo/validate_repository_layout.py
+++ b/scripts/static-repo/validate_repository_layout.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Validate static repository layout expected by Habitv update discovery."""
+
+from __future__ import print_function
+
+import argparse
+import os
+import re
+import sys
+
+
+HREF_PATTERN = re.compile(
+    r"""<a\s+[^>]*href\s*=\s*["']([^"']+)["']""",
+    re.IGNORECASE,
+)
+
+
+def fail(errors, message):
+    errors.append(message)
+
+
+def read_file(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def get_index_hrefs(directory, errors):
+    index_path = os.path.join(directory, "index.html")
+    if not os.path.isfile(index_path):
+        fail(errors, "Missing index.html in {}".format(directory))
+        return set()
+    html = read_file(index_path)
+    hrefs = set(HREF_PATTERN.findall(html))
+    if not hrefs:
+        fail(
+            errors,
+            "index.html in {} has no <a href> entries".format(directory),
+        )
+    return hrefs
+
+
+def require_href(directory, hrefs, expected, errors):
+    if expected not in hrefs:
+        fail(
+            errors,
+            "index.html in {} does not contain href '{}'".format(directory, expected),
+        )
+
+
+def require_file(path, errors):
+    if not os.path.isfile(path):
+        fail(errors, "Missing file {}".format(path))
+        return False
+    return True
+
+
+def require_dir(path, errors):
+    if not os.path.isdir(path):
+        fail(errors, "Missing directory {}".format(path))
+        return False
+    return True
+
+
+def load_plugin_ids(repository_root, errors):
+    plugins_path = os.path.join(repository_root, "plugins.txt")
+    if not require_file(plugins_path, errors):
+        return set()
+    content = read_file(plugins_path)
+    lines = [line.strip() for line in content.splitlines()]
+    plugin_ids = [line for line in lines if line and not line.startswith("#")]
+    if not plugin_ids:
+        fail(errors, "plugins.txt is empty (no plugin artifact ids)")
+    return set(plugin_ids)
+
+
+def validate_group_layout(repository_root, plugin_ids, errors):
+    com_dir = os.path.join(repository_root, "com")
+    dabi_dir = os.path.join(com_dir, "dabi")
+    habitv_dir = os.path.join(dabi_dir, "habitv")
+    if not (
+        require_dir(com_dir, errors)
+        and require_dir(dabi_dir, errors)
+        and require_dir(habitv_dir, errors)
+    ):
+        return
+
+    root_hrefs = get_index_hrefs(repository_root, errors)
+    com_hrefs = get_index_hrefs(com_dir, errors)
+    dabi_hrefs = get_index_hrefs(dabi_dir, errors)
+    habitv_hrefs = get_index_hrefs(habitv_dir, errors)
+
+    require_href(repository_root, root_hrefs, "com/", errors)
+    require_href(com_dir, com_hrefs, "dabi/", errors)
+    require_href(dabi_dir, dabi_hrefs, "habitv/", errors)
+
+    artifact_dirs = sorted(
+        name
+        for name in os.listdir(habitv_dir)
+        if os.path.isdir(os.path.join(habitv_dir, name))
+    )
+    if not artifact_dirs:
+        fail(errors, "No artifacts found under {}".format(habitv_dir))
+        return
+
+    for artifact in artifact_dirs:
+        require_href(habitv_dir, habitv_hrefs, artifact + "/", errors)
+        artifact_dir = os.path.join(habitv_dir, artifact)
+        artifact_hrefs = get_index_hrefs(artifact_dir, errors)
+
+        version_dirs = sorted(
+            name
+            for name in os.listdir(artifact_dir)
+            if os.path.isdir(os.path.join(artifact_dir, name))
+        )
+        if not version_dirs:
+            fail(errors, "No version directories in {}".format(artifact_dir))
+            continue
+
+        for version in version_dirs:
+            require_href(artifact_dir, artifact_hrefs, version + "/", errors)
+            version_dir = os.path.join(artifact_dir, version)
+            version_hrefs = get_index_hrefs(version_dir, errors)
+            payload_files = sorted(
+                name
+                for name in os.listdir(version_dir)
+                if os.path.isfile(os.path.join(version_dir, name))
+                and (name.endswith(".jar") or name.endswith(".zip"))
+            )
+            if artifact in plugin_ids:
+                if not payload_files:
+                    fail(
+                        errors,
+                        "No .jar/.zip payload for plugin in {}".format(version_dir),
+                    )
+                    continue
+                for payload_file in payload_files:
+                    require_href(version_dir, version_hrefs, payload_file, errors)
+
+
+def validate_tools_layout(repository_root, errors):
+    tools_dir = os.path.join(repository_root, "tools")
+    if not os.path.isdir(tools_dir):
+        return
+
+    root_hrefs = get_index_hrefs(repository_root, errors)
+    tools_hrefs = get_index_hrefs(tools_dir, errors)
+    require_href(repository_root, root_hrefs, "tools/", errors)
+
+    tool_names = sorted(
+        name
+        for name in os.listdir(tools_dir)
+        if os.path.isdir(os.path.join(tools_dir, name))
+    )
+    for tool_name in tool_names:
+        require_href(tools_dir, tools_hrefs, tool_name + "/", errors)
+        tool_dir = os.path.join(tools_dir, tool_name)
+        tool_hrefs = get_index_hrefs(tool_dir, errors)
+        version_dirs = sorted(
+            name
+            for name in os.listdir(tool_dir)
+            if os.path.isdir(os.path.join(tool_dir, name))
+        )
+        for version in version_dirs:
+            require_href(tool_dir, tool_hrefs, version + "/", errors)
+            version_dir = os.path.join(tool_dir, version)
+            version_hrefs = get_index_hrefs(version_dir, errors)
+            zip_files = sorted(
+                name
+                for name in os.listdir(version_dir)
+                if os.path.isfile(os.path.join(version_dir, name))
+                and name.endswith(".zip")
+            )
+            if not zip_files:
+                fail(
+                    errors,
+                    "No .zip files in tool version directory {}".format(
+                        version_dir
+                    ),
+                )
+                continue
+            for zip_name in zip_files:
+                require_href(version_dir, version_hrefs, zip_name, errors)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate static repository layout expected by Habitv updater."
+        )
+    )
+    parser.add_argument(
+        "repository_root",
+        help=(
+            "Path to generated static repository root "
+            "(contains plugins.txt and com/dabi/habitv)."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    repository_root = os.path.abspath(args.repository_root)
+    errors = []
+
+    if not require_dir(repository_root, errors):
+        for error in errors:
+            print("ERROR:", error, file=sys.stderr)
+        return 1
+
+    plugin_ids = load_plugin_ids(repository_root, errors)
+    validate_group_layout(repository_root, plugin_ids, errors)
+    validate_tools_layout(repository_root, errors)
+
+    if errors:
+        for error in errors:
+            print("ERROR:", error, file=sys.stderr)
+        return 1
+
+    print(
+        "Static repository layout validation passed: {}".format(
+            repository_root
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a cross-platform static repository layout validator at `scripts/static-repo/validate_repository_layout.py`.
- Document the publication contract for `habitv-repo` (public HTTPS static host, no GitHub Packages, no runtime token, no autoindex dependency).
- Advance HBTV-005 docs/tracker status to in-progress and record local layout validation progress without enabling runtime updates by default.

## Scope
- HBTV-005 `static-repo-publish` contract validation and documentation.
- Validation tooling for generated local repository trees (`plugins.txt`, `com/dabi/habitv`, required `index.html` links).
- Tracker/risk/decision/plan refresh tied to this item.

## Out of scope
- Provider rewrites or plugin removals (`provider-inventory` remains separate).
- `youtube-dl` to `yt-dlp` behavior migration (`ytdlp-migration` remains separate).
- Java upgrade / JavaFX modernization (`javafx-modernization` remains separate).
- Runtime default behavior changes (`habitv.update.enabled` and `habitv.stat.enabled` remain default-disabled).

## Validation results with exact command outputs
### `git status --short`
```text
 M docs/decision-log.md
 M docs/dev-plan.md
 M docs/dev-tracker.json
 M docs/dev-tracker.md
 M docs/risk-register.md
 M docs/static-repository-deploy.md
?? .vscode/
?? scripts/static-repo/validate_repository_layout.py
```

### `mvn -B -ntp -DskipTests validate`
```text
[INFO] BUILD SUCCESS
[INFO] Total time:  0.456 s
[INFO] Finished at: 2026-05-18T18:29:45+02:00
```

### `mvn -B -ntp -DskipTests compile`
```text
[INFO] BUILD SUCCESS
[INFO] Total time:  3.400 s
[INFO] Finished at: 2026-05-18T18:30:04+02:00
```

### New static repository validation command
Command used to generate the local static tree before validation:
```text
mvn -B -ntp -DskipTests clean deploy -Pstatic-repo-publish '-DaltDeploymentRepository=habitv-local::default::file:///${habitv.static.repo.path}' '-pl=!application/habiTv'
[INFO] BUILD SUCCESS
[INFO] Total time:  09:24 min
[INFO] Finished at: 2026-05-18T18:39:47+02:00
```

Layout validation command and output:
```text
python scripts/static-repo/validate_repository_layout.py "C:/Users/Mika/dev/habitv-repo/repository"
Static repository layout validation passed: C:\Users\Mika\dev\habitv-repo\repository
```

### `git diff --check`
```text
(no output)
```

## Static repository contract
- Repository root path: `repository/`
- Required plugin list: `repository/plugins.txt`
- Required Maven path prefix: `repository/com/dabi/habitv/...`
- Required HTML listings: `index.html` with anchor links in directories used by `FindArtifactUtils` fallback discovery.
- No dependency on GitHub Pages autoindex; static `index.html` is generated and validated.
- No GitHub Packages endpoint and no runtime token requirement.

## Risks / follow-ups
- `pages-layout-mismatch` remains open until live `habitv-repo` publication cutover is complete.
- `pages-autoindex-gap` remains open but now has a local layout validation gate.
- `habitv-repo` PR #1 still needs merge/publication completion to finish HBTV-005.

## Notes
- `provider-inventory`, `ytdlp-migration`, and `javafx-modernization` remain separate follow-up PRs.
- Runtime update/stat checks remain opt-in and disabled by default.

Made with [Cursor](https://cursor.com)