### PR TITLE
fix(arte): restore ARTE provider discovery through EMAC API

### DIFF
--- a/plugins/arte/pom.xml
+++ b/plugins/arte/pom.xml
@@ -32,5 +32,11 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.dabi.habitv</groupId>
+			<artifactId>youtube</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/plugins/arte/pom.xml
+++ b/plugins/arte/pom.xml
@@ -23,10 +23,6 @@
 			<artifactId>framework</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jsoup</groupId>
-			<artifactId>jsoup</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
 			<version>${project.version}</version>

--- a/plugins/arte/pom.xml
+++ b/plugins/arte/pom.xml
@@ -28,11 +28,5 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.dabi.habitv</groupId>
-			<artifactId>youtube</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/plugins/arte/src/com/dabi/habitv/provider/arte/ArteConf.java
+++ b/plugins/arte/src/com/dabi/habitv/provider/arte/ArteConf.java
@@ -6,18 +6,31 @@ interface ArteConf {
 
 	String NAME = "arte";
 
-	String CAT_PAGE = "http://www.arte.tv/guide/fr/plus7";
+	String HOME_URL = "https://www.arte.tv";
 
-	String ID_EMISSION_TOKEN = "#ID_EMISSION#";
+	String EMAC_API_BASE = "https://www.arte.tv/api/rproxy/emac/v4";
 
-	String RSS_CATEGORY_URL = "http://videos.arte.tv/fr/do_delegate/videos/programmes/" + ID_EMISSION_TOKEN + ",view,rss.xml";
+	/** Query param required by EMAC zone listing endpoints. */
+	String AUTHORIZED_COUNTRY = "FR";
 
-	String ID_EPISODE_TOKEN = "#ID_EPISODE#";
+	String[][] LANGUAGES = {
+			{ "fr", "Français" },
+			{ "de", "Deutsch" },
+			{ "en", "English" },
+	};
 
-	String RTMPDUMP_CMD = "-r \"#VIDEO_URL#\" -c 1935 -m 10 -o \"#FILE_DEST#\"";
-
-	String HOME_URL = "http://www.arte.tv";
+	/**
+	 * Stable EMAC page codes used to discover replay categories.
+	 */
+	String[][] PAGE_CODES = {
+			{ "DOR", "Documentaries" },
+			{ "CIN", "Cinema" },
+			{ "SER", "Series" },
+			{ "ACT", "News & Society" },
+			{ "CPO", "Culture & Pop" },
+			{ "SCI", "Science" },
+			{ "HIS", "History" },
+	};
 
 	String EXTENSION = FrameworkConf.MP4;
-
 }

--- a/plugins/arte/src/com/dabi/habitv/provider/arte/ArtePluginManager.java
+++ b/plugins/arte/src/com/dabi/habitv/provider/arte/ArtePluginManager.java
@@ -1,26 +1,37 @@
 package com.dabi.habitv.provider.arte;
 
-import java.util.Collection;
+import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 
 import com.dabi.habitv.api.plugin.api.PluginProviderDownloaderInterface;
 import com.dabi.habitv.api.plugin.dto.CategoryDTO;
 import com.dabi.habitv.api.plugin.dto.DownloadParamDTO;
 import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
 import com.dabi.habitv.api.plugin.exception.DownloadFailedException;
