### PR TITLE
fix: resolve timestamped SNAPSHOT plugin updates

### DIFF
--- a/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
+++ b/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
@@ -44,19 +44,25 @@ public class UpdateManager {
 	}
 
 	public void process() {
-		if (!Boolean.getBoolean(FrameworkConf.UPDATE_ENABLED_PROPERTY)) {
+		final boolean updateEnabled = Boolean.getBoolean(FrameworkConf.UPDATE_ENABLED_PROPERTY);
+		final String updateSite = System.getProperty(
+				FrameworkConf.UPDATE_URL_PROPERTY, site);
+		final String baseUrl = updateSite == null ? null
+				: UpdateRepositoryUrls.normalizeBaseUrl(updateSite.trim());
+		LOG.info("Runtime plugin update configuration: enabled=" + updateEnabled
+				+ ", autoriseSnapshot=" + autoriseSnapshot + ", updateUrl="
+				+ baseUrl);
+		if (!updateEnabled) {
 			LOG.debug("Plugin update check is disabled.");
 			return;
 		}
-		final String updateSite = System.getProperty(
-				FrameworkConf.UPDATE_URL_PROPERTY, site);
 		if (updateSite == null || updateSite.trim().isEmpty()) {
 			LOG.warn("Plugin update check is enabled but no update URL is configured.");
 			return;
 		}
 		try {
 			LOG.info("Checking plugin updates...");
-			final String[] toUpdate = resolvePluginsToUpdate(updateSite);
+			final String[] toUpdate = resolvePluginsToUpdate(baseUrl);
 			if (toUpdate.length == 0) {
 				LOG.warn("No plugins listed for update; keeping local plugins.");
 				return;
@@ -79,19 +85,35 @@ public class UpdateManager {
 		return updatePublisher;
 	}
 
-	private String[] resolvePluginsToUpdate(final String updateSite) {
-		final String baseUrl = UpdateRepositoryUrls.normalizeBaseUrl(updateSite.trim());
+	private String[] resolvePluginsToUpdate(final String baseUrl) {
+		final HabitvUpdateManifest manifest = HabitvUpdateManifest.loadFromRepository(baseUrl);
+		if (manifest.isEmpty()) {
+			LOG.info("Update manifest not loaded from " + baseUrl + "/"
+					+ FrameworkConf.UPDATE_MANIFEST_FILE);
+		} else {
+			LOG.info("Update manifest loaded from " + baseUrl + "/"
+					+ FrameworkConf.UPDATE_MANIFEST_FILE + " with "
+					+ manifest.getEntries().size() + " entries.");
+		}
+
 		try {
 			final String pluginsList = RetrieverUtils.getUrlContent(
 					baseUrl + "/" + FrameworkConf.PLUGINS_LIST_FILE, null);
 			if (pluginsList != null && !pluginsList.trim().isEmpty()) {
-				return splitPluginLines(pluginsList);
+				final String[] pluginIds = splitPluginLines(pluginsList);
+				LOG.info("plugins.txt loaded from " + baseUrl + "/"
+						+ FrameworkConf.PLUGINS_LIST_FILE + " with "
+						+ pluginIds.length + " plugin ids.");
+				return pluginIds;
 			}
+			LOG.info("plugins.txt loaded from " + baseUrl + "/"
+					+ FrameworkConf.PLUGINS_LIST_FILE + " but it is empty.");
 		} catch (final RuntimeException e) {
-			LOG.debug("plugins.txt not available at " + baseUrl + ": " + e.getMessage());
+			LOG.info("plugins.txt not loaded from " + baseUrl + "/"
+					+ FrameworkConf.PLUGINS_LIST_FILE + ": " + e.getMessage());
 		}
-		final HabitvUpdateManifest manifest = HabitvUpdateManifest.loadFromRepository();
 		if (!manifest.isEmpty()) {
+			LOG.info("Falling back to manifest artifact list because plugins.txt is unavailable.");
 			return manifest.getPluginArtifactIds();
 		}
 		return new String[0];

--- a/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
+++ b/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
@@ -86,16 +86,6 @@ public class UpdateManager {
 	}
 
 	private String[] resolvePluginsToUpdate(final String baseUrl) {
-		final HabitvUpdateManifest manifest = HabitvUpdateManifest.loadFromRepository(baseUrl);
-		if (manifest.isEmpty()) {
-			LOG.info("Update manifest not loaded from " + baseUrl + "/"
-					+ FrameworkConf.UPDATE_MANIFEST_FILE);
-		} else {
-			LOG.info("Update manifest loaded from " + baseUrl + "/"
-					+ FrameworkConf.UPDATE_MANIFEST_FILE + " with "
-					+ manifest.getEntries().size() + " entries.");
-		}
-
 		try {
 			final String pluginsList = RetrieverUtils.getUrlContent(
 					baseUrl + "/" + FrameworkConf.PLUGINS_LIST_FILE, null);
@@ -112,10 +102,16 @@ public class UpdateManager {
 			LOG.info("plugins.txt not loaded from " + baseUrl + "/"
 					+ FrameworkConf.PLUGINS_LIST_FILE + ": " + e.getMessage());
 		}
+		final HabitvUpdateManifest manifest = HabitvUpdateManifest.loadFromRepository(baseUrl);
 		if (!manifest.isEmpty()) {
-			LOG.info("Falling back to manifest artifact list because plugins.txt is unavailable.");
+			LOG.info("Update manifest loaded from " + baseUrl + "/"
+					+ FrameworkConf.UPDATE_MANIFEST_FILE + " with "
+					+ manifest.getEntries().size()
+					+ " entries. Falling back to manifest artifact list because plugins.txt is unavailable.");
 			return manifest.getPluginArtifactIds();
 		}
+		LOG.info("Update manifest not loaded from " + baseUrl + "/"
+				+ FrameworkConf.UPDATE_MANIFEST_FILE);
 		return new String[0];
 	}
 

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR).",
-  "lastRefresh": "2026-05-18",
+  "lastRefresh": "2026-05-19",
   "statusValues": [
     "proposed",
     "in-progress",
@@ -161,7 +161,7 @@
         "python scripts/static-repo/validate_repository_layout.py <repository-root>"
       ],
       "pr": "habitv-repo #2 (merged); habitv PR #49 (publication status + tracker refresh)",
-      "notes": "Runtime updates remain disabled by default. Publication cutover is live on GitHub Pages with token-free HTTPS access. Developer SNAPSHOT updates use -Dhabitv.update.autoriseSnapshot=true while configuration.xml keeps autoriseSnapshot false. Remaining follow-up: run one dedicated opt-in runtime update smoke test with habitv.update.enabled=true against the published URL."
+      "notes": "Runtime updates remain disabled by default. Publication cutover is live on GitHub Pages with token-free HTTPS access. Developer SNAPSHOT updates use -Dhabitv.update.autoriseSnapshot=true while configuration.xml keeps autoriseSnapshot false. Runtime artifact resolution now prioritizes explicit manifest download paths and falls back to maven-metadata.xml for timestamped SNAPSHOT JAR names. Remaining follow-up: run one dedicated opt-in runtime update smoke test with habitv.update.enabled=true against the published URL."
     },
     {
       "id": "provider-inventory",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -277,6 +277,8 @@ developers is opt-in via `-Dhabitv.update.autoriseSnapshot=true` while
 `configuration.xml` keeps `autoriseSnapshot` false. Remaining follow-up:
 run one dedicated opt-in runtime update smoke test with
 `-Dhabitv.update.enabled=true` against the published Pages URL.
+Runtime artifact resolution now prefers explicit manifest download paths and
+falls back to `maven-metadata.xml` for timestamped SNAPSHOT JAR filenames.
 
 ---
 

--- a/docs/runtime-quickstart.md
+++ b/docs/runtime-quickstart.md
@@ -137,3 +137,12 @@ Development snapshot updates: keep `<autoriseSnapshot>false</autoriseSnapshot>`
 in `configuration.xml` and pass `-Dhabitv.update.autoriseSnapshot=true` when you
 need Maven timestamped SNAPSHOT plugin artifacts from the static repository.
 This override must not be enabled for normal end users.
+
+Reference launch command:
+
+```bash
+java -Dhabitv.update.enabled=true \
+  -Dhabitv.update.autoriseSnapshot=true \
+  -Dhabitv.update.url=https://mika3578.github.io/habitv-repo/repository/ \
+  -jar application/habiTv/target/habiTv-4.1.0-SNAPSHOT.jar
+```

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -151,8 +151,12 @@ GitHub Pages serves `repository/` at
 
 When `-Dhabitv.update.enabled=true` (optional `-Dhabitv.update.url=...`):
 
-1. **Plugins** — `plugins.txt` or `habitv-update-manifest.properties` plugin entries.
-2. **Artifact versions** — manifest, optional `index.html`, then Maven path layout.
+1. **Plugins** — `plugins.txt` first, fallback to plugin entries in
+   `habitv-update-manifest.properties`.
+2. **Artifact resolution (runtime priority)**:
+   - manifest entry with explicit final JAR path (preferred);
+   - `maven-metadata.xml` snapshotVersion (fallback when no manifest entry);
+   - directory listing fallback for non-SNAPSHOT artifacts.
 3. **External tools** — manifest `tool` entries, then `tools/<name>/<version>/<file>`.
 
 Updates are **disabled by default**. If GitHub Pages is unreachable, Habitv keeps
@@ -163,6 +167,8 @@ local plugins and tools.
 Maven deploy publishes timestamped SNAPSHOT JARs (for example
 `arte-4.1.0-20260518.163022-1.jar`). Normal users must keep
 `updateConfig/autoriseSnapshot` set to `false` in `configuration.xml`.
+Do not rely on non-timestamped `artifactId-<version>-SNAPSHOT.jar` names on
+GitHub Pages.
 
 For local development against the published static repository, run Habitv with an
 explicit JVM override (configuration value is read first, then overridden only

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtils.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtils.java
@@ -202,7 +202,8 @@ public class FindArtifactUtils {
 			if (!matchesExtension(entry, extension)) {
 				continue;
 			}
-			if (entry.getVersion() != null && entry.getVersion().contains("SNAPSHOT")) {
+			if (entry.getVersion() != null && entry.getVersion().contains("SNAPSHOT")
+					&& (versionMaj == null || entry.getVersion().startsWith(versionMaj))) {
 				snapshotEntryFound = true;
 			}
 			if (!isVersionEligible(entry.getVersion(), versionMaj, autoriseSnapshot)) {
@@ -230,7 +231,7 @@ public class FindArtifactUtils {
 		Collections.sort(entries, (left, right) -> AlphanumComparator.INSTANCE
 				.compare(left.getRelativeUrl(), right.getRelativeUrl()));
 		final Entry entry = entries.get(entries.size() - 1);
-		return new ArtifactVersion(entry.getDownloadUrl(), version, ArtifactVersion.ResolutionSource.MANIFEST);
+		return new ArtifactVersion(entry.getDownloadUrl(manifest.getBaseUrl()), version, ArtifactVersion.ResolutionSource.MANIFEST);
 	}
 
 	private static boolean matchesExtension(final Entry entry, final String extension) {
@@ -284,11 +285,7 @@ public class FindArtifactUtils {
 		}
 		final String artifactVersionUrl = artifactURL + "/" + version;
 		if (version.contains("SNAPSHOT")) {
-			final ArtifactVersion snapshotVersion = findSnapshotVersionFromMetadata(artifactVersionUrl, artifactId, version,
-					extension);
-			if (snapshotVersion != null) {
-				return snapshotVersion;
-			}
+			return findSnapshotVersionFromMetadata(artifactVersionUrl, artifactId, version, extension);
 		}
 		items = findItems(Type.FILE, artifactVersionUrl);
 		final List<String> files = new LinkedList<>();
@@ -313,7 +310,7 @@ public class FindArtifactUtils {
 			final String metadataContent = RetrieverUtils.getUrlContent(metadataUrl, null);
 			final String snapshotValue = extractSnapshotValueFromMetadata(metadataContent, extension);
 			if (snapshotValue == null) {
-				LOG.warn("No <snapshotVersion> jar entry found in " + metadataUrl);
+				LOG.warn("No <snapshotVersion> " + extension + " entry found in " + metadataUrl);
 				return null;
 			}
 			final String finalFileName = artifactId + "-" + snapshotValue + "." + extension;

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtils.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtils.java
@@ -2,13 +2,21 @@ package com.dabi.habitv.framework.plugin.utils.update;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.log4j.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import com.dabi.habitv.framework.FrameworkConf;
 import com.dabi.habitv.framework.plugin.utils.AlphanumComparator;
@@ -16,24 +24,35 @@ import com.dabi.habitv.framework.plugin.utils.RetrieverUtils;
 import com.dabi.habitv.framework.plugin.utils.update.HabitvUpdateManifest.ArtifactKind;
 import com.dabi.habitv.framework.plugin.utils.update.HabitvUpdateManifest.Entry;
 
+import java.io.StringReader;
+
 public class FindArtifactUtils {
 
 	private static final Logger LOG = Logger.getLogger(FindArtifactUtils.class);
 
 	private static List<String> EXCLUDE = Arrays.asList("Parent Directory", "Name", "Last modified", "Size", "Description");
 
+	private static final String SNAPSHOT_DISABLED_MESSAGE =
+			"Skipping SNAPSHOT plugin artifact because snapshot updates are disabled. Enable -Dhabitv.update.autoriseSnapshot=true for development bootstrap.";
+
 	private static volatile HabitvUpdateManifest cachedManifest;
 
 	private static volatile boolean manifestLookupAttempted;
 
 	public static class ArtifactVersion {
+		public enum ResolutionSource {
+			MANIFEST, MAVEN_METADATA, DIRECTORY_LISTING
+		}
+
 		private String artifactId;
 		private final String url;
 		private final String version;
+		private final ResolutionSource source;
 
-		private ArtifactVersion(final String url, final String version) {
+		private ArtifactVersion(final String url, final String version, final ResolutionSource source) {
 			this.url = url;
 			this.version = version;
+			this.source = source;
 		}
 
 		public String getUrl() {
@@ -52,15 +71,21 @@ public class FindArtifactUtils {
 			this.artifactId = artifactId;
 		}
 
+		public ResolutionSource getSource() {
+			return source;
+		}
+
 		@Override
 		public String toString() {
-			return "ArtifactVersion [url=" + url + ", version=" + version + "]";
+			return "ArtifactVersion [url=" + url + ", version=" + version + ", source=" + source + "]";
 		}
 
 	}
 
 	public static ArtifactVersion findLastVersionUrl(final String groupId, final String artifactId, final String coreVersion,
 			final boolean autoriseSnapshot, String extension) {
+		extension = normalizeExtension(extension);
+		LOG.info("Resolving artifact update for " + artifactId + " (extension=" + extension + ")");
 		final String versionMaj = getVersionMaj(coreVersion);
 		final ArtifactKind kind = "zip".equalsIgnoreCase(extension) ? ArtifactKind.TOOL : ArtifactKind.PLUGIN;
 
@@ -75,7 +100,8 @@ public class FindArtifactUtils {
 		if (kind == ArtifactKind.TOOL) {
 			final String toolsArtifactUrl = UpdateRepositoryUrls.buildRepositoryUrl(FrameworkConf.TOOLS_REPOSITORY_PREFIX
 					+ "/" + artifactId);
-			final ArtifactVersion toolVersion = findLastVersionUrl(toolsArtifactUrl, versionMaj, autoriseSnapshot, extension);
+			final ArtifactVersion toolVersion = findLastVersionUrl(toolsArtifactUrl, artifactId, versionMaj,
+					autoriseSnapshot, extension, kind);
 			if (toolVersion != null) {
 				toolVersion.setArtifactId(artifactId);
 				return toolVersion;
@@ -83,7 +109,8 @@ public class FindArtifactUtils {
 		}
 
 		final String artifactURL = UpdateRepositoryUrls.buildRepositoryUrl(groupIdUrl + "/" + artifactId);
-		final ArtifactVersion lastVersion = findLastVersionUrl(artifactURL, versionMaj, autoriseSnapshot, extension);
+		final ArtifactVersion lastVersion = findLastVersionUrl(artifactURL, artifactId, versionMaj, autoriseSnapshot,
+				extension, kind);
 		if (lastVersion == null) {
 			return null;
 		}
@@ -108,6 +135,56 @@ public class FindArtifactUtils {
 		return cachedManifest != null ? cachedManifest : HabitvUpdateManifest.empty();
 	}
 
+	static String extractSnapshotValueFromMetadata(final String metadataContent, final String extension) {
+		if (metadataContent == null || metadataContent.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setNamespaceAware(false);
+			factory.setExpandEntityReferences(false);
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			final Document document = factory.newDocumentBuilder().parse(
+					new InputSource(new StringReader(metadataContent)));
+			final NodeList snapshotVersionNodes = document.getElementsByTagName("snapshotVersion");
+			final List<String> values = new LinkedList<>();
+			for (int i = 0; i < snapshotVersionNodes.getLength(); i++) {
+				final Node snapshotVersionNode = snapshotVersionNodes.item(i);
+				final String extensionValue = findChildNodeText(snapshotVersionNode, "extension");
+				if (!extension.equalsIgnoreCase(extensionValue)) {
+					continue;
+				}
+				final String classifier = findChildNodeText(snapshotVersionNode, "classifier");
+				if (classifier != null && !classifier.trim().isEmpty()) {
+					continue;
+				}
+				final String value = findChildNodeText(snapshotVersionNode, "value");
+				if (value != null && !value.trim().isEmpty()) {
+					values.add(value.trim());
+				}
+			}
+			if (values.isEmpty()) {
+				return null;
+			}
+			Collections.sort(values, AlphanumComparator.INSTANCE);
+			return values.get(values.size() - 1);
+		} catch (final Exception e) {
+			LOG.warn("Failed to parse maven-metadata.xml for snapshot artifact resolution: " + e.getMessage());
+			return null;
+		}
+	}
+
+	private static String findChildNodeText(final Node parent, final String childName) {
+		final NodeList children = parent.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			final Node child = children.item(i);
+			if (childName.equals(child.getNodeName())) {
+				return child.getTextContent();
+			}
+		}
+		return null;
+	}
+
 	private static ArtifactVersion findLastVersionFromManifest(final String groupId, final String artifactId,
 			final String versionMaj, final boolean autoriseSnapshot, final String extension, final ArtifactKind kind) {
 		final HabitvUpdateManifest manifest = getManifest();
@@ -119,23 +196,41 @@ public class FindArtifactUtils {
 			return null;
 		}
 		final List<String> versions = new LinkedList<>();
-		final java.util.Map<String, Entry> versionToEntry = new java.util.HashMap<>();
+		final Map<String, List<Entry>> versionToEntries = new HashMap<>();
+		boolean snapshotEntryFound = false;
 		for (final Entry entry : matches) {
 			if (!matchesExtension(entry, extension)) {
 				continue;
+			}
+			if (entry.getVersion() != null && entry.getVersion().contains("SNAPSHOT")) {
+				snapshotEntryFound = true;
 			}
 			if (!isVersionEligible(entry.getVersion(), versionMaj, autoriseSnapshot)) {
 				continue;
 			}
 			versions.add(entry.getVersion());
-			versionToEntry.put(entry.getVersion(), entry);
+			List<Entry> entriesForVersion = versionToEntries.get(entry.getVersion());
+			if (entriesForVersion == null) {
+				entriesForVersion = new LinkedList<>();
+				versionToEntries.put(entry.getVersion(), entriesForVersion);
+			}
+			entriesForVersion.add(entry);
 		}
 		final String version = findLastVersion(versionMaj, versions, autoriseSnapshot);
 		if (version == null) {
+			if (!autoriseSnapshot && snapshotEntryFound && kind == ArtifactKind.PLUGIN) {
+				LOG.warn(SNAPSHOT_DISABLED_MESSAGE);
+			}
 			return null;
 		}
-		final Entry entry = versionToEntry.get(version);
-		return new ArtifactVersion(entry.getDownloadUrl(), version);
+		final List<Entry> entries = versionToEntries.get(version);
+		if (entries == null || entries.isEmpty()) {
+			return null;
+		}
+		Collections.sort(entries, (left, right) -> AlphanumComparator.INSTANCE
+				.compare(left.getRelativeUrl(), right.getRelativeUrl()));
+		final Entry entry = entries.get(entries.size() - 1);
+		return new ArtifactVersion(entry.getDownloadUrl(), version, ArtifactVersion.ResolutionSource.MANIFEST);
 	}
 
 	private static boolean matchesExtension(final Entry entry, final String extension) {
@@ -166,14 +261,35 @@ public class FindArtifactUtils {
 		return versionMaj;
 	}
 
-	private static ArtifactVersion findLastVersionUrl(final String artifactURL, final String versionMaj, final boolean autoriseSnapshot,
-			final String extension) {
+	private static String normalizeExtension(final String extension) {
+		if (extension == null) {
+			return null;
+		}
+		final String trimmed = extension.trim();
+		if (trimmed.startsWith(".")) {
+			return trimmed.substring(1);
+		}
+		return trimmed;
+	}
+
+	private static ArtifactVersion findLastVersionUrl(final String artifactURL, final String artifactId, final String versionMaj,
+			final boolean autoriseSnapshot, final String extension, final ArtifactKind kind) {
 		List<String> items = findItems(Type.DIR, artifactURL + "/");
 		final String version = findLastVersion(versionMaj, items, autoriseSnapshot);
 		if (version == null) {
+			if (!autoriseSnapshot && hasSnapshotCandidate(items, versionMaj) && kind == ArtifactKind.PLUGIN) {
+				LOG.warn(SNAPSHOT_DISABLED_MESSAGE);
+			}
 			return null;
 		}
 		final String artifactVersionUrl = artifactURL + "/" + version;
+		if (version.contains("SNAPSHOT")) {
+			final ArtifactVersion snapshotVersion = findSnapshotVersionFromMetadata(artifactVersionUrl, artifactId, version,
+					extension);
+			if (snapshotVersion != null) {
+				return snapshotVersion;
+			}
+		}
 		items = findItems(Type.FILE, artifactVersionUrl);
 		final List<String> files = new LinkedList<>();
 		for (final String file : items) {
@@ -185,7 +301,27 @@ public class FindArtifactUtils {
 			return null;
 		} else {
 			Collections.sort(files);
-			return new ArtifactVersion(artifactVersionUrl + "/" + files.get(files.size() - 1), version);
+			return new ArtifactVersion(artifactVersionUrl + "/" + files.get(files.size() - 1), version,
+					ArtifactVersion.ResolutionSource.DIRECTORY_LISTING);
+		}
+	}
+
+	private static ArtifactVersion findSnapshotVersionFromMetadata(final String artifactVersionUrl, final String artifactId,
+			final String logicalVersion, final String extension) {
+		final String metadataUrl = artifactVersionUrl + "/maven-metadata.xml";
+		try {
+			final String metadataContent = RetrieverUtils.getUrlContent(metadataUrl, null);
+			final String snapshotValue = extractSnapshotValueFromMetadata(metadataContent, extension);
+			if (snapshotValue == null) {
+				LOG.warn("No <snapshotVersion> jar entry found in " + metadataUrl);
+				return null;
+			}
+			final String finalFileName = artifactId + "-" + snapshotValue + "." + extension;
+			return new ArtifactVersion(artifactVersionUrl + "/" + finalFileName, logicalVersion,
+					ArtifactVersion.ResolutionSource.MAVEN_METADATA);
+		} catch (final RuntimeException e) {
+			LOG.warn("maven-metadata.xml unavailable at " + metadataUrl + ": " + e.getMessage());
+			return null;
 		}
 	}
 
@@ -228,6 +364,18 @@ public class FindArtifactUtils {
 			}
 		}
 		return null;
+	}
+
+	private static boolean hasSnapshotCandidate(final List<String> versions, final String versionRef) {
+		for (final String version : versions) {
+			if (versionRef != null && !version.startsWith(versionRef)) {
+				continue;
+			}
+			if (version.contains("SNAPSHOT")) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static boolean isDirectory(final String attr) {

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifest.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifest.java
@@ -77,8 +77,16 @@ public final class HabitvUpdateManifest {
 		}
 
 		public String getDownloadUrl() {
+			return getDownloadUrl(null);
+		}
+
+		public String getDownloadUrl(final String baseUrl) {
 			if (relativeUrl.startsWith("http://") || relativeUrl.startsWith("https://")) {
 				return relativeUrl;
+			}
+			if (baseUrl != null && !baseUrl.isEmpty()) {
+				final String path = relativeUrl.startsWith("/") ? relativeUrl.substring(1) : relativeUrl;
+				return baseUrl + "/" + path;
 			}
 			return UpdateRepositoryUrls.buildRepositoryUrl(relativeUrl);
 		}
@@ -86,12 +94,19 @@ public final class HabitvUpdateManifest {
 
 	private final List<Entry> entries;
 
-	private HabitvUpdateManifest(final List<Entry> entries) {
+	private final String baseUrl;
+
+	private HabitvUpdateManifest(final List<Entry> entries, final String baseUrl) {
 		this.entries = Collections.unmodifiableList(entries);
+		this.baseUrl = baseUrl;
 	}
 
 	public List<Entry> getEntries() {
 		return entries;
+	}
+
+	public String getBaseUrl() {
+		return baseUrl;
 	}
 
 	public List<Entry> findEntries(final String groupId, final String artifactId, final ArtifactKind kind) {
@@ -131,7 +146,8 @@ public final class HabitvUpdateManifest {
 		final String manifestUrl = normalizedBase + "/" + FrameworkConf.UPDATE_MANIFEST_FILE;
 		try {
 			final String content = RetrieverUtils.getUrlContent(manifestUrl, null);
-			return parse(content);
+			final HabitvUpdateManifest parsed = parse(content);
+			return new HabitvUpdateManifest(new ArrayList<>(parsed.entries), normalizedBase);
 		} catch (final RuntimeException e) {
 			LOG.debug("Update manifest not available at " + manifestUrl + ": " + e.getMessage());
 			return empty();
@@ -164,7 +180,7 @@ public final class HabitvUpdateManifest {
 				}
 			}
 		}
-		return new HabitvUpdateManifest(parsed);
+		return new HabitvUpdateManifest(parsed, null);
 	}
 
 	static Entry parseLine(final String line) {
@@ -207,7 +223,7 @@ public final class HabitvUpdateManifest {
 	}
 
 	public static HabitvUpdateManifest empty() {
-		return new HabitvUpdateManifest(Collections.<Entry>emptyList());
+		return new HabitvUpdateManifest(Collections.<Entry>emptyList(), null);
 	}
 
 	public boolean isEmpty() {

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifest.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifest.java
@@ -119,7 +119,16 @@ public final class HabitvUpdateManifest {
 	}
 
 	public static HabitvUpdateManifest loadFromRepository() {
-		final String manifestUrl = UpdateRepositoryUrls.buildRepositoryUrl(FrameworkConf.UPDATE_MANIFEST_FILE);
+		return loadFromRepository(UpdateRepositoryUrls.getUpdateBaseUrl());
+	}
+
+	public static HabitvUpdateManifest loadFromRepository(final String baseUrl) {
+		final String normalizedBase = UpdateRepositoryUrls.normalizeBaseUrl(baseUrl);
+		if (normalizedBase == null || normalizedBase.isEmpty()) {
+			LOG.debug("Update manifest base URL is empty.");
+			return empty();
+		}
+		final String manifestUrl = normalizedBase + "/" + FrameworkConf.UPDATE_MANIFEST_FILE;
 		try {
 			final String content = RetrieverUtils.getUrlContent(manifestUrl, null);
 			return parse(content);

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifest.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifest.java
@@ -85,8 +85,9 @@ public final class HabitvUpdateManifest {
 				return relativeUrl;
 			}
 			if (baseUrl != null && !baseUrl.isEmpty()) {
+				final String normalizedBase = UpdateRepositoryUrls.normalizeBaseUrl(baseUrl);
 				final String path = relativeUrl.startsWith("/") ? relativeUrl.substring(1) : relativeUrl;
-				return baseUrl + "/" + path;
+				return normalizedBase + "/" + path;
 			}
 			return UpdateRepositoryUrls.buildRepositoryUrl(relativeUrl);
 		}

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/Updater.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/Updater.java
@@ -65,12 +65,15 @@ public abstract class Updater {
 
 	private void updateFile(final File currentFolder, final String fileToUpdate) {
 		onChecking(fileToUpdate);
+		LOG.info("Resolving update artifact: artifactId=" + fileToUpdate + ", extension=" + getServerExtension());
 		final ArtifactVersion artifactNewVersion = FindArtifactUtils.findLastVersionUrl(groupId, fileToUpdate, coreVersion,
 				autoriseSnapshot, getServerExtension());
 		if (artifactNewVersion == null) {
-			LOG.info("Nothing found for " + fileToUpdate);
+			LOG.warn("Skipping artifact " + fileToUpdate + " because no downloadable URL could be resolved.");
 			return;
 		}
+		LOG.info("Resolved artifact " + fileToUpdate + " from " + artifactNewVersion.getSource()
+				+ " with version " + artifactNewVersion.getVersion() + " at " + artifactNewVersion.getUrl());
 		final File currentFile = new File(folderToUpdate + "/" + fileToUpdate + "." + getLocalExtension());
 		if (currentFile.exists()) {
 			final String currentVersion = getCurrentVersion(currentFile);//
@@ -96,6 +99,7 @@ public abstract class Updater {
 			onUpdate(current, artifactNewVersion);
 			File newVersion;
 			try {
+				LOG.info("Downloading artifact from " + artifactNewVersion.getUrl() + " to " + current.getPath() + ".tmp");
 				newVersion = new File(downloadFile(artifactNewVersion.getUrl(), current.getPath() + ".tmp"));
 			} catch (final IOException e) {
 				onUpdateError(current, artifactNewVersion);

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtilsTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtilsTest.java
@@ -1,0 +1,215 @@
+package com.dabi.habitv.framework.plugin.utils.update;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.dabi.habitv.framework.FrameworkConf;
+import com.dabi.habitv.framework.plugin.utils.update.FindArtifactUtils.ArtifactVersion;
+import com.dabi.habitv.framework.plugin.utils.update.FindArtifactUtils.ArtifactVersion.ResolutionSource;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+public class FindArtifactUtilsTest {
+
+	private static final String GROUP_ID = "com.dabi.habitv";
+	private static final String ARTIFACT_ID = "youtube";
+	private static final String SNAPSHOT_VERSION = "4.1.0-SNAPSHOT";
+	private static final String TIMESTAMPED_VALUE = "4.1.0-20260518.163022-1";
+	private static final String TIMESTAMPED_JAR = "youtube-" + TIMESTAMPED_VALUE + ".jar";
+
+	private String previousUpdateUrl;
+	private HttpServer server;
+	private final Map<String, String> responses = new HashMap<>();
+
+	@Before
+	public void setUp() throws IOException {
+		previousUpdateUrl = System.getProperty(FrameworkConf.UPDATE_URL_PROPERTY);
+		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/", new FixtureHandler(responses));
+		server.start();
+		final String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/repository/";
+		System.setProperty(FrameworkConf.UPDATE_URL_PROPERTY, baseUrl);
+		FindArtifactUtils.clearManifestCache();
+	}
+
+	@After
+	public void tearDown() {
+		if (previousUpdateUrl == null) {
+			System.clearProperty(FrameworkConf.UPDATE_URL_PROPERTY);
+		} else {
+			System.setProperty(FrameworkConf.UPDATE_URL_PROPERTY, previousUpdateUrl);
+		}
+		FindArtifactUtils.clearManifestCache();
+		if (server != null) {
+			server.stop(0);
+		}
+	}
+
+	@Test
+	public void resolvesTimestampedSnapshotJarFromManifestWithoutReconstruction() {
+		addManifest("plugin|com.dabi.habitv|youtube|4.1.0-SNAPSHOT|jar|com/dabi/habitv/youtube/4.1.0-SNAPSHOT/"
+				+ TIMESTAMPED_JAR);
+
+		final ArtifactVersion resolved = FindArtifactUtils.findLastVersionUrl(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION,
+				true, "jar");
+
+		assertNotNull(resolved);
+		assertEquals(ResolutionSource.MANIFEST, resolved.getSource());
+		assertEquals(expectedRepositoryUrl("com/dabi/habitv/youtube/4.1.0-SNAPSHOT/" + TIMESTAMPED_JAR),
+				resolved.getUrl());
+	}
+
+	@Test
+	public void fallsBackToMavenMetadataAndKeepsJarSnapshotVersionOnly() {
+		addManifest("plugin|com.dabi.habitv|arte|4.1.0-SNAPSHOT|jar|com/dabi/habitv/arte/4.1.0-SNAPSHOT/arte.jar");
+		addVersionListing();
+		addSnapshotMetadata();
+
+		final ArtifactVersion resolved = FindArtifactUtils.findLastVersionUrl(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION,
+				true, "jar");
+
+		assertNotNull(resolved);
+		assertEquals(ResolutionSource.MAVEN_METADATA, resolved.getSource());
+		assertEquals(expectedRepositoryUrl("com/dabi/habitv/youtube/4.1.0-SNAPSHOT/" + TIMESTAMPED_JAR),
+				resolved.getUrl());
+		assertTrue("Resolution must ignore sources classifier entry", !resolved.getUrl().contains("sources"));
+	}
+
+	@Test
+	public void rejectsSnapshotWhenSnapshotsDisabled() {
+		addManifest("plugin|com.dabi.habitv|arte|4.1.0-SNAPSHOT|jar|com/dabi/habitv/arte/4.1.0-SNAPSHOT/arte.jar");
+		addVersionListing();
+		addSnapshotMetadata();
+
+		final ArtifactVersion resolved = FindArtifactUtils.findLastVersionUrl(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION,
+				false, "jar");
+
+		assertNull(resolved);
+	}
+
+	@Test
+	public void logsSnapshotSkipReasonWhenSnapshotsDisabled() {
+		addManifest("plugin|com.dabi.habitv|arte|4.1.0-SNAPSHOT|jar|com/dabi/habitv/arte/4.1.0-SNAPSHOT/arte.jar");
+		addVersionListing();
+		addSnapshotMetadata();
+
+		final MemoryAppender appender = new MemoryAppender();
+		final Logger logger = Logger.getLogger(FindArtifactUtils.class);
+		logger.addAppender(appender);
+		try {
+			final ArtifactVersion resolved = FindArtifactUtils.findLastVersionUrl(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION,
+					false, "jar");
+			assertNull(resolved);
+		} finally {
+			logger.removeAppender(appender);
+		}
+
+		assertTrue(appender.contains("Skipping SNAPSHOT plugin artifact because snapshot updates are disabled."));
+	}
+
+	@Test
+	public void extractSnapshotValueFromMetadataUsesJarExtensionWithoutClassifier() {
+		final String metadata = buildMetadata();
+		final String snapshotValue = FindArtifactUtils.extractSnapshotValueFromMetadata(metadata, "jar");
+		assertEquals(TIMESTAMPED_VALUE, snapshotValue);
+	}
+
+	private void addManifest(final String line) {
+		responses.put("/repository/habitv-update-manifest.properties", line + "\n");
+	}
+
+	private void addVersionListing() {
+		responses.put("/repository/com/dabi/habitv/youtube/", "<html><body><a href=\"4.1.0-SNAPSHOT/\">4.1.0-SNAPSHOT/</a></body></html>");
+	}
+
+	private void addSnapshotMetadata() {
+		responses.put("/repository/com/dabi/habitv/youtube/4.1.0-SNAPSHOT/maven-metadata.xml", buildMetadata());
+	}
+
+	private String buildMetadata() {
+		return ""
+				+ "<metadata>\n"
+				+ "  <groupId>com.dabi.habitv</groupId>\n"
+				+ "  <artifactId>youtube</artifactId>\n"
+				+ "  <version>4.1.0-SNAPSHOT</version>\n"
+				+ "  <versioning>\n"
+				+ "    <snapshotVersions>\n"
+				+ "      <snapshotVersion><extension>pom</extension><value>4.1.0-20260518.163022-1</value></snapshotVersion>\n"
+				+ "      <snapshotVersion><extension>jar</extension><classifier>sources</classifier><value>4.1.0-20260518.163022-1</value></snapshotVersion>\n"
+				+ "      <snapshotVersion><extension>jar</extension><value>" + TIMESTAMPED_VALUE + "</value></snapshotVersion>\n"
+				+ "    </snapshotVersions>\n"
+				+ "  </versioning>\n"
+				+ "</metadata>\n";
+	}
+
+	private String expectedRepositoryUrl(final String relativePath) {
+		return UpdateRepositoryUrls.normalizeBaseUrl(System.getProperty(FrameworkConf.UPDATE_URL_PROPERTY)) + "/"
+				+ relativePath;
+	}
+
+	private static final class FixtureHandler implements HttpHandler {
+		private final Map<String, String> responses;
+
+		private FixtureHandler(final Map<String, String> responses) {
+			this.responses = responses;
+		}
+
+		@Override
+		public void handle(final HttpExchange exchange) throws IOException {
+			final String body = responses.get(exchange.getRequestURI().getPath());
+			if (body == null) {
+				exchange.sendResponseHeaders(404, -1);
+				exchange.close();
+				return;
+			}
+			final byte[] payload = body.getBytes("UTF-8");
+			exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=UTF-8");
+			exchange.sendResponseHeaders(200, payload.length);
+			try (OutputStream stream = exchange.getResponseBody()) {
+				stream.write(payload);
+			}
+		}
+	}
+
+	private static final class MemoryAppender extends AppenderSkeleton {
+		private final StringBuilder events = new StringBuilder();
+
+		@Override
+		protected void append(final LoggingEvent event) {
+			if (event.getLevel().isGreaterOrEqual(Level.WARN)) {
+				events.append(String.valueOf(event.getRenderedMessage())).append('\n');
+			}
+		}
+
+		@Override
+		public void close() {
+			// no-op
+		}
+
+		@Override
+		public boolean requiresLayout() {
+			return false;
+		}
+
+		private boolean contains(final String expected) {
+			return events.toString().contains(expected);
+		}
+	}
+}

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtilsTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtilsTest.java
@@ -125,6 +125,53 @@ public class FindArtifactUtilsTest {
 	}
 
 	@Test
+	public void returnsNullWhenSnapshotMetadataUnavailableInsteadOfFallingThroughToDirectoryListing() {
+		// No manifest entry for youtube and no metadata - only a version directory listing
+		addVersionListing();
+		// Metadata endpoint intentionally absent (no addSnapshotMetadata call)
+
+		final ArtifactVersion resolved = FindArtifactUtils.findLastVersionUrl(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION,
+				true, "jar");
+
+		assertNull("SNAPSHOT resolution must fail when maven-metadata.xml is missing, not fall back to directory listing",
+				resolved);
+	}
+
+	@Test
+	public void doesNotLogSnapshotSkipWarningWhenManifestOnlyContainsWrongMajorVersionSnapshot() {
+		// Manifest has a SNAPSHOT for a different major version (5.0, not 4.1)
+		addManifest("plugin|com.dabi.habitv|youtube|5.0-SNAPSHOT|jar|com/dabi/habitv/youtube/5.0-SNAPSHOT/youtube-5.0-SNAPSHOT.jar");
+
+		final MemoryAppender appender = new MemoryAppender();
+		final Logger logger = Logger.getLogger(FindArtifactUtils.class);
+		logger.addAppender(appender);
+		try {
+			// Resolve with coreVersion that resolves to major "4.1"
+			final ArtifactVersion resolved = FindArtifactUtils.findLastVersionUrl(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION,
+					false, "jar");
+			assertNull(resolved);
+		} finally {
+			logger.removeAppender(appender);
+		}
+
+		assertTrue("No snapshot-disabled warning expected when the only SNAPSHOT is for a different major version",
+				!appender.contains("Skipping SNAPSHOT plugin artifact"));
+	}
+
+	@Test
+	public void manifestEntryDownloadUrlUsesManifestBaseUrlWhenRelative() {
+		final String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/repository";
+		final String relativeUrl = "com/dabi/habitv/youtube/4.1.0-SNAPSHOT/" + TIMESTAMPED_JAR;
+		final HabitvUpdateManifest manifest = HabitvUpdateManifest.loadFromRepository(baseUrl);
+		// Build a synthetic entry to verify URL resolution path (parse-based)
+		final HabitvUpdateManifest.Entry entry = HabitvUpdateManifest.parseLine(
+				"plugin|com.dabi.habitv|youtube|4.1.0-SNAPSHOT|jar|" + relativeUrl);
+		assertNotNull(entry);
+		final String downloadUrl = entry.getDownloadUrl(UpdateRepositoryUrls.normalizeBaseUrl(baseUrl));
+		assertEquals(UpdateRepositoryUrls.normalizeBaseUrl(baseUrl) + "/" + relativeUrl, downloadUrl);
+	}
+
+	@Test
 	public void extractSnapshotValueFromMetadataUsesJarExtensionWithoutClassifier() {
 		final String metadata = buildMetadata();
 		final String snapshotValue = FindArtifactUtils.extractSnapshotValueFromMetadata(metadata, "jar");

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtilsTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtilsTest.java
@@ -125,7 +125,7 @@ public class FindArtifactUtilsTest {
 	}
 
 	@Test
-	public void returnsNullWhenSnapshotMetadataUnavailableInsteadOfFallingThroughToDirectoryListing() {
+	public void returnsNullWhenSnapshotMetadataUnavailable() {
 		// No manifest entry for youtube and no metadata - only a version directory listing
 		addVersionListing();
 		// Metadata endpoint intentionally absent (no addSnapshotMetadata call)
@@ -138,7 +138,7 @@ public class FindArtifactUtilsTest {
 	}
 
 	@Test
-	public void doesNotLogSnapshotSkipWarningWhenManifestOnlyContainsWrongMajorVersionSnapshot() {
+	public void noWarningWhenSnapshotMajorVersionMismatch() {
 		// Manifest has a SNAPSHOT for a different major version (5.0, not 4.1)
 		addManifest("plugin|com.dabi.habitv|youtube|5.0-SNAPSHOT|jar|com/dabi/habitv/youtube/5.0-SNAPSHOT/youtube-5.0-SNAPSHOT.jar");
 

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifestTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifestTest.java
@@ -48,7 +48,7 @@ public class HabitvUpdateManifestTest {
 	}
 
 	@Test
-	public void loadFromRepositoryStoresBaseUrlAndEntryDownloadUrlUsesIt() {
+	public void parsedManifestHasNullBaseUrl() {
 		// Entries with relative URLs loaded via loadFromRepository must resolve against
 		// the URL that was passed, not against the system property.
 		final String content = "plugin|com.dabi.habitv|arte|4.1.0|jar|com/dabi/habitv/arte/4.1.0/arte-4.1.0.jar\n";

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifestTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/HabitvUpdateManifestTest.java
@@ -48,6 +48,32 @@ public class HabitvUpdateManifestTest {
 	}
 
 	@Test
+	public void loadFromRepositoryStoresBaseUrlAndEntryDownloadUrlUsesIt() {
+		// Entries with relative URLs loaded via loadFromRepository must resolve against
+		// the URL that was passed, not against the system property.
+		final String content = "plugin|com.dabi.habitv|arte|4.1.0|jar|com/dabi/habitv/arte/4.1.0/arte-4.1.0.jar\n";
+		final HabitvUpdateManifest manifest = HabitvUpdateManifest.parse(content);
+		// parse() has no baseUrl context, so getBaseUrl() is null
+		assertEquals(null, manifest.getBaseUrl());
+	}
+
+	@Test
+	public void entryGetDownloadUrlWithExplicitBaseUrlPrefersThatBaseUrl() {
+		final Entry entry = HabitvUpdateManifest.parseLine(
+				"plugin|com.dabi.habitv|arte|4.1.0|jar|com/dabi/habitv/arte/4.1.0/arte-4.1.0.jar");
+		final String url = entry.getDownloadUrl("https://custom.example.com/repo");
+		assertEquals("https://custom.example.com/repo/com/dabi/habitv/arte/4.1.0/arte-4.1.0.jar", url);
+	}
+
+	@Test
+	public void entryGetDownloadUrlWithAbsoluteRelativeUrlIgnoresBaseUrl() {
+		final Entry entry = HabitvUpdateManifest.parseLine(
+				"plugin|com.dabi.habitv|arte|4.1.0|jar|https://cdn.example.com/arte-4.1.0.jar");
+		final String url = entry.getDownloadUrl("https://other.example.com/repo");
+		assertEquals("https://cdn.example.com/arte-4.1.0.jar", url);
+	}
+
+	@Test
 	public void parseLineAcceptsBomPrefixedPluginEntry() {
 		final Entry entry = HabitvUpdateManifest.parseLine(
 				"\uFEFFplugin|com.dabi.habitv|arte|4.1.0|jar|com/dabi/habitv/arte/4.1.0/arte-4.1.0.jar");


### PR DESCRIPTION
## Summary
- Resolve runtime plugin artifact URLs without assuming `artifactId-version.jar` for SNAPSHOT artifacts.
- Prioritize explicit final download paths from `habitv-update-manifest.properties` and add Maven metadata fallback.
- Add offline local-fixture tests for timestamped SNAPSHOT resolution and update developer docs/tracker notes.

## Root cause
Maven 3 deploy publishes SNAPSHOT artifacts with timestamped filenames (for example `youtube-4.1.0-20260518.163022-1.jar`), while runtime update resolution could still rely on inferred names or directory listing assumptions.

## Runtime resolution strategy
- Load `habitv-update-manifest.properties` first and use explicit manifest JAR URLs when present.
- For artifacts missing manifest entries, resolve the version directory and read `maven-metadata.xml`.
- In metadata, select only `<snapshotVersion>` entries with `<extension>jar</extension>` and no classifier.
- Build the final timestamped filename from the metadata value and download that exact JAR URL.
- Keep release/non-SNAPSHOT fallback behavior via directory listing.
- Log runtime diagnostics: update URL, enabled flag, snapshot authorization, plugins list/manifest status, resolved artifact source, final JAR URL, skip reason, and download target path.

## Dev launch command
```bash
java -Dhabitv.update.enabled=true -Dhabitv.update.autoriseSnapshot=true -Dhabitv.update.url=https://mika3578.github.io/habitv-repo/repository/ -jar application/habiTv/target/habiTv-4.1.0-SNAPSHOT.jar
```

## Validation results
- `git status --short` (before commit): scoped updater/doc changes staged; unrelated workspace changes left untouched.
- `mvn -B -ntp -DskipTests validate` -> BUILD SUCCESS.
- `mvn --% -B -ntp -pl fwk/framework -am -Dtest=FindArtifactUtilsTest,HabitvUpdateManifestTest,UpdateRepositoryUrlsTest -Dsurefire.failIfNoSpecifiedTests=false test` -> BUILD SUCCESS (15 tests, 0 failures).
- `mvn --% -B -ntp -pl application/core -am -Dtest=UpdateManagerTest -Dsurefire.failIfNoSpecifiedTests=false test` -> BUILD SUCCESS (2 tests, 0 failures).
- Tracker consistency checks:
  - docs/dev-tracker slug cross-reference check -> OK.
  - docs/dev-tracker summary count check -> OK.

## Non-goals
- no provider repair
- no Java migration
- no release packaging change
- no attempt to disable Maven timestamped SNAPSHOT deployment