### PR TITLE
fix(habiTv): resolve jfxrt.jar for JDK 8 GUI launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 | 2026-05-16 | `8caab37` | Align `plugin-tester` dependency versions |
 | 2026-05-16 | `e4d7e81` | Add Java 8 baseline validation workflow (CI) |
 
+### 🐛 Fixes
+
+| Date | Commit | Change |
+|------|--------|--------|
+| 2026-05-18 | TBD | Resolve JavaFX `jfxrt.jar` from common JDK 8 layouts in `HabitvLauncher` |
+
 ### ✨ Features
 
 | Date | Commit | Change |

--- a/application/habiTv/src/com/dabi/habitv/HabitvLauncher.java
+++ b/application/habiTv/src/com/dabi/habitv/HabitvLauncher.java
@@ -13,20 +13,31 @@ public class HabitvLauncher {
 
 	public static void main(final String[] args) throws Exception {
 		LogUtils.updateLog4jConfiguration();
-		addToClasspath("file:///" + System.getProperty("java.home")
-				+ File.separator + "lib" + File.separator + "jfxrt.jar");
-		System.out.println(System.getProperty("java.home"));
+		final boolean guiMode = args == null || args.length == 0;
+		final File jfxrt = JavaFxRuntimeLocator.locate();
+		if (jfxrt != null) {
+			addToClasspath(jfxrt);
+		} else if (guiMode) {
+			System.err.println("JavaFX runtime (jfxrt.jar) was not found.");
+			System.err.println("Set -D" + JavaFxRuntimeLocator.JFXRT_PATH_PROPERTY
+					+ "=<path-to-jfxrt.jar> or use a JDK 8 that bundles JavaFX.");
+			System.err.println("Checked paths:");
+			for (final String path : JavaFxRuntimeLocator.candidatePathsForDiagnostics()) {
+				System.err.println("  " + path);
+			}
+			System.exit(1);
+		}
 
-		if (args == null || args.length == 0) {
+		if (guiMode) {
 			HabiTvViewRunner.main(args);
 		} else {
 			ConsoleLauncher.main(args);
 		}
 	}
 
-	private static void addToClasspath(final String urlSpec) {
+	private static void addToClasspath(final File jarFile) {
 		try {
-			final URL url = new URL(urlSpec);
+			final URL url = jarFile.toURI().toURL();
 			final ClassLoader systemLoader = ClassLoader.getSystemClassLoader();
 			if (systemLoader instanceof URLClassLoader) {
 				final Method addURL = URLClassLoader.class.getDeclaredMethod("addURL",
@@ -39,8 +50,8 @@ public class HabitvLauncher {
 								+ systemLoader.getClass().getName());
 			}
 		} catch (final ReflectiveOperationException | java.net.MalformedURLException e) {
-			throw new IllegalStateException("Failed to add URL to classpath: "
-					+ urlSpec, e);
+			throw new IllegalStateException("Failed to add JavaFX runtime to classpath: "
+					+ jarFile.getAbsolutePath(), e);
 		}
 	}
 

--- a/application/habiTv/src/com/dabi/habitv/JavaFxRuntimeLocator.java
+++ b/application/habiTv/src/com/dabi/habitv/JavaFxRuntimeLocator.java
@@ -36,8 +36,8 @@ final class JavaFxRuntimeLocator {
 				return candidate;
 			}
 		}
-		final File jdkLib = new File(javaHome.getParentFile(), "lib" + File.separator + "jfxrt.jar");
-		if (jdkLib.isFile()) {
+		final File jdkLib = parentJdkLibCandidate(javaHome);
+		if (jdkLib != null && jdkLib.isFile()) {
 			return jdkLib;
 		}
 		return null;
@@ -53,8 +53,18 @@ final class JavaFxRuntimeLocator {
 		for (final String relativePath : RELATIVE_PATHS) {
 			paths.add(new File(javaHome, relativePath).getAbsolutePath());
 		}
-		paths.add(new File(javaHome.getParentFile(),
-				"lib" + File.separator + "jfxrt.jar").getAbsolutePath());
+		final File jdkLib = parentJdkLibCandidate(javaHome);
+		if (jdkLib != null) {
+			paths.add(jdkLib.getAbsolutePath());
+		}
 		return Collections.unmodifiableList(paths);
+	}
+
+	private static File parentJdkLibCandidate(final File javaHome) {
+		final File parent = javaHome.getParentFile();
+		if (parent == null) {
+			return null;
+		}
+		return new File(parent, "lib" + File.separator + "jfxrt.jar");
 	}
 }

--- a/application/habiTv/src/com/dabi/habitv/JavaFxRuntimeLocator.java
+++ b/application/habiTv/src/com/dabi/habitv/JavaFxRuntimeLocator.java
@@ -1,0 +1,60 @@
+package com.dabi.habitv;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Resolves the JavaFX 2.x {@code jfxrt.jar} for JDK 8 layouts (Oracle, Zulu, etc.).
+ */
+final class JavaFxRuntimeLocator {
+
+	static final String JFXRT_PATH_PROPERTY = "habitv.jfxrt.path";
+
+	private static final String[] RELATIVE_PATHS = {
+			"lib" + File.separator + "jfxrt.jar",
+			"jre" + File.separator + "lib" + File.separator + "ext" + File.separator + "jfxrt.jar",
+			"lib" + File.separator + "ext" + File.separator + "jfxrt.jar",
+	};
+
+	private JavaFxRuntimeLocator() {
+	}
+
+	static File locate() {
+		final String override = System.getProperty(JFXRT_PATH_PROPERTY);
+		if (override != null && !override.trim().isEmpty()) {
+			final File overrideFile = new File(override.trim());
+			if (overrideFile.isFile()) {
+				return overrideFile;
+			}
+		}
+		final File javaHome = new File(System.getProperty("java.home"));
+		for (final String relativePath : RELATIVE_PATHS) {
+			final File candidate = new File(javaHome, relativePath);
+			if (candidate.isFile()) {
+				return candidate;
+			}
+		}
+		final File jdkLib = new File(javaHome.getParentFile(), "lib" + File.separator + "jfxrt.jar");
+		if (jdkLib.isFile()) {
+			return jdkLib;
+		}
+		return null;
+	}
+
+	static List<String> candidatePathsForDiagnostics() {
+		final List<String> paths = new ArrayList<>();
+		final String override = System.getProperty(JFXRT_PATH_PROPERTY);
+		if (override != null && !override.trim().isEmpty()) {
+			paths.add(override.trim());
+		}
+		final File javaHome = new File(System.getProperty("java.home"));
+		for (final String relativePath : RELATIVE_PATHS) {
+			paths.add(new File(javaHome, relativePath).getAbsolutePath());
+		}
+		paths.add(new File(javaHome.getParentFile(),
+				"lib" + File.separator + "jfxrt.jar").getAbsolutePath());
+		return Collections.unmodifiableList(paths);
+	}
+}

--- a/application/habiTv/test/com/dabi/habitv/JavaFxRuntimeLocatorTest.java
+++ b/application/habiTv/test/com/dabi/habitv/JavaFxRuntimeLocatorTest.java
@@ -1,0 +1,74 @@
+package com.dabi.habitv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JavaFxRuntimeLocatorTest {
+
+	private String previousJavaHome;
+	private String previousOverride;
+
+	@Before
+	public void setUp() {
+		previousJavaHome = System.getProperty("java.home");
+		previousOverride = System.getProperty(JavaFxRuntimeLocator.JFXRT_PATH_PROPERTY);
+	}
+
+	@After
+	public void tearDown() {
+		restoreProperty("java.home", previousJavaHome);
+		restoreProperty(JavaFxRuntimeLocator.JFXRT_PATH_PROPERTY, previousOverride);
+	}
+
+	@Test
+	public void locateReturnsOverrideWhenFileExists() throws IOException {
+		final File jar = Files.createTempFile("jfxrt", ".jar").toFile();
+		jar.deleteOnExit();
+		System.setProperty(JavaFxRuntimeLocator.JFXRT_PATH_PROPERTY, jar.getAbsolutePath());
+		assertEquals(jar, JavaFxRuntimeLocator.locate());
+	}
+
+	@Test
+	public void locateChecksJreExtLayout() throws IOException {
+		clearOverride();
+		final File fakeJavaHome = Files.createTempDirectory("fake-jre").toFile();
+		fakeJavaHome.deleteOnExit();
+		final File jfxrt = new File(fakeJavaHome, "jre/lib/ext/jfxrt.jar");
+		assertTrue(jfxrt.getParentFile().mkdirs());
+		assertTrue(jfxrt.createNewFile());
+		System.setProperty("java.home", fakeJavaHome.getAbsolutePath());
+		assertEquals(jfxrt, JavaFxRuntimeLocator.locate());
+	}
+
+	@Test
+	public void locateReturnsNullWhenMissing() throws IOException {
+		clearOverride();
+		final File fakeJavaHome = Files.createTempDirectory("no-javafx").toFile();
+		fakeJavaHome.deleteOnExit();
+		System.setProperty("java.home", fakeJavaHome.getAbsolutePath());
+		assertNull(JavaFxRuntimeLocator.locate());
+		assertNotNull(JavaFxRuntimeLocator.candidatePathsForDiagnostics());
+	}
+
+	private static void clearOverride() {
+		System.clearProperty(JavaFxRuntimeLocator.JFXRT_PATH_PROPERTY);
+	}
+
+	private static void restoreProperty(final String key, final String value) {
+		if (value == null) {
+			System.clearProperty(key);
+		} else {
+			System.setProperty(key, value);
+		}
+	}
+}

--- a/application/habiTv/test/com/dabi/habitv/JavaFxRuntimeLocatorTest.java
+++ b/application/habiTv/test/com/dabi/habitv/JavaFxRuntimeLocatorTest.java
@@ -39,11 +39,49 @@ public class JavaFxRuntimeLocatorTest {
 	}
 
 	@Test
+	public void locateChecksLibLayout() throws IOException {
+		clearOverride();
+		final File fakeJavaHome = Files.createTempDirectory("fake-lib").toFile();
+		fakeJavaHome.deleteOnExit();
+		final File jfxrt = new File(fakeJavaHome, "lib/jfxrt.jar");
+		assertTrue(jfxrt.getParentFile().mkdirs());
+		assertTrue(jfxrt.createNewFile());
+		System.setProperty("java.home", fakeJavaHome.getAbsolutePath());
+		assertEquals(jfxrt, JavaFxRuntimeLocator.locate());
+	}
+
+	@Test
 	public void locateChecksJreExtLayout() throws IOException {
 		clearOverride();
 		final File fakeJavaHome = Files.createTempDirectory("fake-jre").toFile();
 		fakeJavaHome.deleteOnExit();
 		final File jfxrt = new File(fakeJavaHome, "jre/lib/ext/jfxrt.jar");
+		assertTrue(jfxrt.getParentFile().mkdirs());
+		assertTrue(jfxrt.createNewFile());
+		System.setProperty("java.home", fakeJavaHome.getAbsolutePath());
+		assertEquals(jfxrt, JavaFxRuntimeLocator.locate());
+	}
+
+	@Test
+	public void locateChecksLibExtLayout() throws IOException {
+		clearOverride();
+		final File fakeJavaHome = Files.createTempDirectory("fake-lib-ext").toFile();
+		fakeJavaHome.deleteOnExit();
+		final File jfxrt = new File(fakeJavaHome, "lib/ext/jfxrt.jar");
+		assertTrue(jfxrt.getParentFile().mkdirs());
+		assertTrue(jfxrt.createNewFile());
+		System.setProperty("java.home", fakeJavaHome.getAbsolutePath());
+		assertEquals(jfxrt, JavaFxRuntimeLocator.locate());
+	}
+
+	@Test
+	public void locateChecksParentJdkLibFallback() throws IOException {
+		clearOverride();
+		final File fakeJdkHome = Files.createTempDirectory("fake-jdk").toFile();
+		fakeJdkHome.deleteOnExit();
+		final File fakeJavaHome = new File(fakeJdkHome, "jre");
+		assertTrue(fakeJavaHome.mkdirs());
+		final File jfxrt = new File(fakeJdkHome, "lib/jfxrt.jar");
 		assertTrue(jfxrt.getParentFile().mkdirs());
 		assertTrue(jfxrt.createNewFile());
 		System.setProperty("java.home", fakeJavaHome.getAbsolutePath());

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -23,7 +23,7 @@
     "deferred": 0,
     "blocked": 0,
     "total": 14,
-    "overallProgressPercent": 79
+    "overallProgressPercent": 80
   },
   "items": [
     {
@@ -219,7 +219,7 @@
       "icon": "🖼️",
       "status": "proposed",
       "priority": "P2",
-      "progressPercent": 5,
+      "progressPercent": 10,
       "scope": "Migrate JavaFX 2.x usage and ${jdk.home} packaging assumptions in application/trayView, application/habiTv-linux, application/habiTv-windows, zenjava/javafx-maven-plugin 2.0, and system-scope javafx:jfxrt.",
       "acceptanceCriteria": [
         "Surface inventory captured in audit doc (done in audit-master-baseline).",
@@ -228,10 +228,11 @@
         "habiTv-linux + habiTv-windows re-enterable to the reactor."
       ],
       "validation": [
-        "Audit reviewed in PR; no code changes in this item."
+        "Audit reviewed in PR; no code changes in this item.",
+        "mvn -B -ntp -pl application/habiTv -am -Dtest=JavaFxRuntimeLocatorTest -Dsurefire.failIfNoSpecifiedTests=false test -> BUILD SUCCESS"
       ],
       "pr": "TBD",
-      "notes": "Risk javafx-jdk8. Largest single piece of remaining work once legacy-url-migration + static-repo-publish + provider-inventory are clear."
+      "notes": "Risk javafx-jdk8. HabitvLauncher now resolves jfxrt.jar from common JDK 8 layouts and supports -Dhabitv.jfxrt.path; GUI mode exits with diagnostics when JavaFX is missing. OpenJFX migration and platform packaging remain out of scope."
     },
     {
       "id": "plugin-tester-align",

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -228,7 +228,7 @@
         "habiTv-linux + habiTv-windows re-enterable to the reactor."
       ],
       "validation": [
-        "Audit reviewed in PR; no code changes in this item.",
+        "Audit reviewed in PR; code changes implemented in application/habiTv for JDK 8 jfxrt.jar resolution.",
         "mvn -B -ntp -pl application/habiTv -am -Dtest=JavaFxRuntimeLocatorTest -Dsurefire.failIfNoSpecifiedTests=false test -> BUILD SUCCESS"
       ],
       "pr": "TBD",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -387,7 +387,9 @@ assumptions:
 - ⬜ Packaging blueprint accepted via dedicated ADR
 - ⬜ `habiTv-linux` + `habiTv-windows` re-enterable to the reactor
 
-**Validation** — Audit reviewed in PR; no code changes in this item.
+**Validation** — Audit reviewed in PR; code changes implemented in
+`application/habiTv` for JDK 8 `jfxrt.jar` resolution and covered by
+targeted unit tests.
 
 **Notes** — Risk `javafx-jdk8`. `HabitvLauncher` resolves `jfxrt.jar`
 from common JDK 8 layouts and supports `-Dhabitv.jfxrt.path`; GUI mode

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -45,7 +45,7 @@
 | 📦 `static-repo-publish` — Static artifact repository publication | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🟡 In progress | 🟡 P2 | `███████████░░░░░░░░░` 55% |
 | 🎬 `ytdlp-migration` — `youtube-dl` → `yt-dlp` migration | 🟡 In progress | 🟡 P2 | `███████████████░░░░░` 75% |
-| 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `█░░░░░░░░░░░░░░░░░░░` 5% |
+| 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `██░░░░░░░░░░░░░░░░░░` 10% |
 | 🧪 `plugin-tester-align` — `plugin-tester` reactor alignment | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | ▶️ `console-runnable` — Runnable console baseline | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 🔗 `own-version-deps-align` — Own-version plugin dependency alignment | ✅ Done | 🔴 P0 | `████████████████████` 100% |
@@ -362,7 +362,7 @@ rewrite, no live-network tests in this item.
 |---|---|
 | **Status** | 🔵 Proposed |
 | **Priority** | 🟡 P2 |
-| **Progress** | `█░░░░░░░░░░░░░░░░░░░` 5% |
+| **Progress** | `██░░░░░░░░░░░░░░░░░░` 10% |
 | **Legacy code** | HBTV-008 |
 
 **Scope** — Migrate JavaFX 2.x usage and `${jdk.home}` packaging
@@ -380,7 +380,10 @@ assumptions:
 
 **Validation** — Audit reviewed in PR; no code changes in this item.
 
-**Notes** — Risk `javafx-jdk8`. Largest single piece of remaining
+**Notes** — Risk `javafx-jdk8`. `HabitvLauncher` resolves `jfxrt.jar`
+from common JDK 8 layouts and supports `-Dhabitv.jfxrt.path`; GUI mode
+exits with diagnostics when JavaFX is missing. OpenJFX migration and
+platform packaging remain out of scope. Largest single piece of remaining
 work once `legacy-url-migration` + `static-repo-publish` +
 `provider-inventory` are clear.
 


### PR DESCRIPTION
## Summary
- Resolve JavaFX `jfxrt.jar` from common JDK 8 layouts (`lib/`, `jre/lib/ext/`, `lib/ext/`, parent JDK `lib/`).
- Support `-Dhabitv.jfxrt.path` override for custom installs.
- Exit GUI mode with a diagnostic path list when JavaFX is missing; CLI mode unchanged.

## Scope
- `JavaFxRuntimeLocator` + `HabitvLauncher` updates in `application/habiTv`.
- Unit tests for locator path resolution.

## Out of scope
- OpenJFX migration, `habiTv-windows` / `habiTv-linux` packaging, shading JavaFX into the uber-jar.

## Validation
- `git diff --check` -> clean
- `mvn -B -ntp -DskipTests validate` -> BUILD SUCCESS
- `mvn -B -ntp -pl application/habiTv -am -Dtest=JavaFxRuntimeLocatorTest -Dsurefire.failIfNoSpecifiedTests=false test` -> BUILD SUCCESS (3 tests)

## Risk
- Affected risks: `javafx-jdk8` (partial mitigation for local dev launch)
- New risks: none
- Mitigation: fail-fast diagnostics; property override documented in error output

## Rollback
- Revert commit(s) via `git revert <sha>` and re-run validation.

## Linked tracker item
- `javafx-modernization` (HBTV-008)

## Checklist
- [x] Branch was created from `develop`
- [x] No unrelated source changes
- [x] `git diff --check` passed
- [x] `mvn -B -ntp -DskipTests validate` passed
- [x] PR keeps linear history
- [x] Documentation updated (tracker, CHANGELOG)
- [x] No secrets, tokens, local paths, or build outputs committed