+import com.dabi.habitv.api.plugin.exception.TechnicalException;
 import com.dabi.habitv.api.plugin.holder.DownloaderPluginHolder;
 import com.dabi.habitv.api.plugin.holder.ProcessHolder;
 import com.dabi.habitv.framework.plugin.api.BasePluginWithProxy;
 import com.dabi.habitv.framework.plugin.utils.DownloadUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ArtePluginManager extends BasePluginWithProxy implements PluginProviderDownloaderInterface { // NO_UCD
+
+	private static final Pattern EPISODE_URL_PATTERN = Pattern.compile(
+			"https://www\\.arte\\.tv/[a-z]{2}/videos/\\d{6}-\\d{3}-[AF]/[^\"'\\s<>]+");
+
+	private static final String CATEGORY_ID_SEPARATOR = ":";
+
+	private static final int MAX_ZONE_PAGES = 25;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Override
 	public String getName() {
@@ -29,85 +40,148 @@ public class ArtePluginManager extends BasePluginWithProxy implements PluginProv
 
 	@Override
 	public Set<EpisodeDTO> findEpisode(final CategoryDTO category) {
-		final Set<EpisodeDTO> episodes = new LinkedHashSet<>();
-
-		Document doc = Jsoup.parse(getUrlContent(category.getId()));
-		for (Element aEp : doc.select("section#videos article a")) {
-			String url = ArteConf.HOME_URL + aEp.attr("href");
-			final String name = aEp.select("h3").first().text();
-			if (!StringUtils.isEmpty(name)) {
-				episodes.add(new EpisodeDTO(category, name, url));
-			}
+		final String[] categoryParts = parseCategoryId(category.getId());
+		if (categoryParts == null) {
+			return new LinkedHashSet<>();
 		}
-//		for (Element aEp : doc.select("div#playlistContainer li")) {
-//			String url = ArteConf.HOME_URL + aEp.attr("href");
-//			final String name = aEp.select("h3").first().text();
-//			if (!StringUtils.isEmpty(name)) {
-//				episodes.add(new EpisodeDTO(category, name, url));
-//			}
-//		}		
-		return episodes;
+		try {
+			return loadEpisodesFromPage(category, categoryParts[0], categoryParts[1]);
+		} catch (final TechnicalException e) {
+			return new LinkedHashSet<>();
+		}
 	}
 
 	@Override
 	public Set<CategoryDTO> findCategory() {
 		final Set<CategoryDTO> categories = new LinkedHashSet<>();
 
-		final Document doc = Jsoup.parse(getUrlContent(ArteConf.HOME_URL));
-
-		final Elements aChannels = doc.select("ul.next-language__list li.next-language__list-item a");
-
-		for (final Element aLanguage : aChannels) {
-			String href = aLanguage.attr("href");
-			String language = aLanguage.text();
-			CategoryDTO languageCat = new CategoryDTO(ArteConf.NAME, language, href, ArteConf.EXTENSION);
+		for (final String[] language : ArteConf.LANGUAGES) {
+			final String langCode = language[0];
+			final String langLabel = language[1];
+			final String homeUrl = ArteConf.HOME_URL + "/" + langCode + "/";
+			final CategoryDTO languageCat = new CategoryDTO(ArteConf.NAME, langLabel, homeUrl, ArteConf.EXTENSION);
 			languageCat.setDownloadable(false);
-			languageCat.addSubCategories(findCategoryByLanguage(href));
+			for (final String[] pageCode : ArteConf.PAGE_CODES) {
+				final String categoryId = buildCategoryId(langCode, pageCode[0]);
+				final CategoryDTO mainCategory = new CategoryDTO(ArteConf.NAME, pageCode[1], categoryId, ArteConf.EXTENSION);
+				mainCategory.setDownloadable(true);
+				languageCat.addSubCategory(mainCategory);
+			}
 			categories.add(languageCat);
 		}
 
 		return categories;
 	}
 
-	private Collection<CategoryDTO> findCategoryByLanguage(String languageUrl) {
-		final Set<CategoryDTO> categories = new LinkedHashSet<>();
-
-		final Document doc = Jsoup.parse(getUrlContent(languageUrl));
-
-		final Elements aMainCats = doc.select("ul.next-menu-nav__main-menu li.next-menu-nav__menu-item a");
-
-		for (final Element aMainCat : aMainCats) {
-			String url = ArteConf.HOME_URL + aMainCat.attr("href");
-			String text = aMainCat.text();
-			CategoryDTO mainCat = new CategoryDTO(ArteConf.NAME, text, url, ArteConf.EXTENSION);
-			mainCat.setDownloadable(false);
-			mainCat.addSubCategories(findSubCategory(url));
-			categories.add(mainCat);
+	private Set<EpisodeDTO> loadEpisodesFromPage(final CategoryDTO category, final String languageCode, final String pageCode) {
+		final Set<EpisodeDTO> episodes = new LinkedHashSet<>();
+		final String pageUrl = buildPageUrl(languageCode, pageCode);
+		final JsonNode pageRoot = parseJson(getUrlContent(pageUrl), pageUrl);
+		final JsonNode zones = pageRoot.path("value").path("zones");
+		if (!zones.isArray()) {
+			return episodes;
 		}
-
-		return categories;
+		for (final JsonNode zone : zones) {
+			final JsonNode content = zone.path("content");
+			addEpisodesFromDataNode(category, episodes, content.path("data"));
+			loadZonePagination(category, episodes, languageCode, pageCode, zone.path("code").asText(), content.path("pagination"));
+		}
+		return episodes;
 	}
 
-	private Collection<CategoryDTO> findSubCategory(String catUrl) {
-		final Set<CategoryDTO> categories = new LinkedHashSet<>();
-
-		final Document doc = Jsoup.parse(getUrlContent(catUrl));
-
-		addSubCategories(categories, doc, "collections");
-		//addSubCategories(categories, doc, "playlists_");
-
-		return categories;
+	private void loadZonePagination(final CategoryDTO category, final Set<EpisodeDTO> episodes, final String languageCode,
+			final String pageCode, final String zoneCode, final JsonNode pagination) {
+		if (StringUtils.isEmpty(zoneCode) || !pagination.has("pages")) {
+			return;
+		}
+		final int pages = Math.min(pagination.path("pages").asInt(1), MAX_ZONE_PAGES);
+		for (int pageNumber = 2; pageNumber <= pages; pageNumber++) {
+			final String zoneUrl = buildZoneUrl(languageCode, zoneCode, pageCode, pageNumber);
+			try {
+				final JsonNode zoneRoot = parseJson(getUrlContent(zoneUrl), zoneUrl);
+				addEpisodesFromDataNode(category, episodes, zoneRoot.path("value").path("data"));
+			} catch (final TechnicalException e) {
+				// EMAC sometimes reports extra pages that return HTTP 400; keep already fetched episodes.
+				break;
+			}
+		}
 	}
 
-	private void addSubCategories(final Set<CategoryDTO> categories, final Document doc, String clazz) {
-		final Elements aMainCats = doc.select("div[class~="+clazz+"_] article a");
+	private void addEpisodesFromDataNode(final CategoryDTO category, final Set<EpisodeDTO> episodes, final JsonNode data) {
+		if (!data.isArray()) {
+			return;
+		}
+		final Map<String, EpisodeDTO> episodeByUrl = new LinkedHashMap<>();
+		for (final EpisodeDTO episode : episodes) {
+			episodeByUrl.put(episode.getId(), episode);
+		}
+		for (final JsonNode item : data) {
+			addEpisodeFromTeaser(category, episodeByUrl, item);
+		}
+		episodes.clear();
+		episodes.addAll(episodeByUrl.values());
+	}
 
-		for (final Element aMainCat : aMainCats) {
-			String href = aMainCat.attr("href");
-			String text = aMainCat.select("h3").first().text();
-			CategoryDTO cat = new CategoryDTO(ArteConf.NAME, text, href, ArteConf.EXTENSION);
-			cat.setDownloadable(true);
-			categories.add(cat);
+	private void addEpisodeFromTeaser(final CategoryDTO category, final Map<String, EpisodeDTO> episodeByUrl, final JsonNode item) {
+		final String url = resolveUrl(item.path("url").asText(null));
+		if (StringUtils.isEmpty(url) || !EPISODE_URL_PATTERN.matcher(url).find()) {
+			return;
+		}
+		String title = item.path("title").asText(null);
+		if (StringUtils.isEmpty(title)) {
+			title = item.path("subtitle").asText(null);
+		}
+		if (StringUtils.isEmpty(title)) {
+			return;
+		}
+		if (!episodeByUrl.containsKey(url)) {
+			episodeByUrl.put(url, new EpisodeDTO(category, title, url));
+		}
+	}
+
+	private String buildCategoryId(final String languageCode, final String pageCode) {
+		return languageCode + CATEGORY_ID_SEPARATOR + pageCode;
+	}
+
+	private String[] parseCategoryId(final String categoryId) {
+		if (StringUtils.isEmpty(categoryId)) {
+			return null;
+		}
+		final String[] parts = categoryId.split(CATEGORY_ID_SEPARATOR);
+		if (parts.length != 2 || StringUtils.isEmpty(parts[0]) || StringUtils.isEmpty(parts[1])) {
+			return null;
+		}
+		return parts;
+	}
+
+	private String buildPageUrl(final String languageCode, final String pageCode) {
+		return ArteConf.EMAC_API_BASE + "/" + languageCode + "/web/pages/" + pageCode + "/?authorizedCountry="
+				+ ArteConf.AUTHORIZED_COUNTRY;
+	}
+
+	private String buildZoneUrl(final String languageCode, final String zoneCode, final String pageCode, final int pageNumber) {
+		return ArteConf.EMAC_API_BASE + "/" + languageCode + "/web/zones/" + zoneCode + "/content?page=" + pageNumber
+				+ "&pageId=" + pageCode + "&authorizedCountry=" + ArteConf.AUTHORIZED_COUNTRY;
+	}
+
+	private String resolveUrl(final String url) {
+		if (StringUtils.isEmpty(url)) {
+			return url;
+		}
+		if (url.startsWith("http://") || url.startsWith("https://")) {
+			return url;
+		}
+		if (url.startsWith("/")) {
+			return ArteConf.HOME_URL + url;
+		}
+		return ArteConf.HOME_URL + "/" + url;
+	}
+
+	private JsonNode parseJson(final String json, final String sourceUrl) {
+		try {
+			return objectMapper.readTree(json);
+		} catch (final IOException e) {
+			throw new TechnicalException("Cannot parse Arte EMAC response from " + sourceUrl, e);
 		}
 	}
 

--- a/plugins/arte/src/com/dabi/habitv/provider/arte/ArtePluginManager.java
+++ b/plugins/arte/src/com/dabi/habitv/provider/arte/ArtePluginManager.java
@@ -1,9 +1,7 @@
 package com.dabi.habitv.provider.arte;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -31,7 +29,7 @@ public class ArtePluginManager extends BasePluginWithProxy implements PluginProv
 
 	private static final int MAX_ZONE_PAGES = 25;
 
-	private final ObjectMapper objectMapper = new ObjectMapper();
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	@Override
 	public String getName() {
@@ -47,6 +45,7 @@ public class ArtePluginManager extends BasePluginWithProxy implements PluginProv
 		try {
 			return loadEpisodesFromPage(category, categoryParts[0], categoryParts[1]);
 		} catch (final TechnicalException e) {
+			getLog().warn("Failed to load Arte episodes for category " + category.getId(), e);
 			return new LinkedHashSet<>();
 		}
 	}
@@ -111,18 +110,12 @@ public class ArtePluginManager extends BasePluginWithProxy implements PluginProv
 		if (!data.isArray()) {
 			return;
 		}
-		final Map<String, EpisodeDTO> episodeByUrl = new LinkedHashMap<>();
-		for (final EpisodeDTO episode : episodes) {
-			episodeByUrl.put(episode.getId(), episode);
-		}
 		for (final JsonNode item : data) {
-			addEpisodeFromTeaser(category, episodeByUrl, item);
+			addEpisodeFromTeaser(category, episodes, item);
 		}
-		episodes.clear();
-		episodes.addAll(episodeByUrl.values());
 	}
 
-	private void addEpisodeFromTeaser(final CategoryDTO category, final Map<String, EpisodeDTO> episodeByUrl, final JsonNode item) {
+	private void addEpisodeFromTeaser(final CategoryDTO category, final Set<EpisodeDTO> episodes, final JsonNode item) {
 		final String url = resolveUrl(item.path("url").asText(null));
 		if (StringUtils.isEmpty(url) || !EPISODE_URL_PATTERN.matcher(url).find()) {
 			return;
@@ -134,9 +127,7 @@ public class ArtePluginManager extends BasePluginWithProxy implements PluginProv
 		if (StringUtils.isEmpty(title)) {
 			return;
 		}
-		if (!episodeByUrl.containsKey(url)) {
-			episodeByUrl.put(url, new EpisodeDTO(category, title, url));
-		}
+		episodes.add(new EpisodeDTO(category, title, url));
 	}
 
 	private String buildCategoryId(final String languageCode, final String pageCode) {
@@ -179,7 +170,7 @@ public class ArtePluginManager extends BasePluginWithProxy implements PluginProv
 
 	private JsonNode parseJson(final String json, final String sourceUrl) {
 		try {
-			return objectMapper.readTree(json);
+			return OBJECT_MAPPER.readTree(json);
 		} catch (final IOException e) {
 			throw new TechnicalException("Cannot parse Arte EMAC response from " + sourceUrl, e);
 		}

--- a/plugins/arte/test/com/dabi/habitv/provider/arte/ArteEmacParsingOfflineTest.java
+++ b/plugins/arte/test/com/dabi/habitv/provider/arte/ArteEmacParsingOfflineTest.java
@@ -1,0 +1,137 @@
+package com.dabi.habitv.provider.arte;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+import com.dabi.habitv.api.plugin.exception.TechnicalException;
+
+/**
+ * Offline test covering {@link ArtePluginManager} category browsing and EMAC
+ * teaser parsing against captured JSON fixtures. Runs without network access so
+ * the parsing contract can be verified in CI sandboxes where arte.tv is
+ * unreachable.
+ */
+public class ArteEmacParsingOfflineTest {
+
+	private static final String PAGE_FIXTURE = "test/resources/fixtures/arte/emac-page-DOR.json";
+	private static final String ZONE_PAGE2_FIXTURE = "test/resources/fixtures/arte/emac-zone-page2.json";
+
+	@Test
+	public void findCategoryReturnsLanguageTreeWithStablePageCodes() {
+		final ArtePluginManager plugin = new ArtePluginManager();
+
+		final Set<CategoryDTO> languages = plugin.findCategory();
+
+		assertEquals("one CategoryDTO per supported language", ArteConf.LANGUAGES.length, languages.size());
+		for (final CategoryDTO language : languages) {
+			assertFalse("language container must not be downloadable", language.isDownloadable());
+			assertEquals("each language exposes the configured page codes",
+					ArteConf.PAGE_CODES.length, language.getSubCategories().size());
+			for (final CategoryDTO sub : language.getSubCategories()) {
+				assertTrue("sub-category id must include language:pageCode separator",
+						sub.getId().contains(":"));
+				assertTrue("sub-categories must be downloadable", sub.isDownloadable());
+			}
+		}
+	}
+
+	@Test
+	public void findEpisodeParsesTeasersFiltersInvalidUrlsAndDedupes() throws IOException {
+		final Map<String, String> urlToContent = new HashMap<>();
+		final String pageUrl = "https://www.arte.tv/api/rproxy/emac/v4/fr/web/pages/DOR/?authorizedCountry=FR";
+		urlToContent.put(pageUrl, readFixture(PAGE_FIXTURE));
+		urlToContent.put(
+				"https://www.arte.tv/api/rproxy/emac/v4/fr/web/zones/listing_DOCUMENTARIES_main/content?page=2&pageId=DOR&authorizedCountry=FR",
+				readFixture(ZONE_PAGE2_FIXTURE));
+
+		final RecordingArtePlugin plugin = new RecordingArtePlugin(urlToContent);
+		final CategoryDTO category = new CategoryDTO(ArteConf.NAME, "Documentaries", "fr:DOR", ArteConf.EXTENSION);
+
+		final Set<EpisodeDTO> episodes = plugin.findEpisode(category);
+
+		final List<String> ids = new ArrayList<>();
+		final List<String> names = new ArrayList<>();
+		for (final EpisodeDTO episode : episodes) {
+			ids.add(episode.getId());
+			names.add(episode.getName());
+		}
+
+		assertTrue("absolute https URL preserved",
+				ids.contains("https://www.arte.tv/fr/videos/119999-001-A/test-documentary-two/"));
+		assertTrue("relative URL resolved against HOME_URL",
+				ids.contains("https://www.arte.tv/fr/videos/119999-000-A/test-documentary-one/"));
+		assertTrue("teaser without title falls back to subtitle",
+				names.contains("Subtitle Only Three"));
+		assertTrue("zone pagination fetched page 2",
+				ids.contains("https://www.arte.tv/fr/videos/119999-200-A/page-two-item/"));
+		assertFalse("non-episode URL filtered out by EPISODE_URL_PATTERN",
+				ids.contains("https://www.arte.tv/fr/programmes/119999/"));
+		assertFalse("teaser without title or subtitle dropped",
+				ids.contains("https://www.arte.tv/fr/videos/119999-003-A/test-no-title/"));
+		assertEquals("duplicate URL collapses into a single episode",
+				new java.util.HashSet<>(ids).size(), ids.size());
+		assertEquals("expected episodes after filtering and dedup", 6, episodes.size());
+	}
+
+	@Test
+	public void findEpisodeRejectsInvalidCategoryIdentifiers() {
+		final ArtePluginManager plugin = new ArtePluginManager();
+		assertTrue(plugin.findEpisode(new CategoryDTO(ArteConf.NAME, "x", "", ArteConf.EXTENSION)).isEmpty());
+		assertTrue(plugin.findEpisode(new CategoryDTO(ArteConf.NAME, "x", "fr", ArteConf.EXTENSION)).isEmpty());
+		assertTrue(plugin.findEpisode(new CategoryDTO(ArteConf.NAME, "x", "fr:", ArteConf.EXTENSION)).isEmpty());
+	}
+
+	@Test
+	public void findEpisodeReturnsEmptyOnUpstreamFailure() {
+		final RecordingArtePlugin plugin = new RecordingArtePlugin(new HashMap<String, String>());
+		final CategoryDTO category = new CategoryDTO(ArteConf.NAME, "Documentaries", "fr:DOR", ArteConf.EXTENSION);
+
+		assertTrue("network failures must surface as an empty set, not a runtime exception",
+				plugin.findEpisode(category).isEmpty());
+	}
+
+	private static String readFixture(final String relativePath) throws IOException {
+		try (InputStream input = new FileInputStream(relativePath)) {
+			final ByteArrayOutputStream out = new ByteArrayOutputStream();
+			final byte[] buffer = new byte[4096];
+			int read;
+			while ((read = input.read(buffer)) != -1) {
+				out.write(buffer, 0, read);
+			}
+			return out.toString("UTF-8");
+		}
+	}
+
+	private static final class RecordingArtePlugin extends ArtePluginManager {
+
+		private final Map<String, String> urlToContent;
+
+		RecordingArtePlugin(final Map<String, String> urlToContent) {
+			this.urlToContent = urlToContent;
+		}
+
+		@Override
+		protected String getUrlContent(final String url) {
+			final String content = urlToContent.get(url);
+			if (content == null) {
+				throw new TechnicalException("unexpected URL fetched: " + url);
+			}
+			return content;
+		}
+	}
+}

--- a/plugins/arte/test/com/dabi/habitv/provider/arte/ArtePluginManagerTest.java
+++ b/plugins/arte/test/com/dabi/habitv/provider/arte/ArtePluginManagerTest.java
@@ -1,5 +1,6 @@
 package com.dabi.habitv.provider.arte;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.dabi.habitv.api.plugin.exception.DownloadFailedException;
@@ -7,7 +8,10 @@ import com.dabi.habitv.plugintester.BasePluginProviderTester;
 
 public class ArtePluginManagerTest extends BasePluginProviderTester {
 
+	// arte.tv is a Next.js SPA; legacy Jsoup selectors no longer match static HTML.
+	// Re-enable after provider rewrite (see ArteYtDlpLiveDownloadTest for download path).
 	@Test
+	@Ignore
 	public final void testArtePluginManager() throws InstantiationException, IllegalAccessException, DownloadFailedException {
 		testPluginProvider(ArtePluginManager.class, true);
 	}

--- a/plugins/arte/test/com/dabi/habitv/provider/arte/ArtePluginManagerTest.java
+++ b/plugins/arte/test/com/dabi/habitv/provider/arte/ArtePluginManagerTest.java
@@ -1,6 +1,5 @@
 package com.dabi.habitv.provider.arte;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.dabi.habitv.api.plugin.exception.DownloadFailedException;
@@ -8,10 +7,7 @@ import com.dabi.habitv.plugintester.BasePluginProviderTester;
 
 public class ArtePluginManagerTest extends BasePluginProviderTester {
 
-	// arte.tv is a Next.js SPA; legacy Jsoup selectors no longer match static HTML.
-	// Re-enable after provider rewrite (see ArteYtDlpLiveDownloadTest for download path).
 	@Test
-	@Ignore
 	public final void testArtePluginManager() throws InstantiationException, IllegalAccessException, DownloadFailedException {
 		testPluginProvider(ArtePluginManager.class, true);
 	}

--- a/plugins/arte/test/com/dabi/habitv/provider/arte/ArteYtDlpLiveDownloadTest.java
+++ b/plugins/arte/test/com/dabi/habitv/provider/arte/ArteYtDlpLiveDownloadTest.java
@@ -11,6 +11,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
 
 import org.junit.After;
 import org.junit.Test;
@@ -22,11 +23,11 @@ import com.dabi.habitv.api.plugin.exception.DownloadFailedException;
 import com.dabi.habitv.api.plugin.holder.DownloaderPluginHolder;
 import com.dabi.habitv.api.plugin.holder.ProcessHolder;
 import com.dabi.habitv.framework.FrameworkConf;
-import com.dabi.habitv.plugin.youtube.YoutubePluginDownloader;
+import com.dabi.habitv.framework.plugin.utils.CmdExecutor;
 
 /**
  * Opt-in live download test: ARTE episode URL via {@link ArtePluginManager}
- * delegating to yt-dlp ({@link YoutubePluginDownloader}).
+ * delegating to yt-dlp through the "youtube" downloader key.
  *
  * <p>Run only when explicitly enabled (network + yt-dlp + ffmpeg required):
  * <pre>
@@ -93,7 +94,7 @@ public class ArteYtDlpLiveDownloadTest {
 		downloadParam.addParam(FrameworkConf.PARAMETER_ARGS, YT_DLP_ARGS);
 
 		final Map<String, com.dabi.habitv.api.plugin.api.PluginDownloaderInterface> downloaders = new HashMap<>();
-		downloaders.put("youtube", new YoutubePluginDownloader());
+		downloaders.put("youtube", new YtDlpPassthroughDownloader());
 		final Map<String, String> binPaths = new HashMap<>();
 		binPaths.put("youtube", ytDlpBinary);
 		final DownloaderPluginHolder holder = new DownloaderPluginHolder(CMD_PROCESSOR,
@@ -156,6 +157,32 @@ public class ArteYtDlpLiveDownloadTest {
 		} catch (final InterruptedException e) {
 			Thread.currentThread().interrupt();
 			return null;
+		}
+	}
+
+	private static final class YtDlpPassthroughDownloader implements com.dabi.habitv.api.plugin.api.PluginDownloaderInterface {
+
+		@Override
+		public String getName() {
+			return "youtube";
+		}
+
+		@Override
+		public DownloadableState canDownload(final String downloadInput) {
+			return DownloadableState.SPECIFIC;
+		}
+
+		@Override
+		public ProcessHolder download(final DownloadParamDTO downloadParam, final DownloaderPluginHolder downloaders)
+				throws DownloadFailedException {
+			String cmd = downloaders.getBinPath("youtube") + " ";
+			final String cmdParam = downloadParam.getParam(FrameworkConf.PARAMETER_ARGS);
+			cmd += cmdParam;
+			cmd = cmd.replaceFirst(FrameworkConf.DOWNLOAD_INPUT,
+					Matcher.quoteReplacement(downloadParam.getDownloadInput()));
+			cmd = cmd.replaceFirst(FrameworkConf.DOWNLOAD_DESTINATION,
+					Matcher.quoteReplacement(downloadParam.getDownloadOutput()));
+			return new CmdExecutor(downloaders.getCmdProcessor(), cmd, -1);
 		}
 	}
 }

--- a/plugins/arte/test/com/dabi/habitv/provider/arte/ArteYtDlpLiveDownloadTest.java
+++ b/plugins/arte/test/com/dabi/habitv/provider/arte/ArteYtDlpLiveDownloadTest.java
@@ -42,6 +42,9 @@ public class ArteYtDlpLiveDownloadTest {
 	private static final String LIVE_TESTS_PROPERTY = "habitv.liveTests";
 	private static final String YT_DLP_PATH_PROPERTY = "habitv.ytdlp.path";
 
+	private static final boolean IS_WINDOWS = System.getProperty("os.name", "").toLowerCase().contains("win");
+	private static final String CMD_PROCESSOR = IS_WINDOWS ? "cmd.exe /c #CMD#" : "/bin/sh -c #CMD#";
+
 	/** Stable replay URL; 15s low-quality clip keeps bandwidth small. */
 	private static final String SAMPLE_EPISODE_URL = "https://www.arte.tv/fr/videos/019729-000-A/talons-aiguilles/";
 
@@ -93,7 +96,7 @@ public class ArteYtDlpLiveDownloadTest {
 		downloaders.put("youtube", new YoutubePluginDownloader());
 		final Map<String, String> binPaths = new HashMap<>();
 		binPaths.put("youtube", ytDlpBinary);
-		final DownloaderPluginHolder holder = new DownloaderPluginHolder("",
+		final DownloaderPluginHolder holder = new DownloaderPluginHolder(CMD_PROCESSOR,
 				downloaders, binPaths, outputDir.getAbsolutePath(), outputDir.getAbsolutePath(),
 				outputDir.getAbsolutePath(), outputDir.getAbsolutePath());
 
@@ -136,8 +139,7 @@ public class ArteYtDlpLiveDownloadTest {
 			return file.getAbsolutePath();
 		}
 
-		final boolean windows = System.getProperty("os.name", "").toLowerCase().contains("win");
-		final String[] command = windows
+		final String[] command = IS_WINDOWS
 				? new String[] { "cmd.exe", "/c", "where yt-dlp" }
 				: new String[] { "sh", "-c", "command -v yt-dlp" };
 

--- a/plugins/arte/test/com/dabi/habitv/provider/arte/ArteYtDlpLiveDownloadTest.java
+++ b/plugins/arte/test/com/dabi/habitv/provider/arte/ArteYtDlpLiveDownloadTest.java
@@ -1,0 +1,159 @@
+package com.dabi.habitv.provider.arte;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.DownloadParamDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+import com.dabi.habitv.api.plugin.exception.DownloadFailedException;
+import com.dabi.habitv.api.plugin.holder.DownloaderPluginHolder;
+import com.dabi.habitv.api.plugin.holder.ProcessHolder;
+import com.dabi.habitv.framework.FrameworkConf;
+import com.dabi.habitv.plugin.youtube.YoutubePluginDownloader;
+
+/**
+ * Opt-in live download test: ARTE episode URL via {@link ArtePluginManager}
+ * delegating to yt-dlp ({@link YoutubePluginDownloader}).
+ *
+ * <p>Run only when explicitly enabled (network + yt-dlp + ffmpeg required):
+ * <pre>
+ * mvn -B -ntp -pl plugins/arte -am \
+ *   "-Dhabitv.liveTests=true" \
+ *   "-Dtest=ArteYtDlpLiveDownloadTest" \
+ *   "-Dsurefire.failIfNoSpecifiedTests=false" test
+ * </pre>
+ * Optional: {@code -Dhabitv.ytdlp.path=/path/to/yt-dlp}
+ */
+public class ArteYtDlpLiveDownloadTest {
+
+	private static final String LIVE_TESTS_PROPERTY = "habitv.liveTests";
+	private static final String YT_DLP_PATH_PROPERTY = "habitv.ytdlp.path";
+
+	/** Stable replay URL; 15s low-quality clip keeps bandwidth small. */
+	private static final String SAMPLE_EPISODE_URL = "https://www.arte.tv/fr/videos/019729-000-A/talons-aiguilles/";
+
+	private static final String YT_DLP_ARGS = " \"#VIDEO_URL#\" -o \"#FILE_DEST#\""
+			+ " -f VF-STF-426+VF-STF-audio_0-fran\u00e7ais"
+			+ " --download-sections \"*0:00-0:15\""
+			+ " --no-check-certificate --no-write-sub --no-write-auto-sub";
+
+	private File outputDir;
+
+	@After
+	public void tearDown() {
+		if (outputDir == null || !outputDir.exists()) {
+			return;
+		}
+		final File[] files = outputDir.listFiles();
+		if (files != null) {
+			for (final File file : files) {
+				if (!file.delete()) {
+					file.deleteOnExit();
+				}
+			}
+		}
+		if (!outputDir.delete()) {
+			outputDir.deleteOnExit();
+		}
+	}
+
+	@Test
+	public void downloadsShortArteClipViaYtDlp() throws DownloadFailedException, IOException {
+		assumeTrue("Set -Dhabitv.liveTests=true to run network live tests",
+				"true".equalsIgnoreCase(System.getProperty(LIVE_TESTS_PROPERTY)));
+
+		final String ytDlpBinary = resolveYtDlpBinary();
+		assumeNotNull("yt-dlp not found; install it or set -D" + YT_DLP_PATH_PROPERTY + "=...", ytDlpBinary);
+
+		outputDir = new File("target/arte-ytdlp-live-test");
+		if (!outputDir.exists() && !outputDir.mkdirs()) {
+			throw new IOException("cannot create output dir: " + outputDir.getAbsolutePath());
+		}
+
+		final String outputPath = new File(outputDir, "arte-live-clip.tmp.mp4").getAbsolutePath();
+		final CategoryDTO category = new CategoryDTO(ArteConf.NAME, "live-test", SAMPLE_EPISODE_URL, ArteConf.EXTENSION);
+		final EpisodeDTO episode = new EpisodeDTO(category, "Talons aiguilles", SAMPLE_EPISODE_URL);
+		final DownloadParamDTO downloadParam = new DownloadParamDTO(episode.getId(), outputPath, ArteConf.EXTENSION);
+		downloadParam.addParam(FrameworkConf.PARAMETER_ARGS, YT_DLP_ARGS);
+
+		final Map<String, com.dabi.habitv.api.plugin.api.PluginDownloaderInterface> downloaders = new HashMap<>();
+		downloaders.put("youtube", new YoutubePluginDownloader());
+		final Map<String, String> binPaths = new HashMap<>();
+		binPaths.put("youtube", ytDlpBinary);
+		final DownloaderPluginHolder holder = new DownloaderPluginHolder("",
+				downloaders, binPaths, outputDir.getAbsolutePath(), outputDir.getAbsolutePath(),
+				outputDir.getAbsolutePath(), outputDir.getAbsolutePath());
+
+		final ArtePluginManager provider = new ArtePluginManager();
+		final ProcessHolder process = provider.download(downloadParam, holder);
+		process.start();
+
+		final File outputFile = findDownloadedMedia(outputDir);
+		assertTrue("expected a non-empty mp4 under " + outputDir.getAbsolutePath()
+				+ " (yt-dlp may name the file from the video title)", outputFile != null && outputFile.length() > 0);
+	}
+
+	private static File findDownloadedMedia(final File directory) {
+		final File[] files = directory.listFiles();
+		if (files == null) {
+			return null;
+		}
+		File best = null;
+		for (final File file : files) {
+			if (!file.isFile()) {
+				continue;
+			}
+			final String name = file.getName().toLowerCase();
+			if (!name.endsWith(".mp4") && !name.endsWith(".mp4.part")) {
+				continue;
+			}
+			if (best == null || file.length() > best.length()) {
+				best = file;
+			}
+		}
+		return best != null && best.getName().endsWith(".part") ? new File(best.getParentFile(),
+				best.getName().substring(0, best.getName().length() - 5)) : best;
+	}
+
+	private static String resolveYtDlpBinary() throws IOException {
+		final String configured = System.getProperty(YT_DLP_PATH_PROPERTY);
+		if (configured != null && !configured.trim().isEmpty()) {
+			final File file = new File(configured.trim());
+			assumeTrue("habitv.ytdlp.path does not exist: " + file.getAbsolutePath(), file.isFile());
+			return file.getAbsolutePath();
+		}
+
+		final boolean windows = System.getProperty("os.name", "").toLowerCase().contains("win");
+		final String[] command = windows
+				? new String[] { "cmd.exe", "/c", "where yt-dlp" }
+				: new String[] { "sh", "-c", "command -v yt-dlp" };
+
+		final Process process = Runtime.getRuntime().exec(command);
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+			final String line = reader.readLine();
+			process.waitFor();
+			if (line == null || line.trim().isEmpty()) {
+				return null;
+			}
+			final File candidate = new File(line.trim());
+			return candidate.isFile() ? candidate.getAbsolutePath() : line.trim();
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return null;
+		}
+	}
+}

--- a/plugins/arte/test/resources/fixtures/arte/emac-page-DOR.json
+++ b/plugins/arte/test/resources/fixtures/arte/emac-page-DOR.json
@@ -1,0 +1,56 @@
+{
+  "value": {
+    "zones": [
+      {
+        "code": "listing_DOCUMENTARIES_main",
+        "content": {
+          "data": [
+            {
+              "url": "/fr/videos/119999-000-A/test-documentary-one/",
+              "title": "Test Documentary One"
+            },
+            {
+              "url": "https://www.arte.tv/fr/videos/119999-001-A/test-documentary-two/",
+              "title": "Test Documentary Two",
+              "subtitle": "Episode 2"
+            },
+            {
+              "url": "/fr/videos/119999-002-A/test-documentary-three/",
+              "title": "",
+              "subtitle": "Subtitle Only Three"
+            },
+            {
+              "url": "/fr/programmes/119999/",
+              "title": "Not An Episode (programmes path)"
+            },
+            {
+              "url": "",
+              "title": "Missing URL"
+            },
+            {
+              "url": "/fr/videos/119999-003-A/test-no-title/"
+            },
+            {
+              "url": "/fr/videos/119999-000-A/test-documentary-one/",
+              "title": "Duplicate Of First"
+            }
+          ],
+          "pagination": {
+            "pages": 2
+          }
+        }
+      },
+      {
+        "code": "",
+        "content": {
+          "data": [
+            {
+              "url": "/fr/videos/119999-100-A/no-zone-code/",
+              "title": "Zone Without Code"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/plugins/arte/test/resources/fixtures/arte/emac-zone-page2.json
+++ b/plugins/arte/test/resources/fixtures/arte/emac-zone-page2.json
@@ -1,0 +1,14 @@
+{
+  "value": {
+    "data": [
+      {
+        "url": "/fr/videos/119999-200-A/page-two-item/",
+        "title": "Page Two Item"
+      },
+      {
+        "url": "/fr/videos/119999-201-A/page-two-second/",
+        "title": "Page Two Second"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR restores the ARTE provider by replacing the obsolete HTML selector parsing with ARTE EMAC rproxy API discovery.

### Changes

- Replace brittle `arte.tv` HTML parsing with EMAC rproxy JSON endpoints.
- Add stable language and page-code category mapping.
- Add zone pagination with a safety cap to avoid unbounded crawling.
- Keep the existing download flow unchanged by continuing to delegate downloads to the YouTube/yt-dlp downloader.
- Remove the unused `jsoup` dependency from the ARTE plugin.
- Add offline JSON fixture coverage for EMAC parsing.
- Add an opt-in live yt-dlp smoke test for ARTE downloads.

### Tests

Default deterministic tests:

```bash
mvn -B -ntp -pl plugins/arte -am -Dtest=ArteEmacParsingOfflineTest,ArteOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test
```