### PR TITLE
fix: enable runtime updates by default

### DIFF
--- a/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
+++ b/application/core/src/com/dabi/habitv/core/updater/UpdateManager.java
@@ -44,8 +44,10 @@ public class UpdateManager {
 	}
 
 	public void process() {
-		if (!Boolean.getBoolean(FrameworkConf.UPDATE_ENABLED_PROPERTY)) {
-			LOG.debug("Plugin update check is disabled.");
+		final boolean updateEnabled = resolveUpdateEnabled();
+		if (!updateEnabled) {
+			LOG.info("Plugin update check is disabled by "
+					+ FrameworkConf.UPDATE_ENABLED_PROPERTY + "=false.");
 			return;
 		}
 		final String updateSite = System.getProperty(
@@ -73,6 +75,25 @@ public class UpdateManager {
 		} catch (Exception e) {
 			LOG.error("Plugin update failed; keeping local plugins.", e);
 		}
+	}
+
+	private static boolean resolveUpdateEnabled() {
+		final String configured = System
+				.getProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY);
+		if (configured == null) {
+			return true;
+		}
+		final String normalized = configured.trim();
+		if ("true".equalsIgnoreCase(normalized)) {
+			return true;
+		}
+		if ("false".equalsIgnoreCase(normalized)) {
+			return false;
+		}
+		LOG.warn("Ignoring invalid " + FrameworkConf.UPDATE_ENABLED_PROPERTY
+				+ " value \"" + configured
+				+ "\"; defaulting to enabled update checks.");
+		return true;
 	}
 
 	public Publisher<UpdatePluginEvent> getUpdatePublisher() {

--- a/application/core/test/com/dabi/habitv/core/updater/UpdateManagerTest.java
+++ b/application/core/test/com/dabi/habitv/core/updater/UpdateManagerTest.java
@@ -2,6 +2,8 @@ package com.dabi.habitv.core.updater;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,7 +45,7 @@ public class UpdateManagerTest {
 
 	@Test
 	public void processSkipsWhenUpdatesDisabled() {
-		System.clearProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY);
+		System.setProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY, "false");
 		System.setProperty(FrameworkConf.UPDATE_URL_PROPERTY, "https://updates.must-not-be-used.example/repository/");
 
 		final AtomicInteger notifications = new AtomicInteger();
@@ -57,6 +59,31 @@ public class UpdateManagerTest {
 		updateManager.process();
 
 		assertEquals(0, notifications.get());
+	}
+
+	@Test
+	public void resolveUpdateEnabledDefaultsToTrueWhenPropertyMissing()
+			throws Exception {
+		System.clearProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY);
+		final Method resolveUpdateEnabled = UpdateManager.class
+				.getDeclaredMethod("resolveUpdateEnabled");
+		resolveUpdateEnabled.setAccessible(true);
+
+		assertTrue((Boolean) resolveUpdateEnabled.invoke(null));
+	}
+
+	@Test
+	public void resolveUpdateEnabledSupportsExplicitTrueFalse()
+			throws Exception {
+		final Method resolveUpdateEnabled = UpdateManager.class
+				.getDeclaredMethod("resolveUpdateEnabled");
+		resolveUpdateEnabled.setAccessible(true);
+
+		System.setProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY, "true");
+		assertTrue((Boolean) resolveUpdateEnabled.invoke(null));
+
+		System.setProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY, "false");
+		assertFalse((Boolean) resolveUpdateEnabled.invoke(null));
 	}
 
 	@Test

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR).",
-  "lastRefresh": "2026-05-18",
+  "lastRefresh": "2026-05-19",
   "statusValues": [
     "proposed",
     "in-progress",
@@ -123,12 +123,12 @@
       "status": "done",
       "priority": "P0",
       "progressPercent": 100,
-      "scope": "Remove or replace every active reference to <scm>scm:svn:..., <repository>http://dabiboo.free.fr/repository, <distributionManagement>ftp://ftpperso.free.fr/repository + wagon-ftp, and runtime constants UPDATE_URL and STAT_URL.",
+      "scope": "Remove or replace every active reference to <scm>scm:svn:..., <repository>http://dabiboo.free.fr/repository, <distributionManagement>ftp://ftpperso.free.fr/repository + wagon-ftp, and runtime constants UPDATE_URL and STAT_URL while externalizing runtime update controls.",
       "acceptanceCriteria": [
         "Active POM/runtime references to dabiboo.free.fr, subversion.assembla.com, scm:svn, and cpt.php are removed.",
         "Root repository uses https://mika3578.github.io/habitv-repo/repository.",
         "Telemetry is opt-in via habitv.stat.enabled and habitv.stat.url.",
-        "Plugin updates are opt-in via habitv.update.enabled and optional habitv.update.url."
+        "Plugin updates are controlled via habitv.update.enabled (default enabled, set false to disable) and optional habitv.update.url."
       ],
       "validation": [
         "git grep -nIE \"dabiboo|free\\.fr|ftpperso|subversion\\.assembla|scm:svn\" -- . -> matches only documentation/history, no active code/POM endpoints.",
@@ -136,7 +136,7 @@
         "mvn -B -ntp -DskipTests compile -> BUILD SUCCESS (33 modules)"
       ],
       "pr": "chore: remove legacy DabiBoo repository wiring (#36)",
-      "notes": "Execution supersedes PR #25 plan-only work. Publication cutover and updater HTML index contract remain HBTV-005; do not enable habitv.update.enabled until static index.html or manifest layout is verified."
+      "notes": "Execution supersedes PR #25 plan-only work. Publication cutover and updater HTML index contract remain HBTV-005. Runtime update checks are enabled by default; use habitv.update.enabled=false only when startup updates must be bypassed."
     },
     {
       "id": "static-repo-publish",
@@ -161,7 +161,7 @@
         "python scripts/static-repo/validate_repository_layout.py <repository-root>"
       ],
       "pr": "habitv-repo #2 (merged); habitv PR #49 (publication status + tracker refresh)",
