### PR TITLE
fix(updater): default autoriseSnapshot to true to match repository contents

### DIFF
--- a/application/core/configuration.xml
+++ b/application/core/configuration.xml
@@ -18,7 +18,7 @@
     </downloadConfig>
     <updateConfig>
         <updateOnStartup>true</updateOnStartup>
-        <autoriseSnapshot>false</autoriseSnapshot>
+        <autoriseSnapshot>true</autoriseSnapshot>
     </updateConfig>
     <exportConfig>
         <exporters>

--- a/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
@@ -69,7 +69,7 @@ public class XMLUserConfig implements UserConfig {
 
 	private static final boolean DEFAULT_UPDATE_ON_STARTUP = true;
 
-	private static final Boolean DEFAULT_AUTORISE_SNAPSHOT = false;
+	private static final Boolean DEFAULT_AUTORISE_SNAPSHOT = true;
 
 	private XMLUserConfig(final Configuration config) {
 		super();
@@ -478,7 +478,7 @@ public class XMLUserConfig implements UserConfig {
 	@Override
 	public boolean autoriseSnapshot() {
 		final boolean fromConfiguration = config.getUpdateConfig() == null
-				|| config.getUpdateConfig().getAutoriseSnapshot() == null ? false
+				|| config.getUpdateConfig().getAutoriseSnapshot() == null ? DEFAULT_AUTORISE_SNAPSHOT
 				: config.getUpdateConfig().getAutoriseSnapshot();
 		return UpdateConfigResolver.resolveAutoriseSnapshot(fromConfiguration);
 	}

--- a/docs/runtime-quickstart.md
+++ b/docs/runtime-quickstart.md
@@ -135,16 +135,15 @@ You can disable runtime plugin updates explicitly with
 `-Dhabitv.update.enabled=false` (optional custom base:
 `-Dhabitv.update.url=...`).
 
-Development snapshot updates: keep `<autoriseSnapshot>false</autoriseSnapshot>`
-in `configuration.xml` and pass `-Dhabitv.update.autoriseSnapshot=true` when you
-need Maven timestamped SNAPSHOT plugin artifacts from the static repository.
-This override must not be enabled for normal end users.
+Snapshot artifacts: `<autoriseSnapshot>true</autoriseSnapshot>` is the
+default because the published static repository currently ships only Maven
+timestamped `-SNAPSHOT` plugin builds. To pin to release-only behaviour,
+set `<autoriseSnapshot>false</autoriseSnapshot>` in `configuration.xml`, or
+pass `-Dhabitv.update.autoriseSnapshot=false`.
 
 Reference launch command:
 
 ```bash
-java -Dhabitv.update.enabled=true \
-  -Dhabitv.update.autoriseSnapshot=true \
-  -Dhabitv.update.url=https://mika3578.github.io/habitv-repo/repository/ \
+java -Dhabitv.update.url=https://mika3578.github.io/habitv-repo/repository/ \
   -jar application/habiTv/target/habiTv-4.1.0-SNAPSHOT.jar
 ```

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -163,22 +163,20 @@ disable startup updates with `-Dhabitv.update.enabled=false`.
 
 If GitHub Pages is unreachable, Habitv keeps local plugins and tools.
 
-### Development snapshot updates
+### Snapshot artifacts
 
 Maven deploy publishes timestamped SNAPSHOT JARs (for example
-`arte-4.1.0-20260518.163022-1.jar`). Normal users must keep
-`updateConfig/autoriseSnapshot` set to `false` in `configuration.xml`.
-Do not rely on non-timestamped `artifactId-<version>-SNAPSHOT.jar` names on
-GitHub Pages.
+`arte-4.1.0-20260518.163022-1.jar`). Because the published static repository
+currently ships only `-SNAPSHOT` builds for every plugin, `autoriseSnapshot`
+defaults to `true` in `configuration.xml`. Do not rely on non-timestamped
+`artifactId-<version>-SNAPSHOT.jar` names on GitHub Pages.
 
-For local development against the published static repository, run Habitv with an
-explicit JVM override (configuration value is read first, then overridden only
-when the property is set):
+To pin to release-only behaviour (skip SNAPSHOT entries from the manifest),
+set `<autoriseSnapshot>false</autoriseSnapshot>` in `configuration.xml`, or
+pass `-Dhabitv.update.autoriseSnapshot=false`:
 
 ```bash
-java -Dhabitv.update.enabled=true \
-  -Dhabitv.update.autoriseSnapshot=true \
-  -jar habitv.jar
+java -Dhabitv.update.autoriseSnapshot=false -jar habitv.jar
 ```
 
 Supported values for `habitv.update.autoriseSnapshot` are `true` and `false`


### PR DESCRIPTION
## Symptom

At startup, plugin updates from `habitv-repo` were silently no-ops even though the runtime correctly fetched and parsed `habitv-update-manifest.properties`.

## Diagnosis

`develop` already fixed the JVM-property gate (#62) so the updater runs. However, every manifest entry in the published repository is a Maven timestamped SNAPSHOT (`4.1.x-SNAPSHOT`). With `autoriseSnapshot=false`, `FindArtifactUtils.isVersionEligible` rejected every candidate version and the updater logged `No plugins listed for update; keeping local plugins.`

## Changes

Default `autoriseSnapshot` to `true` to match the actual content of the static repository:

- `application/core/configuration.xml`: `<autoriseSnapshot>true</autoriseSnapshot>`
- `XMLUserConfig.DEFAULT_AUTORISE_SNAPSHOT = true` and use the constant in the `autoriseSnapshot()` getter fallback (instead of a hardcoded `false`).
- Docs `runtime-quickstart.md` and `static-repository-deploy.md`: describe the new default and how to opt back into release-only behaviour.

Release-only behaviour remains available via `<autoriseSnapshot>false</autoriseSnapshot>` in `configuration.xml` or `-Dhabitv.update.autoriseSnapshot=false`. The existing `UpdateConfigResolver` JVM-override logic is untouched.

## Test plan

- [ ] Launch with the default config: verify the updater downloads plugin JARs from `https://mika3578.github.io/habitv-repo/repository/` instead of logging "No plugins listed for update".
- [ ] Launch with `<autoriseSnapshot>false</autoriseSnapshot>`: verify SNAPSHOT manifest entries are skipped (current published repo has no release artifacts, so updater should still fall back to keeping local plugins).
- [ ] Launch with `-Dhabitv.update.autoriseSnapshot=false`: same as above via JVM override.