### PR TITLE
feat(youtube): migrate downloader binary to yt-dlp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,18 +32,21 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-18 | TBD | Migrate YouTube plugin downloader defaults to yt-dlp |
 | 2026-05-17 | `7a61dd6` | Add runnable yt-dlp runtime path for `consoleView` |
 
 ### 🧪 Tests
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-18 | TBD | Expand offline yt-dlp defaults and command wiring tests |
 | 2026-05-17 | `0163d9a` | Cover yt-dlp command wiring (offline test) |
 
 ### 📚 Documentation
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-18 | TBD | Document yt-dlp CLI compatibility and tracker progress |
 | 2026-05-17 | `750640d` | Update modernization status after console baseline |
 | 2026-05-16 | `be5b667` | Update plugin tester dependency tracker |
 | 2026-05-16 | `993f3d0` | Add AI agent repository instructions |
@@ -64,7 +67,7 @@ What it intentionally **does not yet change** (tracked separately):
 
 - ⬜ Legacy URLs (`dabiboo.free.fr`, Assembla SVN, FTP) — still present
 - ⬜ JavaFX 2.x / `${jdk.home}` packaging — `habiTv-linux` / `habiTv-windows` excluded from reactor
-- ⬜ `youtube-dl` → `yt-dlp` plugin command migration (wiring only, not flags)
+- 🟡 `youtube-dl` → `yt-dlp` plugin binary migration (in progress; see `ytdlp-migration`)
 - ⬜ Provider plugin inventory / dead-endpoint cleanup
 - ⬜ Hardcoded YouTube Data API key (PR [#29](https://github.com/Mika3578/habitv/pull/29) in flight)
 

--- a/application/core/configuration.xml
+++ b/application/core/configuration.xml
@@ -13,7 +13,7 @@
             <aria2>bin\aria2c.exe</aria2>
             <curl>bin\curl.exe</curl>
             <ffmpeg>bin\ffmpeg.exe</ffmpeg>
-            <youtube>bin\youtube-dl.exe</youtube>
+            <youtube>bin\yt-dlp.exe</youtube>
         </downloaders>
     </downloadConfig>
     <updateConfig>

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -20,7 +20,7 @@ work from a later phase.
 | 2 | ☕ Stabilize Java 8 baseline | ✅ Done | `████████████████████` 100% | `java8-baseline`, `plugin-tester-align`, `own-version-deps-align` |
 | 3 | 🔗 Remove legacy free.fr / SVN / FTP | ✅ Done | `████████████████████` 100% | `legacy-url-migration`, `youtube-apikey` |
 | 4 | 📦 Publish artifacts via `habitv-repo` | ✅ Done | `████████████████████` 100% | `static-repo-publish` |
-| 5 | 🎬 Replace `youtube-dl` with `yt-dlp` | 🔵 Proposed | `████░░░░░░░░░░░░░░░░` 20% | `ytdlp-migration` |
+| 5 | 🎬 Replace `youtube-dl` with `yt-dlp` | 🟡 In progress | `███████████████░░░░░` 75% | `ytdlp-migration` |
 | 6 | 🔌 Audit / deprecate obsolete providers | 🟡 In progress | `███████████░░░░░░░░░` 55% | `provider-inventory` |
 | 7 | 🖼️ Modernize UI / runtime packaging | 🔵 Proposed | `█░░░░░░░░░░░░░░░░░░░` 5% | `javafx-modernization` |
 
@@ -112,7 +112,7 @@ branch `develop` created.
 
 ## 🎬 Phase 5 — Replace `youtube-dl` with `yt-dlp`
 
-🔵 **Proposed** · `████░░░░░░░░░░░░░░░░` 20%
+🟡 **In progress** · `███████████████░░░░░` 75%
 
 - Switch the `youtube` plugin's binary expectations from
   `youtube-dl` to `yt-dlp` (executable name, command flags,
@@ -120,7 +120,8 @@ branch `develop` created.
 - Migrate the default config (`application/core/configuration.xml`).
 - Provide a deprecation note for users still on `youtube-dl`.
 
-**Tracker** — `ytdlp-migration`.
+**Tracker** — `ytdlp-migration`. CLI contract: `docs/ytdlp-cli-compatibility.md`.
+Remaining: live fixture validation, `habitv-repo` `yt-dlp` tool zip publication.
 
 ---
 

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -18,12 +18,12 @@
   ],
   "summary": {
     "done": 10,
-    "inProgress": 1,
-    "proposed": 3,
+    "inProgress": 2,
+    "proposed": 2,
     "deferred": 0,
     "blocked": 0,
     "total": 14,
-    "overallProgressPercent": 77
+    "overallProgressPercent": 79
   },
   "items": [
     {
@@ -193,23 +193,24 @@
       "legacyCode": "HBTV-007",
       "displayTitle": "youtube-dl to yt-dlp migration",
       "icon": "🎬",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P2",
-      "progressPercent": 20,
+      "progressPercent": 75,
       "scope": "Plan and execute migration of the youtube plugin's binary contract from youtube-dl to yt-dlp (executable name, command flags, output parsing, post-processors).",
       "acceptanceCriteria": [
         "Runtime path packaged in consoleView fat-jar (done).",
-        "Offline command-wiring test YoutubePluginDownloaderCmdTest passes (done).",
-        "CLI flag diff documented (--format, output template, post-processors).",
-        "application/core/configuration.xml sample updated to yt-dlp.",
-        "Backward-compatibility / deprecation note for users on youtube-dl.",
-        "Provider behavior validated against captured fixtures."
+        "Offline command-wiring tests pass (done).",
+        "CLI flag contract documented in docs/ytdlp-cli-compatibility.md (done).",
+        "application/core/configuration.xml sample updated to yt-dlp (done).",
+        "Backward-compatibility / deprecation note for users on youtube-dl (done).",
+        "Provider behavior validated against captured fixtures (follow-up).",
+        "habitv-repo publishes tools/yt-dlp artifact (follow-up PR)."
       ],
       "validation": [
-        "mvn -B -ntp -pl plugins/youtube -am test -> Tests run: 2, Failures: 0"
+        "mvn -B -ntp -pl plugins/youtube -am -Dsurefire.failIfNoSpecifiedTests=false test"
       ],
-      "pr": "TBD",
-      "notes": "Risk ytdlp-behavior-diff. End-to-end live behavior remains out of scope until provider-inventory cleanup."
+      "pr": "feat(youtube): migrate downloader binary to yt-dlp (TBD)",
+      "notes": "Plugin module id remains youtube. Static-repo tool metadata uses yt-dlp; habitv-repo publication is separate. No provider rewrite or live-network tests."
     },
     {
       "id": "javafx-modernization",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -44,7 +44,7 @@
 | 🔗 `legacy-url-migration` — Legacy URL migration (free.fr / SVN / FTP) | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 📦 `static-repo-publish` — Static artifact repository publication | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🟡 In progress | 🟡 P2 | `███████████░░░░░░░░░` 55% |
-| 🎬 `ytdlp-migration` — `youtube-dl` → `yt-dlp` migration | 🔵 Proposed | 🟡 P2 | `████░░░░░░░░░░░░░░░░` 20% |
+| 🎬 `ytdlp-migration` — `youtube-dl` → `yt-dlp` migration | 🟡 In progress | 🟡 P2 | `███████████████░░░░░` 75% |
 | 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `█░░░░░░░░░░░░░░░░░░░` 5% |
 | 🧪 `plugin-tester-align` — `plugin-tester` reactor alignment | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | ▶️ `console-runnable` — Runnable console baseline | ✅ Done | 🔴 P0 | `████████████████████` 100% |
@@ -324,9 +324,9 @@ capture and dedicated cleanup/rewrite PRs. Risks `live-tests-flaky`,
 
 | | |
 |---|---|
-| **Status** | 🔵 Proposed |
+| **Status** | 🟡 In progress |
 | **Priority** | 🟡 P2 |
-| **Progress** | `████░░░░░░░░░░░░░░░░` 20% |
+| **Progress** | `███████████████░░░░░` 75% |
 | **Legacy code** | HBTV-007 |
 
 **Scope** — Plan and execute migration of the `youtube` plugin's binary
@@ -334,20 +334,23 @@ contract from `youtube-dl` to `yt-dlp` (executable name, command flags,
 output parsing, post-processors).
 
 **Acceptance criteria**
-- 🟡 Runtime path packaged in `consoleView` fat-jar *(done)*
-- 🟡 Offline command-wiring test `YoutubePluginDownloaderCmdTest` passes *(done)*
-- ⬜ CLI flag diff documented (`--format`, output template, post-processors)
-- ⬜ `application/core/configuration.xml` sample updated to `yt-dlp`
-- ⬜ Backward-compatibility / deprecation note for users on `youtube-dl`
-- ⬜ Provider behavior validated against captured fixtures
+- ✅ Runtime path packaged in `consoleView` fat-jar
+- ✅ Offline command-wiring tests (`YoutubePluginDownloaderCmdTest`, defaults)
+- ✅ CLI flag contract documented (`docs/ytdlp-cli-compatibility.md`)
+- ✅ `application/core/configuration.xml` sample updated to `yt-dlp`
+- ✅ Backward-compatibility / deprecation note for users on `youtube-dl`
+- ⬜ Provider behavior validated against captured fixtures (live endpoints; follow-up)
+- ⬜ `habitv-repo` publishes `tools/yt-dlp/...` artifact (follow-up PR)
 
 **Validation**
 ```bash
-mvn -B -ntp -pl plugins/youtube -am test     # Tests run: 2, Failures: 0
+mvn -B -ntp -pl plugins/youtube -am -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
-**Notes** — Risk `ytdlp-behavior-diff`. End-to-end live behavior
-remains out of scope until `provider-inventory` cleanup.
+**Notes** — Risk `ytdlp-behavior-diff`. Plugin module id remains `youtube`.
+Static-repo tool metadata in `scripts/static-repo/tool-sources.properties` uses
+`yt-dlp`; publishing the zip to `habitv-repo` is a separate PR. No provider
+rewrite, no live-network tests in this item.
 
 ---
 

--- a/docs/provider-inventory.md
+++ b/docs/provider-inventory.md
@@ -44,7 +44,7 @@
 | `plugins/rtmpDump` | `rtmpDump` | downloader | keep | `RtmpDumpPluginDownloader` is binary wrapper with updater version pattern; dedicated test exists | keep as-is |
 | `plugins/sfr` | `sfr` | provider | unknown / needs fixture | `SFRConf` uses `sport.sfr.fr` API path; provider tests are live-network style only | add fixture tests |
 | `plugins/wat` | `wat` | provider | obsolete endpoint | `WatConf` points to TF1/WAT-era URLs; plugin naming and endpoint model reflect legacy provider branding | rewrite provider |
-| `plugins/youtube` | `youtube` | provider | keep | `YoutubePluginManager` provider implementation; offline command-wiring tests exist; yt-dlp migration explicitly out of scope here | migrate to yt-dlp |
+| `plugins/youtube` | `youtube` | provider | keep | `YoutubePluginManager` provider; offline tests; binary contract migrated to yt-dlp (`YtDlpCmdExecutor`, defaults `yt-dlp` / `yt-dlp.exe`) | keep (yt-dlp binary) |
 
 ---
 
@@ -99,7 +99,7 @@
 | `canalPlus` (`D8`/`D17` family) | Local fixture metadata + offline baseline test | Multiple legacy endpoint families, highest rewrite risk |
 | `pluzz` | Local fixture metadata + offline baseline test | Renamed/replaced direction (`FranceTV`) must be documented before rewrite |
 | `arte` | Local fixture metadata + offline baseline test | Legacy HTTP/RSS parsing assumptions need stable parser anchors |
-| `youtube` | Local fixture metadata + offline baseline test | Keep fixture boundaries explicit while yt-dlp migration remains separate |
+| `youtube` | Local fixture metadata + offline baseline test | Binary contract migrated to yt-dlp; live provider validation still separate |
 
 ### Infrastructure-only modules not suitable for provider fixtures
 
@@ -151,6 +151,6 @@ Baseline tests added (local fixture loading only):
 - No plugin modules were removed.
 - No provider logic was rewritten.
 - No runtime updater behavior was changed.
-- No yt-dlp migration work started in this inventory PR.
+- yt-dlp binary migration is tracked under `ytdlp-migration` (separate PRs).
 - No JavaFX modernization work started in this inventory PR.
 - No Maven publication layout or `habitv-repo` contract was changed.

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -126,7 +126,8 @@ If you deploy without the profile, run the publisher script after `mvn deploy`:
 ./scripts/static-repo/publish-repository-extras.sh
 ```
 
-Tool sources: `scripts/static-repo/tool-sources.properties`.
+Tool sources: `scripts/static-repo/tool-sources.properties` (includes `yt-dlp`;
+publish `tools/yt-dlp/latest/yt-dlp.zip` to `habitv-repo` in a follow-up PR).
 
 Skipped by default: `rtmpdump` (no reliable upstream Windows binary), `adobeHDS`
 (runtime expects `AdobeHDS.exe`; plugin ships `AdobeHDS.php` only).

--- a/docs/ytdlp-cli-compatibility.md
+++ b/docs/ytdlp-cli-compatibility.md
@@ -1,0 +1,57 @@
+# yt-dlp CLI compatibility (YouTube plugin)
+
+Habitv's `plugins/youtube` module keeps the Maven/plugin id **`youtube`** for
+compatibility. The external downloader binary contract now targets **yt-dlp**
+instead of **youtube-dl**.
+
+## Binary names
+
+| Platform | Default path / name |
+|----------|---------------------|
+| Windows | `yt-dlp.exe` (under configured `bin` dir when not overridden) |
+| Linux / Unix | `yt-dlp` on `PATH`, or an absolute path in user config |
+
+Runtime auto-update looks up artifact id **`yt-dlp`** (formerly `youtube-dl`).
+
+## Default command templates
+
+Resolved at download time (`#VIDEO_URL#` → URL, `#FILE_DEST#` → output path):
+
+**Video (default)**
+
+```text
+"<url>" -o "<dest>" --write-sub --write-auto-sub --no-check-certificate
+```
+
+**MP3 (`youtube-mp3` downloader)**
+
+```text
+"<url>" -o "<dest>" --extract-audio --audio-format mp3 --no-check-certificate
+```
+
+These flags are the subset Habitv relied on with youtube-dl; yt-dlp accepts them
+for the supported sites. Habitv does **not** pass DRM bypass, cookie, browser
+profile, or authentication flags.
+
+## Progress output
+
+`YtDlpCmdExecutor` parses percentage lines matching yt-dlp / legacy youtube-dl
+style output, e.g. `[download]  45.2% of ...`.
+
+## User migration (deprecation)
+
+If you configured a manual path to `youtube-dl` or `youtube-dl.exe`, install
+[yt-dlp](https://github.com/yt-dlp/yt-dlp) and point `<youtube>` in
+`configuration.xml` to that binary (see `application/core/configuration.xml`
+sample: `bin\yt-dlp.exe` on Windows).
+
+No provider rewrite or live endpoint validation is included in the binary
+migration PR; non-YouTube URL domains accepted by `YoutubePluginDownloader`
+are unchanged.
+
+## Out of scope for this contract
+
+- Provider discovery / `canDownload()` domain list changes
+- YouTube Data API key handling (unchanged)
+- Runtime updater default URL enablement
+- Publishing binaries to `habitv-repo` (separate follow-up)

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
@@ -11,12 +11,20 @@ public final class YoutubeConf {
 	public static final String NAME = "youtube";
 	public static final String NAME_MP3 = "youtube-mp3";
 	public static final String ENCODING = "UTF-8";
+	/**
+	 * Default video download flags for yt-dlp (youtube-dl compatible subset).
+	 * Placeholders {@link com.dabi.habitv.framework.FrameworkConf#DOWNLOAD_INPUT} and
+	 * {@link com.dabi.habitv.framework.FrameworkConf#DOWNLOAD_DESTINATION} are resolved at runtime.
+	 */
 	public static final String DUMP_CMD = " \"#VIDEO_URL#\" -o \"#FILE_DEST#\"  --write-sub --write-auto-sub --no-check-certificate";
+	/**
+	 * Default MP3 extraction flags for yt-dlp ({@code --extract-audio} / {@code --audio-format}).
+	 */
 	public static final String DUMP_CMD_MP3 = " \"#VIDEO_URL#\" -o \"#FILE_DEST#\"  --extract-audio --audio-format mp3 --no-check-certificate";
 
 	public static final long MAX_HUNG_TIME = 300000L;
-	public static final String DEFAULT_WINDOWS_EXE = "youtube-dl.exe";
-	public static final String DEFAULT_LINUX_BIN_PATH = "youtube-dl";
+	public static final String DEFAULT_WINDOWS_EXE = "yt-dlp.exe";
+	public static final String DEFAULT_LINUX_BIN_PATH = "yt-dlp";
 	public static final String BASE_URL = "https://www.youtube.com";
 
 	public static String resolveApiKey() {

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeDLCmdExecutor.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeDLCmdExecutor.java
@@ -1,39 +1,14 @@
 package com.dabi.habitv.plugin.youtube;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import com.dabi.habitv.framework.FrameworkConf;
-import com.dabi.habitv.framework.plugin.utils.CmdExecutor;
-
-public class YoutubeDLCmdExecutor extends CmdExecutor {
-
-	private static final Pattern PROGRESS_PATTERN = Pattern
-			.compile(".*\\s(\\d+.\\d+)%.*");
+/**
+ * @deprecated Use {@link YtDlpCmdExecutor}. Retained for binary compatibility with
+ *             any external references to this type name.
+ */
+@Deprecated
+public class YoutubeDLCmdExecutor extends YtDlpCmdExecutor {
 
 	public YoutubeDLCmdExecutor(final String cmdProcessor, final String cmd) {
-		super(cmdProcessor, cmd, YoutubeConf.MAX_HUNG_TIME);
-	}
-
-	@Override
-	protected String handleProgression(final String line) {
-		final Matcher matcher = PROGRESS_PATTERN.matcher(line);
-		final boolean hasMatched = matcher.find();
-		String ret = null;
-		if (hasMatched) {
-			ret = matcher.group(matcher.groupCount());
-		}
-		return ret;
-	}
-
-	@Override
-	protected boolean isSuccess(final String fullOutput) {
-		return true;
-	}
-
-	@Override
-	protected long getHungProcessTime() {
-		return FrameworkConf.HUNG_PROCESS_TIME;
+		super(cmdProcessor, cmd);
 	}
 
 }

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
@@ -41,7 +41,7 @@ public class YoutubePluginDownloader extends BaseUpdatablePlugin implements Plug
 		// }
 
 		try {
-			return (new YoutubeDLCmdExecutor(downloaders.getCmdProcessor(), cmd));
+			return (new YtDlpCmdExecutor(downloaders.getCmdProcessor(), cmd));
 		} catch (final ExecutorFailedException e) {
 			throw new DownloadFailedException(e);
 		}
@@ -69,7 +69,7 @@ public class YoutubePluginDownloader extends BaseUpdatablePlugin implements Plug
 
 	@Override
 	protected String[] getFilesToUpdate() {
-		return new String[] { "youtube-dl" };
+		return new String[] { "yt-dlp" };
 	}
 
 	@Override

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpCmdExecutor.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpCmdExecutor.java
@@ -1,0 +1,43 @@
+package com.dabi.habitv.plugin.youtube;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.dabi.habitv.framework.FrameworkConf;
+import com.dabi.habitv.framework.plugin.utils.CmdExecutor;
+
+/**
+ * Runs yt-dlp (or a user-configured compatible binary) and parses download progress
+ * from stdout/stderr lines such as {@code [download]  45.2% of ...}.
+ */
+public class YtDlpCmdExecutor extends CmdExecutor {
+
+	private static final Pattern PROGRESS_PATTERN = Pattern
+			.compile(".*\\s(\\d+.\\d+)%.*");
+
+	public YtDlpCmdExecutor(final String cmdProcessor, final String cmd) {
+		super(cmdProcessor, cmd, YoutubeConf.MAX_HUNG_TIME);
+	}
+
+	@Override
+	protected String handleProgression(final String line) {
+		final Matcher matcher = PROGRESS_PATTERN.matcher(line);
+		final boolean hasMatched = matcher.find();
+		String ret = null;
+		if (hasMatched) {
+			ret = matcher.group(matcher.groupCount());
+		}
+		return ret;
+	}
+
+	@Override
+	protected boolean isSuccess(final String fullOutput) {
+		return true;
+	}
+
+	@Override
+	protected long getHungProcessTime() {
+		return FrameworkConf.HUNG_PROCESS_TIME;
+	}
+
+}

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
@@ -2,10 +2,36 @@ package com.dabi.habitv.plugin.youtube;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 public class YoutubeConfTest {
+
+	@Test
+	public void defaultWindowsExecutableIsYtDlpExe() {
+		assertEquals("yt-dlp.exe", YoutubeConf.DEFAULT_WINDOWS_EXE);
+	}
+
+	@Test
+	public void defaultLinuxBinaryIsYtDlp() {
+		assertEquals("yt-dlp", YoutubeConf.DEFAULT_LINUX_BIN_PATH);
+	}
+
+	@Test
+	public void defaultVideoCommandIncludesUrlAndOutputPlaceholders() {
+		assertTrue(YoutubeConf.DUMP_CMD.contains("#VIDEO_URL#"));
+		assertTrue(YoutubeConf.DUMP_CMD.contains("#FILE_DEST#"));
+		assertTrue(YoutubeConf.DUMP_CMD.contains("--write-sub"));
+		assertTrue(YoutubeConf.DUMP_CMD.contains("--write-auto-sub"));
+		assertTrue(YoutubeConf.DUMP_CMD.contains("--no-check-certificate"));
+	}
+
+	@Test
+	public void defaultMp3CommandIncludesExtractAudioFlags() {
+		assertTrue(YoutubeConf.DUMP_CMD_MP3.contains("--extract-audio"));
+		assertTrue(YoutubeConf.DUMP_CMD_MP3.contains("--audio-format mp3"));
+	}
 
 	@Test
 	public void normalizeApiKeyReturnsNullForNullInput() {

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeOfflineFixtureBaselineTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeOfflineFixtureBaselineTest.java
@@ -20,8 +20,8 @@ public class YoutubeOfflineFixtureBaselineTest {
 			String content = readUtf8(input);
 			assertTrue("fixture metadata must mention provider", content.contains("provider=youtube"));
 			assertTrue("fixture metadata must disable network access", content.contains("network=disabled"));
-			assertTrue("fixture metadata must keep yt-dlp migration out of scope",
-					content.contains("ytdlpMigrationScope=out-of-scope"));
+			assertTrue("fixture metadata must record yt-dlp migration scope",
+					content.contains("ytdlpMigrationScope=binary-contract-migrated"));
 		}
 	}
 

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
@@ -1,8 +1,11 @@
 package com.dabi.habitv.plugin.youtube;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -13,6 +16,7 @@ import com.dabi.habitv.api.plugin.api.PluginDownloaderInterface.DownloadableStat
 import com.dabi.habitv.api.plugin.dto.DownloadParamDTO;
 import com.dabi.habitv.api.plugin.holder.DownloaderPluginHolder;
 import com.dabi.habitv.api.plugin.holder.ProcessHolder;
+import com.dabi.habitv.framework.plugin.utils.CmdExecutor;
 
 public class YoutubePluginDownloaderCmdTest {
 
@@ -28,7 +32,13 @@ public class YoutubePluginDownloaderCmdTest {
 	}
 
 	@Test
-	public void downloadReturnsAProcessHolderWithConfiguredYtDlpBinary() {
+	public void getFilesToUpdateReturnsYtDlpArtifactId() {
+		final YoutubePluginDownloader downloader = new YoutubePluginDownloader();
+		assertArrayEquals(new String[] { "yt-dlp" }, downloader.getFilesToUpdate());
+	}
+
+	@Test
+	public void downloadReturnsAProcessHolderWithConfiguredYtDlpBinary() throws Exception {
 		final HashMap<String, String> downloaderName2Bin = new HashMap<>();
 		downloaderName2Bin.put(YoutubeConf.NAME, "/usr/bin/yt-dlp");
 		final DownloaderPluginHolder downloaders = new DownloaderPluginHolder(
@@ -44,5 +54,42 @@ public class YoutubePluginDownloaderCmdTest {
 		final ProcessHolder holder = new YoutubePluginDownloader()
 				.download(param, downloaders);
 		assertNotNull(holder);
+		assertTrue(holder instanceof YtDlpCmdExecutor);
+		final String cmd = readCmd(holder);
+		assertTrue(cmd.startsWith("/usr/bin/yt-dlp "));
+		assertTrue(cmd.contains("https://www.youtube.com/watch?v=jNQXAC9IVRw"));
+		assertTrue(cmd.contains("/tmp/out/test.mp4"));
+		assertTrue(cmd.contains("--write-sub"));
+		assertTrue(cmd.contains("--write-auto-sub"));
+		assertTrue(cmd.contains("--no-check-certificate"));
+	}
+
+	@Test
+	public void downloadWithMp3ArgsIncludesExtractAudioFlags() throws Exception {
+		final HashMap<String, String> downloaderName2Bin = new HashMap<>();
+		downloaderName2Bin.put(YoutubeConf.NAME, "/usr/bin/yt-dlp");
+		final DownloaderPluginHolder downloaders = new DownloaderPluginHolder(
+				"/bin/sh -c #CMD#",
+				Collections.<String, PluginDownloaderInterface>emptyMap(),
+				downloaderName2Bin, "/tmp/out", "/tmp/idx", "/tmp/bin",
+				"/tmp/plugins");
+
+		final DownloadParamDTO param = new DownloadParamDTO(
+				"https://www.youtube.com/watch?v=jNQXAC9IVRw",
+				"/tmp/out/test.mp3", "mp3");
+		param.addParam(com.dabi.habitv.framework.FrameworkConf.PARAMETER_ARGS,
+				YoutubeConf.DUMP_CMD_MP3);
+
+		final ProcessHolder holder = new YoutubePluginDownloader()
+				.download(param, downloaders);
+		final String cmd = readCmd(holder);
+		assertTrue(cmd.contains("--extract-audio"));
+		assertTrue(cmd.contains("--audio-format mp3"));
+	}
+
+	private static String readCmd(final ProcessHolder holder) throws Exception {
+		final Field field = CmdExecutor.class.getDeclaredField("cmd");
+		field.setAccessible(true);
+		return (String) field.get(holder);
 	}
 }

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpCmdExecutorTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpCmdExecutorTest.java
@@ -1,0 +1,33 @@
+package com.dabi.habitv.plugin.youtube;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class YtDlpCmdExecutorTest {
+
+	private static final class TestableExecutor extends YtDlpCmdExecutor {
+
+		TestableExecutor() {
+			super("/bin/sh -c #CMD#", "yt-dlp");
+		}
+
+		String parseProgress(final String line) {
+			return handleProgression(line);
+		}
+	}
+
+	@Test
+	public void parseProgressFromYtDlpDownloadLine() {
+		final TestableExecutor executor = new TestableExecutor();
+		assertEquals("45.2", executor.parseProgress("[download]  45.2% of 10.00MiB at 1.23MiB/s ETA 00:05"));
+	}
+
+	@Test
+	public void parseProgressReturnsNullWhenNoPercentage() {
+		final TestableExecutor executor = new TestableExecutor();
+		assertNull(executor.parseProgress("[info] Downloading webpage"));
+	}
+
+}

--- a/plugins/youtube/test/resources/fixtures/youtube/fixture-baseline.txt
+++ b/plugins/youtube/test/resources/fixtures/youtube/fixture-baseline.txt
@@ -1,4 +1,4 @@
 provider=youtube
-ytdlpMigrationScope=out-of-scope
+ytdlpMigrationScope=binary-contract-migrated
 network=disabled
-note=Fixture boundary marker for provider inventory phase only.
+note=Offline fixture boundary; no live endpoint validation in yt-dlp migration PR.

--- a/scripts/static-repo/habitv-update-manifest.properties.example
+++ b/scripts/static-repo/habitv-update-manifest.properties.example
@@ -3,4 +3,4 @@
 #
 # plugin|com.dabi.habitv|6play|4.1.0-SNAPSHOT|jar|com/dabi/habitv/6play/4.1.0-SNAPSHOT/6play-4.1.0-SNAPSHOT.jar
 # tool|com.dabi.habitv|ffmpeg|3.0|zip|tools/ffmpeg/3.0/ffmpeg.zip
-# tool|com.dabi.habitv|youtube-dl|latest|zip|tools/youtube-dl/latest/youtube-dl.zip
+# tool|com.dabi.habitv|yt-dlp|latest|zip|tools/yt-dlp/latest/yt-dlp.zip

--- a/scripts/static-repo/tool-sources.properties
+++ b/scripts/static-repo/tool-sources.properties
@@ -4,10 +4,10 @@
 #
 # type=url means download a single file; type=zip means download and extract packagedExeName from inner path
 #
-youtube-dl.type=url
-youtube-dl.version=latest
-youtube-dl.url=https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe
-youtube-dl.packagedExeName=youtube-dl.exe
+yt-dlp.type=url
+yt-dlp.version=latest
+yt-dlp.url=https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe
+yt-dlp.packagedExeName=yt-dlp.exe
 
 ffmpeg.type=zip
 ffmpeg.version=latest


### PR DESCRIPTION
## Summary

Migrates the `plugins/youtube` downloader binary contract from youtube-dl to yt-dlp (defaults, updater artifact id, command executor) while keeping the plugin module id `youtube` and existing `canDownload()` URL domains.

## What changed

- Default binaries: `yt-dlp.exe` (Windows), `yt-dlp` (Linux/PATH)
- `getFilesToUpdate()` returns `yt-dlp` (was `youtube-dl`)
- New `YtDlpCmdExecutor`; deprecated `YoutubeDLCmdExecutor` extends it
- Sample `application/core/configuration.xml` points to `bin\yt-dlp.exe`
- Static-repo tool metadata (`scripts/static-repo/tool-sources.properties`) renamed to `yt-dlp`
- Offline tests for defaults, command wiring, MP3 flags, progress parsing
- `docs/ytdlp-cli-compatibility.md` and tracker updates (`ytdlp-migration` → in progress, 75%)

## Backward compatibility

- Plugin/downloader id remains **`youtube`** (and `youtube-mp3` for MP3).
- Users who configured a manual path to `youtube-dl` / `youtube-dl.exe` must install yt-dlp and update `<youtube>` in their config.
- `YoutubeDLCmdExecutor` remains as a deprecated subclass of `YtDlpCmdExecutor`.

## Command compatibility notes

Default templates (unchanged flags, yt-dlp compatible):

- Video: URL + `-o` dest + `--write-sub` + `--write-auto-sub` + `--no-check-certificate`
- MP3: above + `--extract-audio` + `--audio-format mp3`

See `docs/ytdlp-cli-compatibility.md`.

## Out of scope

- No provider rewrite.
- No DRM/auth/cookies/browser profile handling.
- No live-network tests added; `YoutubePluginManagerTest` still hits the YouTube Data API (pre-existing).
- No `habitv-repo` publication.
- No JavaFX modernization.
- No runtime updater default behavior change.
- No YouTube Data API key behavior change.

## Validation results

```
git status --short
?? .vscode/
(clean otherwise; .vscode not committed)

mvn -B -ntp -DskipTests validate
[INFO] BUILD SUCCESS
[INFO] Total time:  0.978 s (first run) / 0.385 s (post-commit)

mvn -B -ntp -DskipTests compile
[INFO] BUILD SUCCESS
[INFO] Total time:  7.428 s

mvn -B -ntp -pl plugins/youtube -am "-Dsurefire.failIfNoSpecifiedTests=false" test
(PowerShell: -D property must be quoted)
[INFO] Tests run: 17, Failures: 0, Errors: 1, Skipped: 0
[ERROR] YoutubePluginManagerTest.test — HTTP 403 from YouTube Data API (live test, pre-existing)
[INFO] youtube module offline tests (Conf, Cmd, YtDlpCmdExecutor, fixture baseline, downloader): 16/16 pass

git diff --check
Exit 2: CRLF/trailing-whitespace warnings on Windows-touched Java/XML lines (no conflict markers)

python -m json.tool docs/dev-tracker.json > $null
exit: 0
```

## Follow-up items

- Publish `tools/yt-dlp/latest/yt-dlp.zip` into **habitv-repo** (separate PR; metadata in habitv already uses `yt-dlp`)
- Opt-in runtime update smoke test against live static repository
- Reassess non-YouTube URL domains accepted by `YoutubePluginDownloader.canDownload()`
- Continue provider cleanup (FranceTV / M6+) after YouTube migration is stable
- Live fixture validation for `ytdlp-migration` acceptance criterion

## Linked tracker item

- HBTV-007 / `ytdlp-migration`