-      "notes": "Runtime updates remain disabled by default. Publication cutover is live on GitHub Pages with token-free HTTPS access. Developer SNAPSHOT updates use -Dhabitv.update.autoriseSnapshot=true while configuration.xml keeps autoriseSnapshot false. Remaining follow-up: run one dedicated opt-in runtime update smoke test with habitv.update.enabled=true against the published URL."
+      "notes": "Runtime updates are enabled by default at startup. Publication cutover is live on GitHub Pages with token-free HTTPS access. Developer SNAPSHOT updates use -Dhabitv.update.autoriseSnapshot=true while configuration.xml keeps autoriseSnapshot false. Remaining follow-up: run one dedicated runtime update smoke test with habitv.update.autoriseSnapshot=true against the published URL."
     },
     {
       "id": "provider-inventory",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -209,7 +209,7 @@ nothing technical but everyone has push access to `develop`.
 
 **Scope** — Remove active legacy DabiBoo/free.fr/SVN/Assembla wiring from
 Maven POMs and runtime paths; replace SCM metadata with GitHub; disable
-startup telemetry and plugin update checks by default; point Maven
+startup telemetry by default and externalize runtime update controls; point Maven
 `<repository>` at the public `habitv-repo` GitHub Pages base.
 
 **Acceptance criteria**
@@ -219,8 +219,8 @@ startup telemetry and plugin update checks by default; point Maven
   `https://mika3578.github.io/habitv-repo/repository`
 - ✅ Runtime telemetry ping is opt-in only (`habitv.stat.enabled=true`)
   and requires explicit URL configuration (`habitv.stat.url`)
-- ✅ Runtime plugin updates are opt-in only (`habitv.update.enabled=true`)
-  with optional `habitv.update.url`
+- ✅ Runtime plugin updates are controlled via `habitv.update.enabled`
+  (default enabled, set to `false` to disable) and optional `habitv.update.url`
 
 **Validation**
 ```bash
@@ -235,8 +235,8 @@ mvn -B -ntp -DskipTests compile      # BUILD SUCCESS (33 modules)
 **Notes** — Execution supersedes the documentation-only plan in PR #25.
 Functional publication cutover remains blocked under `static-repo-publish`
 until `habitv-repo` serves `/repository` with Apache-style directory
-listings. Do not enable `habitv.update.enabled` until static `index.html`
-files or an equivalent manifest layout are verified.
+listings. Runtime update checks are now enabled by default; use
+`habitv.update.enabled=false` to disable them temporarily.
 
 ---
 
@@ -270,13 +270,13 @@ python scripts/static-repo/validate_repository_layout.py "<repository-root>"
 
 **Related PRs** · habitv-repo #2 (merged) · habitv PR #49 (publication status + tracker refresh)
 
-**Notes** — Runtime updates stay disabled by default.
+**Notes** — Runtime updates are enabled by default at startup.
 Publication cutover is complete (`https://mika3578.github.io/habitv-repo/repository/`
 and `plugins.txt` live with no authentication). SNAPSHOT consumption for
 developers is opt-in via `-Dhabitv.update.autoriseSnapshot=true` while
 `configuration.xml` keeps `autoriseSnapshot` false. Remaining follow-up:
 run one dedicated opt-in runtime update smoke test with
