### PR TITLE
docs: inventory provider plugin status

### DIFF
--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -10,7 +10,7 @@ work from a later phase.
 ## 🎯 Phase progress
 
 ```
-█████████████████░░░░░░░  71%   (5 / 7 phases)
+██████████████████░░░░░░  76%   (5 / 7 phases done, 1 in progress)
 ```
 
 | Phase | Title | Status | Progress | Tracker items |
@@ -21,7 +21,7 @@ work from a later phase.
 | 3 | 🔗 Remove legacy free.fr / SVN / FTP | ✅ Done | `████████████████████` 100% | `legacy-url-migration`, `youtube-apikey` |
 | 4 | 📦 Publish artifacts via `habitv-repo` | ✅ Done | `████████████████████` 100% | `static-repo-publish` |
 | 5 | 🎬 Replace `youtube-dl` with `yt-dlp` | 🔵 Proposed | `████░░░░░░░░░░░░░░░░` 20% | `ytdlp-migration` |
-| 6 | 🔌 Audit / deprecate obsolete providers | 🔵 Proposed | `░░░░░░░░░░░░░░░░░░░░` 0% | `provider-inventory` |
+| 6 | 🔌 Audit / deprecate obsolete providers | 🟡 In progress | `████████░░░░░░░░░░░░` 40% | `provider-inventory` |
 | 7 | 🖼️ Modernize UI / runtime packaging | 🔵 Proposed | `█░░░░░░░░░░░░░░░░░░░` 5% | `javafx-modernization` |
 
 ---
@@ -126,12 +126,14 @@ branch `develop` created.
 
 ## 🔌 Phase 6 — Audit / deprecate obsolete providers
 
-🔵 **Proposed** · `░░░░░░░░░░░░░░░░░░░░` 0%
+🟡 **In progress** · `████████░░░░░░░░░░░░` 40%
 
 - Inventory all provider plugins and verify endpoints are reachable
   and parsable (offline against captured fixtures, not live).
 - Mark obsolete or renamed providers with a deprecation plan and
   dedicated removal PRs.
