### PR TITLE
fix(francetv): swap dead france-o slug for la1ere, widen canDownload, raise MAX_PAGES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
-| 2026-05-19 | TBD | `francetv` provider: replace dead `france-o` channel slug with `la1ere` (Outre-mer La 1ère), centralise channel labels in `FranceTvUrls`, accept `franceinfo.fr` / `francetvinfo.fr` URLs in `canDownload`, raise `MAX_PAGES` to 100 |
+| 2026-05-19 | PR [#64](https://github.com/Mika3578/habitv/pull/64) | `francetv` provider: replace dead `france-o` channel slug with `la1ere` (Outre-mer La 1ère), centralise channel labels in `FranceTvUrls`, accept `franceinfo.fr` / `francetvinfo.fr` URLs in `canDownload`, raise `MAX_PAGES` to 100 |
 | 2026-05-18 | `2311bbc` | Replace `pluzz` provider with `francetv` (france.tv + yt-dlp) — users must rename `<plugin name="pluzz">` to `<plugin name="francetv">` in their grab-config XML (legacy `pluzz.` URLs in `canDownload` remain accepted) |
 | 2026-05-18 | PR [#52](https://github.com/Mika3578/habitv/pull/52) | Migrate YouTube plugin downloader defaults to yt-dlp |
 | 2026-05-17 | `7a61dd6` | Add runnable yt-dlp runtime path for `consoleView` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-19 | TBD | `francetv` provider: replace dead `france-o` channel slug with `la1ere` (Outre-mer La 1ère), centralise channel labels in `FranceTvUrls`, accept `franceinfo.fr` / `francetvinfo.fr` URLs in `canDownload`, raise `MAX_PAGES` to 100 |
 | 2026-05-18 | `2311bbc` | Replace `pluzz` provider with `francetv` (france.tv + yt-dlp) — users must rename `<plugin name="pluzz">` to `<plugin name="francetv">` in their grab-config XML (legacy `pluzz.` URLs in `canDownload` remain accepted) |
 | 2026-05-18 | PR [#52](https://github.com/Mika3578/habitv/pull/52) | Migrate YouTube plugin downloader defaults to yt-dlp |
 | 2026-05-17 | `7a61dd6` | Add runnable yt-dlp runtime path for `consoleView` |

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvApiClient.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvApiClient.java
@@ -20,7 +20,7 @@ final class FranceTvApiClient {
 
 	private static final ObjectMapper MAPPER = new ObjectMapper();
 
-	private static final int MAX_PAGES = 25;
+	private static final int MAX_PAGES = 100;
 
 	private static final int PAGE_SIZE = 20;
 

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvConf.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvConf.java
@@ -12,7 +12,7 @@ interface FranceTvConf {
 
 	String API_PLATFORM = "apps";
 
-	String[] CHANNEL_SLUGS = { "france-2", "france-3", "france-4", "france-5", "france-o" };
+	String[] CHANNEL_SLUGS = { "france-2", "france-3", "france-4", "france-5", "la1ere" };
 
 	String EXTENSION = FrameworkConf.MP4;
 

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvPluginManager.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvPluginManager.java
@@ -65,7 +65,7 @@ public class FranceTvPluginManager extends BasePluginWithProxy implements Plugin
 		final Set<CategoryDTO> categories = new LinkedHashSet<>();
 		for (final String slug : FranceTvConf.CHANNEL_SLUGS) {
 			final String channelUrl = FranceTvConf.HOME_URL + "/" + slug + "/";
-			final CategoryDTO channel = new CategoryDTO(FranceTvConf.NAME, channelLabel(slug), channelUrl,
+			final CategoryDTO channel = new CategoryDTO(FranceTvConf.NAME, FranceTvUrls.channelLabel(slug), channelUrl,
 					FranceTvConf.EXTENSION);
 			channel.setDownloadable(false);
 			channel.addSubCategories(findPrograms(slug));
@@ -111,17 +111,11 @@ public class FranceTvPluginManager extends BasePluginWithProxy implements Plugin
 		if (downloadInput.contains("france.tv") || downloadInput.contains("france2.")
 				|| downloadInput.contains("france3.") || downloadInput.contains("france4.")
 				|| downloadInput.contains("france5.") || downloadInput.contains("franceo.")
+				|| downloadInput.contains("franceinfo.fr") || downloadInput.contains("francetvinfo.fr")
 				|| downloadInput.contains("pluzz.")) {
 			return DownloadableState.SPECIFIC;
 		}
 		return DownloadableState.IMPOSSIBLE;
-	}
-
-	private static String channelLabel(final String slug) {
-		if ("france-o".equals(slug)) {
-			return "France O";
-		}
-		return "France " + slug.substring(slug.length() - 1);
 	}
 
 	private static String programLabel(final Map<String, Object> item, final String programPath) {

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvUrls.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvUrls.java
@@ -77,6 +77,23 @@ final class FranceTvUrls {
 		return "integrale".equals(type) || "unitaire".equals(type);
 	}
 
+	static String channelLabel(final String slug) {
+		switch (slug) {
+		case "france-2":
+			return "France 2";
+		case "france-3":
+			return "France 3";
+		case "france-4":
+			return "France 4";
+		case "france-5":
+			return "France 5";
+		case "la1ere":
+			return "La 1ère";
+		default:
+			return slug;
+		}
+	}
+
 	private static String programPathFromItem(final Map<String, Object> item) {
 		final Object program = item.get("program");
 		if (!(program instanceof Map)) {

--- a/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvUrlsTest.java
+++ b/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvUrlsTest.java
@@ -101,6 +101,21 @@ public class FranceTvUrlsTest {
 		assertFalse(FranceTvUrls.isReplayVideoType(""));
 	}
 
+	@Test
+	public void channelLabelMapsKnownSlugs() {
+		assertEquals("France 2", FranceTvUrls.channelLabel("france-2"));
+		assertEquals("France 3", FranceTvUrls.channelLabel("france-3"));
+		assertEquals("France 4", FranceTvUrls.channelLabel("france-4"));
+		assertEquals("France 5", FranceTvUrls.channelLabel("france-5"));
+		assertEquals("La 1ère", FranceTvUrls.channelLabel("la1ere"));
+	}
+
+	@Test
+	public void channelLabelEchoesUnknownSlug() {
+		assertEquals("franceinfo", FranceTvUrls.channelLabel("franceinfo"));
+		assertEquals("", FranceTvUrls.channelLabel(""));
+	}
+
 	private static Map<String, Object> sampleEpisode(final long id, final String title,
 			final String programPath, final Integer season) {
 		final Map<String, Object> item = new LinkedHashMap<>();


### PR DESCRIPTION
## Summary

Follow-up improvements on top of PR #58, addressing concrete issues uncovered while reviewing it. Targets `fix/provider-francetv` so the diff shows only the delta; rebase onto `develop` once #58 lands (or change the base).

## Changes

- **Replace dead `france-o` slug with `la1ere`** in `FranceTvConf.CHANNEL_SLUGS`. France Ô left TNT in August 2020; its replays now live on the Outre-mer La 1ère network at `france.tv/la1ere/...` and `la1ere.franceinfo.fr/...`.
- **Move `channelLabel` from `FranceTvPluginManager` to `FranceTvUrls`** and turn it into an explicit slug → label `switch`. Drops the last-character heuristic that would have rendered `la1ere` as `"France e"` and is now unit-testable alongside the other URL helpers.
- **Widen `canDownload`** to also accept `franceinfo.fr` (covers `la1ere.franceinfo.fr` portal URLs) and `francetvinfo.fr` (editorial portal). yt-dlp's `francetv` / `francetvinfo` extractors handle both URL shapes, so habiTv should route them to the `youtube` downloader.
- **Raise `FranceTvApiClient.MAX_PAGES` 25 → 100**. The mobile API response only carries `items`, `label`, `type` (no `total`/`next`/`has_more`), so the size heuristic is the only end-of-stream signal. The higher cap reduces the risk of silently truncating large catalogues — la1ere alone aggregates 9+ overseas regions.

## Validation against the live mobile API

```
curl -A "Mozilla/5.0" "https://api-mobile.yatta.francetv.fr/apps/regions/la1ere/programs?platform=apps&page=0"
```

- HTTP 200, ~108.5 KB body.
- `items[0]` = `{ "id": 43783, "label": "1+1 = Nous", "type": "program", "program_path": "la1ere_1-1-nous", ... }`.
- Page size: 20 (matches `PAGE_SIZE`).
- Response top-level keys: `['items', 'label', 'type']` — no pagination metadata.

Same probe against `france-o` confirmed only that the slug **may** still redirect at the front-end (yt-dlp still has stale `france-o` test URLs), but it is no longer the right entry point for the regional/overseas catalogue.

## Test plan

- [x] `mvn -B -ntp -DskipTests validate` — green.
- [x] `mvn -B -ntp -pl plugins/francetv -am -Dtest='FranceTvUrlsTest,FranceTvOfflineFixtureBaselineTest' -Dsurefire.failIfNoSpecifiedTests=false test` — 12 tests, all green (includes the two new `channelLabel` cases).
- [ ] Live: `mvn -B -ntp -pl plugins/francetv -am -Dtest=FranceTvPluginManagerTest -Dsurefire.failIfNoSpecifiedTests=false test` — please run from a network that can reach `api-mobile.yatta.francetv.fr` (this PR's CI sandbox cannot).
- [ ] End-to-end: pick any item id returned by the curl above (e.g. `la1ere_1-1-nous`) and confirm `yt-dlp` can grab one episode from the resulting `france.tv/la1ere/...` page.

## Out of scope / follow-ups suggested in the original review of #58

- API client `User-Agent` / explicit timeouts (the current `getInputStreamFromUrl` defaults may be permissive enough — separate investigation).
- Replay-type widening beyond `integrale` / `unitaire` (`isReplayVideoType`) — needs a captured episode response to decide.
- One-release `PluzzPluginManager` deprecation shim for users with `<plugin name="pluzz">` in their grab-config XML.
- `FranceTvOfflineFixtureBaselineTest` uses a CWD-relative fixture path (inherited).

---
_Generated by [Claude Code](https://claude.ai/code/session_015z1a1bL9sGw95T83FY3FwL)_