### PR TITLE
docs: complete static repository publication tracking

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -155,8 +155,12 @@ before cutover.
 - ✅ HTTPS, version-controlled publication contract is now fixed.
 - ✅ Runtime update defaults remain unchanged (`habitv.update.enabled=false`
   unless explicitly set by the operator).
-- 🟡 End-to-end cutover in `habitv-repo` is still tracked under
-  `static-repo-publish`.
+- ✅ End-to-end publication cutover completed via
+  `https://github.com/Mika3578/habitv-repo/pull/2` with live Pages
+  validation for `/repository/`, `/repository/plugins.txt`, and
+  `/repository/com/dabi/habitv/`.
+- ⚠️ One dedicated opt-in runtime update smoke test remains recommended
+  (keep default runtime updates disabled).
 
 ---
 

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -10,7 +10,7 @@ work from a later phase.
 ## 🎯 Phase progress
 
 ```
-██████████████░░░░░░░░░░  57%   (4 / 7 phases)
+█████████████████░░░░░░░  71%   (5 / 7 phases)
 ```
 
 | Phase | Title | Status | Progress | Tracker items |
@@ -19,7 +19,7 @@ work from a later phase.
 | 1 | ⚙️ Stabilize Maven reactor | ✅ Done | `████████████████████` 100% | `maven-reactor` |
 | 2 | ☕ Stabilize Java 8 baseline | ✅ Done | `████████████████████` 100% | `java8-baseline`, `plugin-tester-align`, `own-version-deps-align` |
 | 3 | 🔗 Remove legacy free.fr / SVN / FTP | ✅ Done | `████████████████████` 100% | `legacy-url-migration`, `youtube-apikey` |
-| 4 | 📦 Publish artifacts via `habitv-repo` | 🟡 In progress | `██████░░░░░░░░░░░░░░` 30% | `static-repo-publish` |
+| 4 | 📦 Publish artifacts via `habitv-repo` | ✅ Done | `████████████████████` 100% | `static-repo-publish` |
 | 5 | 🎬 Replace `youtube-dl` with `yt-dlp` | 🔵 Proposed | `████░░░░░░░░░░░░░░░░` 20% | `ytdlp-migration` |
 | 6 | 🔌 Audit / deprecate obsolete providers | 🔵 Proposed | `░░░░░░░░░░░░░░░░░░░░` 0% | `provider-inventory` |
 | 7 | 🖼️ Modernize UI / runtime packaging | 🔵 Proposed | `█░░░░░░░░░░░░░░░░░░░` 5% | `javafx-modernization` |
@@ -92,7 +92,7 @@ branch `develop` created.
 
 ## 📦 Phase 4 — Publish artifacts to `habitv-repo`
 
-🟡 **In progress** · `██████░░░░░░░░░░░░░░` 30%
+✅ **Done** · `████████████████████` 100%
 
 - Stand up the `habitv-repo` static repository (GitHub Pages or
   equivalent HTTPS host) for artifacts, plugin drops, and update
@@ -102,6 +102,9 @@ branch `develop` created.
 - Document the publication workflow and credential handling.
 - Validate the generated local repository tree (`plugins.txt`,
   `com/dabi/habitv`, required `index.html` links) before publication.