-`-Dhabitv.update.enabled=true` against the published Pages URL.
+`-Dhabitv.update.autoriseSnapshot=true` against the published Pages URL.
 
 ---
 

--- a/docs/runtime-quickstart.md
+++ b/docs/runtime-quickstart.md
@@ -128,10 +128,12 @@ plugin itself is fully wired (see
 `plugins/youtube/test/.../YoutubePluginDownloaderCmdTest.java`); the
 limitation is purely network policy of the runtime environment.
 
-Startup telemetry and plugin update checks are disabled by default.
-Enable only when needed: `-Dhabitv.stat.enabled=true`
-`-Dhabitv.stat.url=...` and/or `-Dhabitv.update.enabled=true`
-(optional `-Dhabitv.update.url=...`).
+Startup telemetry is disabled by default. Plugin update checks are enabled by
+default on startup for GUI and console launches.
+Use `-Dhabitv.stat.enabled=true` and `-Dhabitv.stat.url=...` only when needed.
+You can disable runtime plugin updates explicitly with
+`-Dhabitv.update.enabled=false` (optional custom base:
+`-Dhabitv.update.url=...`).
 
 Development snapshot updates: keep `<autoriseSnapshot>false</autoriseSnapshot>`
 in `configuration.xml` and pass `-Dhabitv.update.autoriseSnapshot=true` when you

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -149,14 +149,15 @@ GitHub Pages serves `repository/` at
 
 ## Runtime update discovery
 
-When `-Dhabitv.update.enabled=true` (optional `-Dhabitv.update.url=...`):
+By default, startup checks for plugin/tool updates use the configured
+repository base. You can override the base with `-Dhabitv.update.url=...` or
+disable startup updates with `-Dhabitv.update.enabled=false`.
 
 1. **Plugins** — `plugins.txt` or `habitv-update-manifest.properties` plugin entries.
 2. **Artifact versions** — manifest, optional `index.html`, then Maven path layout.
 3. **External tools** — manifest `tool` entries, then `tools/<name>/<version>/<file>`.
 
-Updates are **disabled by default**. If GitHub Pages is unreachable, Habitv keeps
-local plugins and tools.
+If GitHub Pages is unreachable, Habitv keeps local plugins and tools.
 
 ### Development snapshot updates
 


### PR DESCRIPTION
## Summary
- Enable runtime plugin/tool update checks by default for every startup path (GUI and console).
- Keep `-Dhabitv.update.enabled=false` as an explicit opt-out switch.
- Update updater tests and runtime documentation/tracker entries accordingly.

## Validation
- `git status --short`
- `mvn -B -ntp -DskipTests validate` -> BUILD SUCCESS
- `mvn --% -B -ntp -pl application/core -am -Dtest=UpdateManagerTest -Dsurefire.failIfNoSpecifiedTests=false test` -> BUILD SUCCESS
- Tracker consistency checks:
  - slug cross-reference check -> OK
  - summary/status counts check -> OK

## Scope notes
- No provider repair
- No Java version change
- No packaging change