### PR TITLE
fix(updater): honor &lt;updateOnStartup&gt; at launch via opt-out switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 |------|--------|--------|
 | 2026-05-17 | `7a61dd6` | Add runnable yt-dlp runtime path for `consoleView` |
 
+### 🐛 Fixes
+
+| Date | Commit | Change |
+|------|--------|--------|
+| 2026-05-18 | _pending_ | Honor `<updateOnStartup>true</updateOnStartup>` at double-click launch — `habitv.update.enabled` is now an opt-out (`=false` only) instead of an opt-in (`update-default-enabled` ADR) |
+
 ### 🧪 Tests
 
 | Date | Commit | Change |

--- a/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
+++ b/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
@@ -44,8 +44,11 @@ public class UpdateManager {
 	}
 
 	public void process() {
-		if (!Boolean.getBoolean(FrameworkConf.UPDATE_ENABLED_PROPERTY)) {
-			LOG.debug("Plugin update check is disabled.");
+		final String enabledOverride = System.getProperty(
+				FrameworkConf.UPDATE_ENABLED_PROPERTY);
+		if ("false".equalsIgnoreCase(enabledOverride)) {
+			LOG.info("Plugin update check is disabled by system property '"
+					+ FrameworkConf.UPDATE_ENABLED_PROPERTY + "=false'.");
 			return;
 		}
 		final String updateSite = System.getProperty(

--- a/application/core/test/com/dabi/habitv/core/updater/UpdateManagerTest.java
+++ b/application/core/test/com/dabi/habitv/core/updater/UpdateManagerTest.java
@@ -42,8 +42,8 @@ public class UpdateManagerTest {
 	}
 
 	@Test
-	public void processSkipsWhenUpdatesDisabled() {
-		System.clearProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY);
+	public void processSkipsWhenUpdatesExplicitlyDisabled() {
+		System.setProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY, "false");
 		System.setProperty(FrameworkConf.UPDATE_URL_PROPERTY, "https://updates.must-not-be-used.example/repository/");
 
 		final AtomicInteger notifications = new AtomicInteger();

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -24,6 +24,7 @@ older ones rather than rewriting them in place.
 | `doc-sync-and-rule-lifecycle` | Doc sync protocol & rule lifecycle (meta-rules) | ✅ Accepted |
 | `descriptive-slug-ids` | Switch tracker / risk / ADR identifiers to descriptive slugs | ✅ Accepted |
 | `legacy-dabiboo-svn-removal` | Remove active legacy DabiBoo/SVN wiring from build and runtime paths | ✅ Accepted |
+| `update-default-enabled` | Honor `<updateOnStartup>` at launch; `habitv.update.enabled` becomes an explicit opt-out | 🟡 Proposed |
 
 ---
 
@@ -420,6 +421,68 @@ updates by default behind `habitv.update.enabled` with optional
   `index.html` or manifest files on GitHub Pages.
 - ✅ Functional Maven/publication cutover remains a separate
   `static-repo-publish` item.
+
+---
+
+## 🟡 `update-default-enabled` — Honor `<updateOnStartup>` at launch; `habitv.update.enabled` becomes an explicit opt-out
+
+| | |
+|---|---|
+| **Status** | 🟡 Proposed |
+| **Date** | 2026-05-18 |
+| **Tracker** | `legacy-url-migration` |
+| **Risks** | `legacy-update-pull`, `pages-layout-mismatch` |
+| **Supersedes** | partially `legacy-dabiboo-svn-removal` (the "disable runtime plugin updates by default behind `habitv.update.enabled`" clause only) |
+
+**Context** — `configuration.xml` ships with
+`<updateOnStartup>true</updateOnStartup>` and `XMLUserConfig` defaults
+to `true` even when the element is absent. The launchers
+(`ConsoleLauncher.init()`, `UpdateController.RunHabitvTask.call()`)
+correctly route the call to `CoreManager.update()` →
+`PluginManager.update()` → `UpdateManager.process()`. However,
+`UpdateManager.process()` opens with
+`if (!Boolean.getBoolean("habitv.update.enabled")) return;`, which
+short-circuits at every double-click launch because the JVM property
+is not set. The net effect is that JAR plugin updates are silently
+skipped while the XML config and UI splash say "updating".
+
+**Decision** — Invert the system-property gate. The property now acts
+as an explicit kill-switch (opt-out) rather than an opt-in:
+
+| `habitv.update.enabled` value | Behavior |
+|---|---|
+| unset (default) | run, gated upstream by `<updateOnStartup>` |
+| `true` | run (same as unset) |
+| `false` (case-insensitive) | skip with `INFO` log |
+| anything else | run (defensive: trust upstream gate) |
+
+The `<updateOnStartup>false</updateOnStartup>` XML setting remains the
+per-installation way to disable the feature. `-Dhabitv.update.enabled=false`
+remains the global JVM-level kill-switch for operators.
+
+**Consequences**
+- ✅ `<updateOnStartup>true</updateOnStartup>` is no longer a no-op at
+  double-click launch.
+- ⚠️ Repository layout work (`static-repo-publish`) is no longer the
+  hard gate. Safety now relies on the graceful fallback in
+  `UpdateManager.resolvePluginsToUpdate()` — if `plugins.txt` is
+  missing AND the manifest is empty or unreachable, `process()`
+  logs `"No plugins listed for update; keeping local plugins."`
+  and exits without touching local files (`UpdateManager.java:60-62`).
+- ⚠️ Operators who relied on "absent property = disabled" must now
+  set `-Dhabitv.update.enabled=false` explicitly to preserve the
+  prior behavior.
+- ✅ External tools (ZipExeUpdater path) were never gated by this
+  property; their behavior is unchanged (Windows-only, opt-in via
+  `<updateOnStartup>`).
+- ✅ `legacy-update-pull` mitigation is updated in
+  `risk-register.md` with a 2026-05-18 status note.
+
+**Validation** — `UpdateManagerTest.processSkipsWhenUpdatesExplicitlyDisabled`
+covers the explicit `=false` opt-out path. The unset/default path is
+not unit-tested because it would require the live repository or a
+fixture HTTP server; the existing graceful-fallback log
+(`"keeping local plugins"`) is the user-visible signal.
 
 ---
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -223,6 +223,16 @@ base URL constant is `https://mika3578.github.io/habitv-repo/repository`
 `static-repo-publish` publishes Apache-style directory indexes or an
 equivalent manifest layout.
 
+**Status update (`update-default-enabled`, 2026-05-18)** —
+`habitv.update.enabled` flipped from opt-in to opt-out so the
+`<updateOnStartup>true</updateOnStartup>` XML setting is actually
+honored at double-click launch. The kill-switch is preserved as
+`-Dhabitv.update.enabled=false`. Repository layout work remains
+gated under `static-repo-publish`; the gating mechanism is now the
+absence of usable directory listings (404 / empty manifest), which
+keeps `keeping local plugins` as a safe fallback (UpdateManager.java
+line 61) rather than a hard property check.
+
 ---
 
 ## 🟡 Open — Medium / Low priority

--- a/docs/runtime-quickstart.md
+++ b/docs/runtime-quickstart.md
@@ -128,8 +128,13 @@ plugin itself is fully wired (see
 `plugins/youtube/test/.../YoutubePluginDownloaderCmdTest.java`); the
 limitation is purely network policy of the runtime environment.
 
-Startup telemetry and plugin update checks are disabled by default.
-Enable only when needed: `-Dhabitv.stat.enabled=true`
-`-Dhabitv.stat.url=...` and/or `-Dhabitv.update.enabled=true`
-(optional `-Dhabitv.update.url=...`). Do not enable updates until
-HBTV-005 publishes verified static directory indexes.
+Startup telemetry is disabled by default. Enable only when needed:
+`-Dhabitv.stat.enabled=true` `-Dhabitv.stat.url=...`.
+
+Plugin update checks now follow the `<updateOnStartup>` setting in
+`configuration.xml` (defaults to `true` when the element is absent).
+The `habitv.update.enabled` system property is an explicit opt-out:
+set `-Dhabitv.update.enabled=false` to keep the kill-switch behavior
+needed while `static-repo-publish` has not yet published verified
+static directory indexes or the equivalent manifest. See the
+`update-default-enabled` ADR.


### PR DESCRIPTION
## Summary

`UpdateManager.process()` short-circuited on every double-click launch
because `Boolean.getBoolean("habitv.update.enabled")` returned `false`
whenever the system property was unset, even though `configuration.xml`
shipped `<updateOnStartup>true</updateOnStartup>` (and `XMLUserConfig`
defaults to `true` when the element is absent).

The XML config + UI splash claimed updates were running while the JAR
plugin update path silently skipped at line 47 — a documented
inconsistency the user hit while verifying double-click behavior on
the executable jar (`HabitvLauncher` → `HabiTvViewRunner` →
`UpdateController.RunHabitvTask.call()` → `PluginManager.update()` →
`UpdateManager.process()`).

## Change

Invert the system-property gate so it acts as an explicit kill-switch
(opt-out) rather than an opt-in:

| `habitv.update.enabled` value | Behavior |
|---|---|
| unset (default) | run, gated upstream by `<updateOnStartup>` |
| `true` | run |
| `false` (case-insensitive) | skip with `INFO` log |
| anything else | run (defensive: trust upstream gate) |

The `<updateOnStartup>false</updateOnStartup>` XML setting remains the
per-installation way to disable the feature. `-Dhabitv.update.enabled=false`
remains the global JVM-level kill-switch for operators.

The graceful fallback in `resolvePluginsToUpdate()` keeps local plugins
when `plugins.txt` and the manifest are missing or unreachable
(`UpdateManager.java:60-62`), which is now the safety net against the
still-pending `static-repo-publish` layout work.

## Trackers / risks / ADRs touched

- 📦 Tracker — `legacy-url-migration`
- 🚨 Risk — `legacy-update-pull` (status update added 2026-05-18)
- 🧭 ADR — `update-default-enabled` (🟡 Proposed; partially supersedes
  the "disable updates by default" clause of `legacy-dabiboo-svn-removal`)

## Files

- `application/core/src/com/dabi/habitv/core/updater/UpdateManager.java` — gate inversion
- `application/core/test/com/dabi/habitv/core/updater/UpdateManagerTest.java` — `processSkipsWhenUpdatesDisabled` renamed to `processSkipsWhenUpdatesExplicitlyDisabled` and switched from `clearProperty` to `setProperty("false")`
- `CHANGELOG.md` — new `🐛 Fixes` row under Unreleased
- `docs/runtime-quickstart.md` — rewrite the §131-135 block that
  documented the old opt-in behavior
- `docs/risk-register.md` — `legacy-update-pull` status update
- `docs/decision-log.md` — new ADR `update-default-enabled` + dashboard entry

## Validation results

```
$ mvn -B -ntp -DskipTests validate
[INFO] BUILD SUCCESS (33 modules, 2.6s)
```

Direct `javac` compile of `UpdateManager.java` + its direct dependencies
succeeds with no warnings.

`mvn compile -pl application/core` fails with a **pre-existing** error
in `application/core/src/com/dabi/habitv/core/dao/GrabConfigDAO.java`
(`cannot find symbol: method getDeleted()` on
`com.dabi.habitv.grabconfig.entities.Plugin`). Verified by stashing
my changes and re-running — same failure on the unmodified branch.
This is unrelated to the updater path and out of scope here.

## Test plan

- [ ] `mvn -B -ntp -DskipTests validate` — 🟢 green locally
- [ ] CI runs the standard `java8-baseline` workflow
- [ ] Manual smoke test: double-click on the produced fat jar with the
      default `configuration.xml` should hit `Checking plugin updates...`
      INFO log (was: `Plugin update check is disabled.` debug log)
- [ ] Manual smoke test: with `-Dhabitv.update.enabled=false`, observe
      `Plugin update check is disabled by system property 'habitv.update.enabled=false'.`
      INFO log


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBLKbDFBetHyttb7C3RXy6)_