+- Validate live GitHub Pages URLs:
+  `https://mika3578.github.io/habitv-repo/repository/`,
+  `.../plugins.txt`, and `.../com/dabi/habitv/`.
 
 **Tracker** — `static-repo-publish`.
 

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -17,13 +17,13 @@
     "P3"
   ],
   "summary": {
-    "done": 9,
-    "inProgress": 1,
+    "done": 10,
+    "inProgress": 0,
     "proposed": 4,
     "deferred": 0,
     "blocked": 0,
     "total": 14,
-    "overallProgressPercent": 66
+    "overallProgressPercent": 73
   },
   "items": [
     {
@@ -143,16 +143,16 @@
       "legacyCode": "HBTV-005",
       "displayTitle": "Static artifact repository publication",
       "icon": "📦",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P1",
-      "progressPercent": 30,
+      "progressPercent": 100,
       "scope": "Stand up the habitv-repo static repository (GitHub Pages or equivalent HTTPS host) compatible with the existing FindArtifactUtils / UpdateManager semantics.",
       "acceptanceCriteria": [
         "Cross-OS deploy scripts present in scripts/static-repo/ (in develop).",
-        "habitv-repo PR #1 merged.",
-        "repository/com/dabi/habitv/ layout contract validated locally.",
-        "index.html generation for GitHub Pages validated without autoindex dependency.",
-        "plugins.txt format validated against FindArtifactUtils fallback expectations.",
+        "habitv-repo PR #2 merged.",
+        "repository/com/dabi/habitv/ layout contract validated locally and published.",
+        "index.html generation for GitHub Pages validated without autoindex dependency (local + live).",
+        "plugins.txt format validated against FindArtifactUtils fallback expectations (local + live).",
         "HTTPS + no-token runtime consumption contract documented.",
         "Migration path for UPDATE_URL documented."
       ],
@@ -160,8 +160,8 @@
         "mvn -B -ntp -DskipTests validate",
         "python scripts/static-repo/validate_repository_layout.py <repository-root>"
       ],
-      "pr": "habitv-repo #1 (draft, since 2026-04-25); habitv PR TBD (layout validation + docs)",
-      "notes": "Runtime updates remain disabled by default. This step validates publication layout/documentation without changing updater runtime behavior."
+      "pr": "habitv-repo #2 (merged); habitv PR TBD (publication status + tracker refresh)",
+      "notes": "Runtime updates remain disabled by default. Publication cutover is live on GitHub Pages with token-free HTTPS access. Remaining follow-up: run one dedicated opt-in runtime update smoke test with habitv.update.enabled=true against the published URL."
     },
     {
       "id": "provider-inventory",

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -160,7 +160,7 @@
         "mvn -B -ntp -DskipTests validate",
         "python scripts/static-repo/validate_repository_layout.py <repository-root>"
       ],