+- Baseline classification doc added at `docs/provider-inventory.md`;
+  follow-up fixture and rewrite PRs remain pending.
 
 **Tracker** — `provider-inventory`.
 

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -18,12 +18,12 @@
   ],
   "summary": {
     "done": 10,
-    "inProgress": 0,
-    "proposed": 4,
+    "inProgress": 1,
+    "proposed": 3,
     "deferred": 0,
     "blocked": 0,
     "total": 14,
-    "overallProgressPercent": 73
+    "overallProgressPercent": 76
   },
   "items": [
     {
@@ -168,9 +168,9 @@
       "legacyCode": "HBTV-006",
       "displayTitle": "Provider plugin inventory & cleanup",
       "icon": "🔌",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P2",
-      "progressPercent": 0,
+      "progressPercent": 40,
       "scope": "Inventory every plugin in plugins/ (22 in aggregator + plugin-tester); record current status (working, obsolete endpoint, renamed, broken parser). No code removal in this item.",
       "acceptanceCriteria": [
         "Inventory table per plugin with last-known status.",
@@ -180,8 +180,8 @@
       "validation": [
         "Inventory reviewed in a doc-only PR; no behavior change."
       ],
-      "pr": "TBD",
-      "notes": "Visible candidates: pluzz (already renamed francetv on habitv-repo), canalPlus, beinsport, D8/D17/nrj12 (README mentions but no module), wat, sfr, clubic. Risks live-tests-flaky, provider-endpoints-dead."
+      "pr": "docs/provider-plugin-inventory (this PR)",
+      "notes": "Inventory baseline added in docs/provider-inventory.md covering all plugin modules plus historical references (D8, D17, nrj12, FranceTV/Pluzz, Kewego). Follow-up PR queue documented without removing modules. Risks live-tests-flaky, provider-endpoints-dead."
     },
     {
       "id": "ytdlp-migration",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -19,14 +19,14 @@
 ## 📊 Overall progress
 
 ```
-██████████████████░░░░░░  73%
+███████████████████░░░░░  76%
 ```
 
 | Category | Count |
 |---------|------:|
 | ✅ Delivered | **10** |
-| 🟡 In progress | **0** |
-| 🔵 Proposed | **4** |
+| 🟡 In progress | **1** |
+| 🔵 Proposed | **3** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
 | **Total work items** | **14** |
@@ -43,7 +43,7 @@
 | 🛡️ `branch-protection` — GitHub branch protection rules | 🔵 Proposed | 🟠 P1 | `░░░░░░░░░░░░░░░░░░░░` 0% |
 | 🔗 `legacy-url-migration` — Legacy URL migration (free.fr / SVN / FTP) | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 📦 `static-repo-publish` — Static artifact repository publication | ✅ Done | 🟠 P1 | `████████████████████` 100% |
-| 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🔵 Proposed | 🟡 P2 | `░░░░░░░░░░░░░░░░░░░░` 0% |
+| 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🟡 In progress | 🟡 P2 | `████████░░░░░░░░░░░░` 40% |
 | 🎬 `ytdlp-migration` — `youtube-dl` → `yt-dlp` migration | 🔵 Proposed | 🟡 P2 | `████░░░░░░░░░░░░░░░░` 20% |
 | 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `█░░░░░░░░░░░░░░░░░░░` 5% |
 | 🧪 `plugin-tester-align` — `plugin-tester` reactor alignment | ✅ Done | 🟠 P1 | `████████████████████` 100% |
@@ -176,9 +176,9 @@ mvn -B -ntp -DskipTests compile      # BUILD SUCCESS (after plugin-tester-align 
 
 | | |
 |---|---|
-| **Status** | 🔵 Proposed |
+| **Status** | 🟡 In progress |
 | **Priority** | 🟠 P1 |
-| **Progress** | `░░░░░░░░░░░░░░░░░░░░` 0% |
+| **Progress** | `████████░░░░░░░░░░░░` 40% |
 | **Legacy code** | HBTV-003 |
 
 **Scope** — Apply the GitHub settings documented in
@@ -292,17 +292,25 @@ run one dedicated opt-in runtime update smoke test with
 renamed, broken parser). No code removal in this item.
 
 **Acceptance criteria**
-- ⬜ Inventory table per plugin with last-known status
-- ⬜ For each obsolete/renamed plugin, a recommended dedicated
-  removal/rename PR is named
+- ✅ Inventory table per plugin with last-known status
+- ✅ For each obsolete/renamed plugin, a recommended dedicated
+  follow-up PR is named
 - ⬜ Offline fixtures captured where feasible
 
-**Validation** — Inventory reviewed in a doc-only PR; no behavior change.
+**Validation**
+```bash
+docs/provider-inventory.md reviewed in a doc-only PR
+# no provider code, runtime update behavior, or Maven publication behavior change
+```
 
-**Notes** — Visible candidates: `pluzz` (already renamed `francetv` on
-`habitv-repo`), `canalPlus`, `beinsport`, `D8`/`D17`/`nrj12` (README
-mentions but no module exists), `wat`, `sfr`, `clubic`, `kewego`-derived
-RSS samples. Risks `live-tests-flaky`, `provider-endpoints-dead`.
+**Related PR** · `docs: inventory provider plugin status` (this PR)
+
+**Notes** — Inventory baseline is now documented in
+[`provider-inventory.md`](provider-inventory.md) for every plugin module
+plus historical references (`D8`, `D17`, `nrj12`, FranceTV/Pluzz,
+Kewego). This item remains open until fixture-based validation and
+dedicated cleanup/rewrite PRs are completed. Risks `live-tests-flaky`,
+`provider-endpoints-dead`.
 
 ---
 
@@ -562,7 +570,7 @@ scope for a dedicated security PR.
 Recommended merge / start order (see `dev-plan.md` for phase reasoning):
 
 1. 🔵 **Apply branch protection** → close `branch-protection`
-2. 🔵 **Start `provider-inventory`** after HBTV-005 closure confirmation
+2. 🟡 **Complete `provider-inventory` follow-up fixture/rewrite PRs**
 3. 🔵 Then in any order: `ytdlp-migration`, `javafx-modernization`
 
 ---

--- a/docs/provider-inventory.md
+++ b/docs/provider-inventory.md
@@ -1,0 +1,85 @@
+# 🔌 Provider and plugin inventory (HBTV-006)
+
+**Tracker item**: `provider-inventory` (`HBTV-006`)  
+**Scope in this PR**: documentation and classification only (no module removal, no provider rewrite, no runtime behavior change)
+
+---
+
+## Inventory method
+
+- Source of truth for modules: `plugins/pom.xml` aggregator.
+- Classification evidence pulled from:
+  - plugin module `pom.xml` (`artifactId`)
+  - plugin source interfaces and URL constants under `plugins/*/src`
+  - plugin tests under `plugins/*/test`
+  - existing documentation references (`README.md`, `docs/dev-tracker.md`, `docs/risk-register.md`)
+- Runtime update behavior is intentionally unchanged (remains opt-in by flag).
+
+---
+
+## Module inventory
+
+| Module path | Maven artifactId | Plugin type | Current status | Evidence | Recommended follow-up PR |
+|---|---|---|---|---|---|
+| `plugins/pom.xml` | `plugins` | utility | infrastructure-only | Aggregator defines all 23 plugin modules and no runtime logic | keep as-is |
+| `plugins/6play` | `6play` | provider | needs live endpoint rewrite | `SixPlayPluginManager` is a provider; `SixPlayConf.HOME_URL` points to legacy HTTP `6play.fr`; live parser stability unknown | add fixture tests |
+| `plugins/RSS` | `RSS` | provider | keep | `RSSPluginManager` implements provider; test class exists; references generic RSS templates | add fixture tests |
+| `plugins/adobeHDS` | `adobeHDS` | downloader | keep | `AdobeHDSPluginDownloader` implements downloader/proxy interfaces; updater-style binary wrapper | keep as-is |
+| `plugins/aria2` | `aria2` | downloader | keep | `Aria2PluginDownloader` wraps `aria2c`; dedicated test exists | keep as-is |
+| `plugins/arte` | `arte` | provider | needs live endpoint rewrite | `ArteConf` uses legacy HTTP guide/rss URLs and scraping selectors; provider tests are live-network style | add fixture tests |
+| `plugins/beinsport` | `beinsport` | provider | obsolete endpoint | `BeinSportConf` uses legacy `beinsports.com/us/videos` and Dailymotion mapping; known candidate in tracker notes | rewrite provider |
+| `plugins/canalPlus` | `canalPlus` | provider | obsolete endpoint | `CanalPlusConf`/`D8Conf`/`D17Conf` use old Canal service URLs and channel-specific legacy endpoints | rewrite provider |
+| `plugins/clubic` | `clubic` | provider | obsolete endpoint | `ClubicConf` targets legacy Clubic video pages via HTML selectors; provider test is live-network | deprecate provider |
+| `plugins/cmd` | `cmd` | exporter | infrastructure-only | `CmdPluginExporterManager` and `CmdPluginDownloaderManager` are command wrappers, no provider endpoint logic | keep as-is |
+| `plugins/curl` | `curl` | exporter | infrastructure-only | `CurlPluginExporterManager` plus downloader wrapper; utility integration layer | keep as-is |
+| `plugins/email` | `email` | provider | unknown / needs fixture | `EmailPluginManager` is provider-based input channel (not broadcaster endpoint); tests exist but behavior depends on external mailbox integration | add fixture tests |
+| `plugins/ffmpeg` | `ffmpeg` | exporter | infrastructure-only | `FFMPEGPluginExporterManager` and downloader classes are local tool wrappers | keep as-is |
+| `plugins/file` | `file` | utility | keep | `FilePluginManager` is local file-driven provider/downloader bridge; no remote endpoint dependency | keep as-is |
+| `plugins/footyroom` | `footyroom` | provider | needs live endpoint rewrite | `FootyroomConf` points to legacy site URLs and hardcoded host patterns in provider manager | rewrite provider |
+| `plugins/globalnews` | `globalnews` | provider | unknown / needs fixture | `GlobalNewsPluginManager` provider/downloader interface with HTTPS source URL; only live-style test evidence | add fixture tests |
+| `plugins/lequipe` | `lequipe` | provider | needs live endpoint rewrite | Provider/downloader plugin uses HTML scraping; tests include historical Kewego stream-init references | rewrite provider |
+| `plugins/mlssoccer` | `mlssoccer` | provider | unknown / needs fixture | `MLSSoccerPluginManager` provider/downloader with HTTPS URLs; live endpoint compatibility not validated offline | add fixture tests |
+| `plugins/plugin-tester` | `plugin-tester` | test harness | infrastructure-only | `BasePluginProviderTester` / `BasePluginUpdateTester` provide shared live-style harness utilities | keep as-is |
+| `plugins/pluzz` | `pluzz` | provider | renamed/replaced | `PluzzConf` still references `catalogue=Pluzz`; tracker notes and repo context indicate FranceTV naming replacement | deprecate provider |
+| `plugins/rtmpDump` | `rtmpDump` | downloader | keep | `RtmpDumpPluginDownloader` is binary wrapper with updater version pattern; dedicated test exists | keep as-is |
+| `plugins/sfr` | `sfr` | provider | unknown / needs fixture | `SFRConf` uses `sport.sfr.fr` API path; provider tests are live-network style only | add fixture tests |
+| `plugins/wat` | `wat` | provider | obsolete endpoint | `WatConf` points to TF1/WAT-era URLs; plugin naming and endpoint model reflect legacy provider branding | rewrite provider |
+| `plugins/youtube` | `youtube` | provider | keep | `YoutubePluginManager` provider implementation; offline command-wiring tests exist; yt-dlp migration explicitly out of scope here | migrate to yt-dlp |
+
+---
+
+## Historical and missing references
+
+| Name in docs/config | Found in code/docs | In plugins aggregator? | Classification |
+|---|---|---|---|
+| `D8` | `README.md` provider list; `D8PluginManager` inside `plugins/canalPlus` | No standalone module | embedded legacy sub-provider in `canalPlus` |
+| `D17` | `README.md` provider list; `D17PluginManager` inside `plugins/canalPlus` | No standalone module | embedded legacy sub-provider in `canalPlus` |
+| `NRJ12` / `nrj12` | Mentioned in `README.md` and tracker notes | No | historical reference only (missing module) |
+| `FranceTV / Pluzz` | `plugins/pluzz` source constants (`catalogue=Pluzz`), tracker notes | Yes (`pluzz`) | renamed/replaced candidate |
+| `Kewego` | Legacy stream references in `plugins/lequipe/test/TestInitStream.java`; risk register mentions kewego in live tests | No dedicated module | historical endpoint dependency in tests |
+
+---
+
+## Follow-up PR queue (safe order)
+
+1. **test(provider-inventory): add offline fixtures for unknown providers**
+   - Scope: `globalnews`, `mlssoccer`, `sfr`, `email`, plus RSS regression fixtures.
+2. **fix(provider-canal-family): rewrite canalPlus + d8 + d17 provider endpoints**
+   - Scope: `plugins/canalPlus` only, with fixture-backed parser behavior.
+3. **fix(provider-francetv): replace pluzz provider with france.tv metadata flow**
+   - Scope: dedicated replacement/deprecation plan for `plugins/pluzz`.
+4. **fix(provider-legacy-football): rewrite wat, beinsport, footyroom, lequipe**
+   - Scope: endpoint/parser modernization with offline fixtures first.
+5. **docs(provider-cleanup): propose dedicated deprecation PRs for non-recoverable providers**
+   - Scope: doc + tracker + risk updates only, no silent removals.
+
+---
+
+## Out-of-scope confirmations
+
+- No plugin modules were removed.
+- No provider logic was rewritten.
+- No runtime updater behavior was changed.
+- No yt-dlp migration work started in this inventory PR.
+- No JavaFX modernization work started in this inventory PR.
+- No Maven publication layout or `habitv-repo` contract was changed.


### PR DESCRIPTION
## Summary
- Start HBTV-006 (`provider-inventory`) from latest `develop` in a docs-only PR.
- Add `docs/provider-inventory.md` with full plugin/aggregator inventory, status classification, evidence, and follow-up PR recommendations.
- Update tracker/plan docs to mark `provider-inventory` as in progress (40%) without changing runtime/provider/Maven publication behavior.

## Inventory coverage
- Aggregator checked: `plugins/pom.xml`
- Modules covered: `plugin-tester`, `6play`, `adobeHDS`, `aria2`, `arte`, `beinsport`, `canalPlus`, `clubic`, `cmd`, `curl`, `email`, `ffmpeg`, `file`, `footyroom`, `globalnews`, `lequipe`, `mlssoccer`, `pluzz`, `RSS`, `rtmpDump`, `sfr`, `youtube`, `wat`
- Historical/missing references checked: `D8`, `D17`, `NRJ12/nrj12`, `FranceTV/Pluzz`, Kewego-derived references

## Provider classification table summary
- Rows classified: 24 (23 modules + plugins aggregator)
- By type: provider=15, downloader=3, exporter=3, utility=2, test harness=1
- By status:
  - keep=6
  - needs live endpoint rewrite=4
  - obsolete endpoint=4
  - renamed/replaced=1
  - infrastructure-only=5
  - unknown / needs fixture=4

## Out of scope
- No plugin module removal.
- No provider rewrite.
- No runtime update behavior change.
- No merge/revival of PR #48 behavior.
- No yt-dlp migration work in this PR.
- No JavaFX modernization work in this PR.
- No Maven publication or `habitv-repo` layout change.

## Validation results
### `git status --short`
```text
 M docs/dev-plan.md
 M docs/dev-tracker.json
 M docs/dev-tracker.md
?? .vscode/
?? docs/provider-inventory.md
```

### `mvn -B -ntp -DskipTests validate`
```text
[INFO] BUILD SUCCESS
[INFO] Total time:  0.496 s
[INFO] Finished at: 2026-05-18T19:40:51+02:00
```

### `mvn -B -ntp -DskipTests compile`
```text
[INFO] BUILD SUCCESS
[INFO] Total time:  3.386 s
[INFO] Finished at: 2026-05-18T19:40:57+02:00
```

### `git diff --check`
```text
(no output)
```

### `python -m json.tool docs/dev-tracker.json > NUL`
```text
(no output)
```

## Follow-up PR recommendations
1. `test(provider-inventory): add offline fixtures for unknown providers`
2. `fix(provider-canal-family): rewrite canalPlus + d8 + d17 provider endpoints`
3. `fix(provider-francetv): replace pluzz provider with france.tv metadata flow`
4. `fix(provider-legacy-football): rewrite wat, beinsport, footyroom, lequipe`
5. `docs(provider-cleanup): deprecation PR plan for non-recoverable providers`

## Confirmation
- This PR only changes documentation.
- No provider code, runtime updater behavior, or Maven publication behavior changed.