-      "pr": "habitv-repo #2 (merged); habitv PR TBD (publication status + tracker refresh)",
+      "pr": "habitv-repo #2 (merged); habitv PR #49 (publication status + tracker refresh)",
       "notes": "Runtime updates remain disabled by default. Publication cutover is live on GitHub Pages with token-free HTTPS access. Remaining follow-up: run one dedicated opt-in runtime update smoke test with habitv.update.enabled=true against the published URL."
     },
     {

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -19,13 +19,13 @@
 ## 📊 Overall progress
 
 ```
-████████████████░░░░░░░░  66%
+██████████████████░░░░░░  73%
 ```
 
 | Category | Count |
 |---------|------:|
-| ✅ Delivered | **9** |
-| 🟡 In progress | **1** |
+| ✅ Delivered | **10** |
+| 🟡 In progress | **0** |
 | 🔵 Proposed | **4** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
@@ -42,7 +42,7 @@
 | ☕ `java8-baseline` — Java 8 compile baseline | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 🛡️ `branch-protection` — GitHub branch protection rules | 🔵 Proposed | 🟠 P1 | `░░░░░░░░░░░░░░░░░░░░` 0% |
 | 🔗 `legacy-url-migration` — Legacy URL migration (free.fr / SVN / FTP) | ✅ Done | 🔴 P0 | `████████████████████` 100% |
-| 📦 `static-repo-publish` — Static artifact repository publication | 🟡 In progress | 🟠 P1 | `██████░░░░░░░░░░░░░░` 30% |
+| 📦 `static-repo-publish` — Static artifact repository publication | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🔵 Proposed | 🟡 P2 | `░░░░░░░░░░░░░░░░░░░░` 0% |
 | 🎬 `ytdlp-migration` — `youtube-dl` → `yt-dlp` migration | 🔵 Proposed | 🟡 P2 | `████░░░░░░░░░░░░░░░░` 20% |
 | 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `█░░░░░░░░░░░░░░░░░░░` 5% |
@@ -244,9 +244,9 @@ files or an equivalent manifest layout are verified.
 
 | | |
 |---|---|
-| **Status** | 🟡 In progress |
+| **Status** | ✅ Done |
 | **Priority** | 🟠 P1 |
-| **Progress** | `██████░░░░░░░░░░░░░░` 30% |
+| **Progress** | `████████████████████` 100% |
 | **Legacy code** | HBTV-005 |
 
 **Scope** — Stand up the `habitv-repo` static repository (GitHub Pages
@@ -255,12 +255,12 @@ or equivalent HTTPS host) compatible with the existing
 
 **Acceptance criteria**
 - ✅ Cross-OS deploy scripts present in `scripts/static-repo/` *(in develop)*
-- ⬜ `habitv-repo` PR [#1](https://github.com/Mika3578/habitv-repo/pull/1) merged
-- 🟡 `repository/com/dabi/habitv/` layout contract validated locally
-- 🟡 `index.html` generation for GitHub Pages (no autoindex dependency) validated locally
-- 🟡 `plugins.txt` format validated against `FindArtifactUtils` fallback expectations
+- ✅ `habitv-repo` PR [#2](https://github.com/Mika3578/habitv-repo/pull/2) merged
+- ✅ `repository/com/dabi/habitv/` layout contract validated locally
+- ✅ `index.html` generation for GitHub Pages (no autoindex dependency) validated locally and live
+- ✅ `plugins.txt` format validated against `FindArtifactUtils` fallback expectations and live
 - ✅ HTTPS + no-token runtime consumption contract documented
-- ⬜ Migration path for `UPDATE_URL` documented
+- ✅ Migration path for `UPDATE_URL` documented
 
 **Validation**
 ```bash
@@ -268,11 +268,13 @@ mvn -B -ntp -DskipTests validate
 python scripts/static-repo/validate_repository_layout.py "<repository-root>"
 ```
 
-**Related PRs** · habitv-repo #1 (draft, since 2026-04-25) · this PR (layout validation + docs)
+**Related PRs** · habitv-repo #2 (merged) · this PR (publication status + tracker refresh)
 
 **Notes** — Runtime updates stay disabled by default.
-This item validates publication layout and docs without changing
-runtime updater behavior.
+Publication cutover is complete (`https://mika3578.github.io/habitv-repo/repository/`
+and `plugins.txt` live with no authentication). Remaining follow-up:
+run one dedicated opt-in runtime update smoke test with
+`-Dhabitv.update.enabled=true` against the published Pages URL.
 
 ---
 
@@ -560,8 +562,8 @@ scope for a dedicated security PR.
 Recommended merge / start order (see `dev-plan.md` for phase reasoning):
 
 1. 🔵 **Apply branch protection** → close `branch-protection`
-2. 🟡 **Merge `habitv-repo` PR #1** → complete `static-repo-publish`
-3. 🔵 Then in any order: `provider-inventory`, `ytdlp-migration`, `javafx-modernization`
+2. 🔵 **Start `provider-inventory`** after HBTV-005 closure confirmation
+3. 🔵 Then in any order: `ytdlp-migration`, `javafx-modernization`
 
 ---
 

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -256,7 +256,7 @@ or equivalent HTTPS host) compatible with the existing
 **Acceptance criteria**
 - ✅ Cross-OS deploy scripts present in `scripts/static-repo/` *(in develop)*
 - ✅ `habitv-repo` PR [#2](https://github.com/Mika3578/habitv-repo/pull/2) merged
-- ✅ `repository/com/dabi/habitv/` layout contract validated locally
+- ✅ `repository/com/dabi/habitv/` layout contract validated locally and published
 - ✅ `index.html` generation for GitHub Pages (no autoindex dependency) validated locally and live
 - ✅ `plugins.txt` format validated against `FindArtifactUtils` fallback expectations and live
 - ✅ HTTPS + no-token runtime consumption contract documented
@@ -268,7 +268,7 @@ mvn -B -ntp -DskipTests validate
 python scripts/static-repo/validate_repository_layout.py "<repository-root>"
 ```
 
-**Related PRs** · habitv-repo #2 (merged) · this PR (publication status + tracker refresh)
+**Related PRs** · habitv-repo #2 (merged) · habitv PR #49 (publication status + tracker refresh)
 
 **Notes** — Runtime updates stay disabled by default.
 Publication cutover is complete (`https://mika3578.github.io/habitv-repo/repository/`

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -288,7 +288,7 @@ wiring is already covered by an offline test from
 
 | | |
 |---|---|
-| **Status** | 🟡 Open |
+| **Status** | 🟢 Mitigated |
 | **Likelihood** | Medium · **Impact** High · **Priority** 🟠 P1 |
 | **Legacy code** | R-009 |
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -16,10 +16,10 @@ added, mitigated, realized, or accepted.
 
 | Status | Count |
 |---|---:|
-| 🟢 **Mitigated** | 5 |
+| 🟢 **Mitigated** | 7 |
 | 🔴 **Open / Critical (P0)** | 1 |
-| 🟠 **Open / High (P1)** | 6 |
-| 🟡 **Open / Medium (P2)** | 3 |
+| 🟠 **Open / High (P1)** | 5 |
+| 🟡 **Open / Medium (P2)** | 2 |
 | 🟢 **Open / Low (P3)** | 0 |
 | **Total tracked** | **15** |
 
@@ -37,12 +37,12 @@ added, mitigated, realized, or accepted.
 | `provider-endpoints-dead` | High | Med | 🟠 P1 | 🟡 Open |
 | `legacy-update-pull` | Med | High | 🟠 P1 | 🟠 Open |
 | `ytdlp-behavior-diff` | Med | Med | 🟡 P2 | 🟡 Open |
-| `pages-layout-mismatch` | Med | High | 🟠 P1 | 🟡 Open |
+| `pages-layout-mismatch` | Med | High | 🟠 P1 | 🟢 Mitigated |
 | `reactor-version-range` | Low | Low | 🟢 P3 | 🟢 Mitigated |
 | `jaxb-plugin-unpinned` | Low | Low | 🟢 P3 | 🟢 Mitigated |
 | `plugin-tester-mismatch` | Low | Low | 🟢 P3 | 🟢 Mitigated |
 | `youtube-key-hardcoded` | Med | Med | 🟡 P2 | 🟢 Mitigated |
-| `pages-autoindex-gap` | Med | Med | 🟡 P2 | 🟡 Open |
+| `pages-autoindex-gap` | Med | Med | 🟡 P2 | 🟢 Mitigated |
 | `silent-stat-ping` | Med | Med | 🟡 P2 | 🟡 Open |
 
 ---
@@ -216,12 +216,14 @@ fail noisily if it is down).
 required before any runtime fetch (`habitv.update.enabled=true`,
 optional `habitv.update.url`).
 
-**Status update (`legacy-url-migration`)** — `UpdateManager` returns
-immediately unless `habitv.update.enabled=true`. The default target
-base URL constant is `https://mika3578.github.io/habitv-repo/repository`
-(legacy DabiBoo removed). Do not enable updates until
-`static-repo-publish` publishes Apache-style directory indexes or an
-equivalent manifest layout.
+**Status update (`legacy-url-migration` / `static-repo-publish`)** —
+`UpdateManager` returns immediately unless
+`habitv.update.enabled=true`. The default target base URL constant is
+`https://mika3578.github.io/habitv-repo/repository` (legacy DabiBoo
+removed). Publication cutover and live Pages layout validation are now
+complete (habitv-repo PR #2 merged), and updates remain disabled by
+default. Remaining follow-up: one dedicated opt-in runtime update
+smoke test against the live Pages URL.
 
 ---
 
@@ -300,18 +302,14 @@ explicitly and validates it against
 `FindArtifactUtils.findLastVersionUrl` semantics before cutting
 over.
 
-**Status update (`legacy-url-migration` / `static-repo-publish`)** —
-`FindArtifactUtils` parses HTML directory listings via anchor tags
-(Apache `mod_autoindex` shape). GitHub Pages does not provide that
-listing by default. Runtime updates stay disabled
-(`habitv.update.enabled` defaults false) until static `index.html`
-files or manifests are published and verified under
-`static-repo-publish`. Keep this risk at P1 until cutover
-validation completes.
-Local pre-cutover validation now exists via
-`python scripts/static-repo/validate_repository_layout.py <repository-root>`,
-which checks `plugins.txt`, `com/dabi/habitv`, and required `index.html`
-anchor links. Risk remains open until `habitv-repo` publication is live.
+**Status update (`static-repo-publish`)** — `habitv-repo` publication
+is live and validated:
+`https://mika3578.github.io/habitv-repo/repository/`,
+`.../plugins.txt`, and `.../com/dabi/habitv/` all return HTTP 200 with
+generated index pages and usable links. Local layout validation also
+passes via
+`python scripts/static-repo/validate_repository_layout.py <repository-root>`.
+Risk is mitigated for publication layout compatibility.
 
 ---
 
@@ -341,7 +339,7 @@ user-editable field; error messages mask the `key` parameter.
 
 | | |
 |---|---|
-| **Status** | 🟡 Open |
+| **Status** | 🟢 Mitigated |
 | **Likelihood** | Medium · **Impact** Medium · **Priority** 🟡 P2 |
 | **Legacy code** | R-014 |
 
@@ -349,11 +347,13 @@ user-editable field; error messages mask the `key` parameter.
 `mod_autoindex` directory listings. `FindArtifactUtils` discovers
 artifact versions by parsing index pages, which assumes autoindex.
 
-**Mitigation** — `static-repo-publish` plans to generate static
-`index.html` files (or a manifest) so listing semantics are
-preserved without relying on the host.
-Validation now includes a repository-layout check script to assert
-required `index.html` anchor links before publication.
+**Mitigation** — `static-repo-publish` generates static `index.html`
+files and validates required links with
+`validate_repository_layout.py` before publication.
+
+**Status update (`static-repo-publish`)** — GitHub Pages now serves the
+published generated index files at the live repository URLs (HTTP 200,
+no authentication). Autoindex from the host is no longer required.
 
 ---
 

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -175,6 +175,7 @@ python .\scripts\static-repo\validate_repository_layout.py `
 ## Validation URLs
 
 - https://mika3578.github.io/habitv-repo/repository/
+- https://mika3578.github.io/habitv-repo/repository/plugins.txt
 - https://mika3578.github.io/habitv-repo/repository/com/dabi/habitv/
 - https://mika3578.github.io/habitv-repo/repository/tools/
 


### PR DESCRIPTION
## Summary
- Mark `static-repo-publish` (HBTV-005) as completed after `habitv-repo` publication merge and live GitHub Pages validation.
- Refresh tracker/plan/risk/ADR docs to reflect the completed publication cutover while keeping runtime updates disabled by default.
- Add `plugins.txt` to static deployment validation URLs.

## Live URLs validated
- https://mika3578.github.io/habitv-repo/repository/
- https://mika3578.github.io/habitv-repo/repository/plugins.txt
- https://mika3578.github.io/habitv-repo/repository/com/dabi/habitv/

Validation result (live):
```text
URL=https://mika3578.github.io/habitv-repo/repository/
STATUS=200
PREVIEW=<!DOCTYPE html> | <html><head><meta charset="UTF-8"/><title>Index of /</title></head><body> | <h1>Index of /</h1>
---
URL=https://mika3578.github.io/habitv-repo/repository/plugins.txt
STATUS=200
PREVIEW=# Habitv plugin artifact ids (one per line, matches Maven artifactId) | 6play | adobeHDS
---
URL=https://mika3578.github.io/habitv-repo/repository/com/dabi/habitv/
STATUS=200
PREVIEW=<!DOCTYPE html> | <html><head><meta charset="UTF-8"/><title>Index of /</title></head><body> | <h1>Index of /</h1>
---
```

## Exact validation outputs
```text
git status --short
 M docs/decision-log.md
 M docs/dev-plan.md
 M docs/dev-tracker.json
 M docs/dev-tracker.md
 M docs/risk-register.md
 M docs/static-repository-deploy.md
?? .vscode/
```

```text
mvn -B -ntp -DskipTests validate
[INFO] BUILD SUCCESS
[INFO] Total time:  0.515 s
[INFO] Finished at: 2026-05-18T19:07:31+02:00
```

```text
mvn -B -ntp -DskipTests compile
[INFO] BUILD SUCCESS
[INFO] Total time:  3.364 s
[INFO] Finished at: 2026-05-18T19:07:44+02:00
```

```text
python scripts/static-repo/validate_repository_layout.py "C:/Users/Mika/dev/habitv-repo/repository"
Static repository layout validation passed: C:\Users\Mika\dev\habitv-repo\repository
```

```text
git diff --check
(no output)
```

## Remaining risks
- `legacy-update-pull` remains open until one dedicated opt-in runtime update smoke test is executed against the live Pages URL.

## Runtime update default
- Confirmed unchanged: runtime updates remain disabled by default (`habitv.update.enabled=false` unless explicitly enabled).

## Follow-up recommendation
- Start `provider-inventory` only after HBTV-005 is closed (or explicitly documented as externally complete with the runtime smoke-test follow-up).