### PR TITLE
security: add dependency vulnerability audit baseline

### DIFF
--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR).",
-  "lastRefresh": "2026-05-19",
+  "lastRefresh": "2026-05-20",
   "statusValues": [
     "proposed",
     "in-progress",
@@ -18,12 +18,12 @@
   ],
   "summary": {
     "done": 11,
-    "inProgress": 2,
+    "inProgress": 3,
     "proposed": 2,
     "deferred": 0,
     "blocked": 0,
-    "total": 15,
-    "overallProgressPercent": 83
+    "total": 16,
+    "overallProgressPercent": 78
   },
   "items": [
     {
@@ -365,8 +365,30 @@
         "mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am test",
         "mvn -B -ntp -DskipTests package"
       ],
-      "pr": "ci: add Maven PR validation workflow (this PR)",
+      "pr": "ci: add Maven PR validation workflow (#65)",
       "notes": "Java 8 remains the required baseline; Java 11+ stays diagnostic until JAXB and JavaFX modernization is complete."
+    },
+    {
+      "id": "dependency-security-audit",
+      "legacyCode": "HBTV-016",
+      "displayTitle": "Dependency security audit & remediation",
+      "icon": "🔒",
+      "status": "in-progress",
+      "priority": "P1",
+      "progressPercent": 15,
+      "scope": "Establish a documentation-first Dependabot triage baseline for the Java 8 Maven reactor without mass dependency upgrades. Follow-up PRs upgrade build plugins, logging, HTTPS resolution, and runtime libraries in a safe order.",
+      "acceptanceCriteria": [
+        "docs/security-dependency-audit.md records GitHub vulnerability counts, scope, risks, remediation order, and first fix candidates.",
+        "dev-tracker mirrors the work item in Markdown and JSON.",
+        "Optional scripts/security/maven-dependency-inventory.ps1 lists POMs and runs mvn validate (and optional dependency:tree).",
+        "Focused follow-up PRs address Maven plugins, log4j 1.x, and module-scoped runtime bumps without mixing provider rewrites."
+      ],
+      "validation": [
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS",
+        "scripts/security/maven-dependency-inventory.ps1 (optional -DependencyTree)"
+      ],
+      "pr": "security: add dependency vulnerability audit baseline (this PR)",
+      "notes": "Baseline PR security/dependabot-audit-baseline. GitHub reports 294 vulnerabilities (87 critical, 90 high, 89 moderate, 28 low). Dependabot API export to target/dependabot-alerts.json is local-only (gitignored)."
     }
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -12,24 +12,24 @@
 > on each entry for compatibility with existing PRs and commits. See
 > the `descriptive-slug-ids` ADR for the rationale and full mapping.
 
-**Last refresh:** 2026-05-19 · **Active branch:** `develop`
+**Last refresh:** 2026-05-20 · **Active branch:** `develop`
 
 ---
 
 ## 📊 Overall progress
 
 ```
-█████████████████░░░  83%
+████████████████░░░░  78%
 ```
 
 | Category | Count |
 |---------|------:|
 | ✅ Delivered | **11** |
-| 🟡 In progress | **2** |
+| 🟡 In progress | **3** |
 | 🔵 Proposed | **2** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
-| **Total work items** | **15** |
+| **Total work items** | **16** |
 
 ---
 
@@ -52,6 +52,7 @@
 | 🔑 `youtube-apikey` — YouTube Data API key externalization | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧩 `jaxb-launcher-recovery` — JAXB generated sources & launcher classpath recovery | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧱 `maven-pr-validation` — Maven PR validation workflow | ✅ Done | 🟠 P1 | `████████████████████` 100% |
+| 🔒 `dependency-security-audit` — Dependency security audit & remediation | 🟡 In progress | 🟠 P1 | `███░░░░░░░░░░░░░░░░░` 15% |
 
 ---
 
@@ -623,10 +624,46 @@ mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am
 mvn -B -ntp -DskipTests package
 ```
 
-**Related PR** · `ci: add Maven PR validation workflow` (this PR)
+**Related PR** · `ci: add Maven PR validation workflow` (#65)
 
 **Notes** — Java 8 remains the required baseline; Java 11+ stays
 diagnostic until JAXB and JavaFX modernization work is complete.
+
+---
+
+## 🔒 `dependency-security-audit` — Dependency security audit & remediation
+
+| | |
+|---|---|
+| **Status** | 🟡 In progress |
+| **Priority** | 🟠 P1 |
+| **Progress** | `███░░░░░░░░░░░░░░░░░` 15% |
+| **Legacy code** | HBTV-016 |
+
+**Scope** — Establish a documentation-first Dependabot triage baseline
+for the Java 8 Maven reactor without mass dependency upgrades. Follow-up
+PRs upgrade build plugins, logging, HTTPS resolution, and runtime
+libraries in a safe order.
+
+**Acceptance criteria**
+- ✅ `docs/security-dependency-audit.md` records GitHub vulnerability
+  counts, scope, risks, remediation order, and first fix candidates
+- 🟡 `dev-tracker` mirrors the work item in Markdown and JSON
+- 🟡 Optional `scripts/security/maven-dependency-inventory.ps1` lists
+  POMs and runs `mvn validate` (and optional `dependency:tree`)
+- ⬜ Focused follow-up PRs address Maven plugins, log4j 1.x, and
+  module-scoped runtime bumps without mixing provider rewrites
+
+**Validation**
+```bash
+mvn -B -ntp -DskipTests validate
+pwsh -File scripts/security/maven-dependency-inventory.ps1 -DependencyTree
+```
+
+**Notes** — Baseline branch `security/dependabot-audit-baseline`. GitHub
+reports **294** vulnerabilities (87 critical, 90 high, 89 moderate,
+28 low). Dependabot API export to `target/dependabot-alerts.json` is
+local-only (gitignored).
 
 ---
 
@@ -662,3 +699,4 @@ issue trackers:
 | HBTV-013 | `youtube-apikey` |
 | HBTV-014 | `jaxb-launcher-recovery` |
 | HBTV-015 | `maven-pr-validation` |
+| HBTV-016 | `dependency-security-audit` |

--- a/docs/security-dependency-audit.md
+++ b/docs/security-dependency-audit.md
@@ -1,6 +1,6 @@
 # Dependency security audit baseline
 
-> **Tracker:** `dependency-security-audit` (HBTV-015)  
+> **Tracker:** `dependency-security-audit` (HBTV-016)  
 > **Branch:** `security/dependabot-audit-baseline`  
 > **Last refresh:** 2026-05-20
 
@@ -112,10 +112,11 @@ Declared directly under `<build><plugins>` in root `pom.xml`:
 |--------|--------|---------|
 | `application/core` | `maven-jaxb-plugin` (XJC) | 1.1.1 |
 | `application/core` | `build-helper-maven-plugin` | 3.6.0 |
-| `application/habiTv`, `application/consoleView` | `maven-assembly-plugin` | 2.4.3 |
-| `application/trayView` | (plugin) | 2.0 |
-| `application/habiTv-linux` / `habiTv-windows` | JavaFX / bundling plugins | 2.8, 1.6 |
-| `build/static-repo-publisher` | (plugin) | 3.5.0 |
+| `application/habiTv`, `application/consoleView` | `maven-shade-plugin` | 2.4.3 |
+| `application/trayView` | `javafx-maven-plugin` (`com.zenjava`) | 2.0 |
+| `application/habiTv-linux` / `habiTv-windows` | `maven-dependency-plugin` | 2.8 |
+| `application/habiTv-linux` / `habiTv-windows` | `maven-antrun-plugin` | 1.6 |
+| `build/static-repo-publisher` | `exec-maven-plugin` (`org.codehaus.mojo`) | 3.5.0 |
 
 ### Repositories
 

--- a/docs/security-dependency-audit.md
+++ b/docs/security-dependency-audit.md
@@ -1,0 +1,175 @@
+# Dependency security audit baseline
+
+> **Tracker:** `dependency-security-audit` (HBTV-015)  
+> **Branch:** `security/dependabot-audit-baseline`  
+> **Last refresh:** 2026-05-20
+
+## GitHub warning summary
+
+GitHub reports **294 vulnerabilities** on the default branch:
+
+| Severity | Count |
+|----------|------:|
+| Critical | 87 |
+| High | 90 |
+| Moderate | 89 |
+| Low | 28 |
+
+These counts come from the repository **Security → Dependabot** dashboard.
+They include transitive dependencies across the Maven reactor and may
+overlap with alerts that cannot be fixed without coordinated upgrades.
+
+### Dependabot API export (local only)
+
+When authenticated, export alerts for offline triage:
+
+```powershell
+New-Item -ItemType Directory -Force -Path target | Out-Null
+gh api --paginate /repos/Mika3578/habitv/dependabot/alerts `
+  | Set-Content -Encoding utf8 target/dependabot-alerts.json
+```
+
+`target/` is gitignored (`**/target/`). Do not commit the export.
+A successful local export on 2026-05-20 produced a large JSON payload
+(suitable for scripted grouping by package and severity).
+
+If `gh api` fails (missing auth, insufficient `security_events` scope, or
+private-repo restrictions), use the GitHub UI under **Security →
+Dependabot alerts** and record triage notes in follow-up PRs.
+
+## Scope
+
+This PR creates the **security audit baseline only**. It does not attempt
+mass upgrades, change runtime behavior, or modify provider plugins.
+
+Follow-up work must stay in focused PRs (build plugins, logging, HTTP
+repositories, then runtime libraries module by module).
+
+## Risk
+
+Large dependency upgrades may break:
+
+- **Java 8 compatibility** — compiler `source`/`target` 1.8 across the reactor.
+- **JAXB generation** — `com.sun.tools.xjc.maven2:maven-jaxb-plugin` 1.1.1 in
+  `application/core` with XSD-driven packages.
+- **JavaFX runtime** — `habiTv-linux` / `habiTv-windows` (out of reactor) use
+  legacy JavaFX 2.x tooling.
+- **Legacy plugins** — 22 provider/downloader modules with varied own-version
+  coordinates and live-network tests.
+
+Blind version bumps on parent `dependencyManagement` can shift transitive
+graphs for all modules at once.
+
+## Maven module inventory
+
+**36** `pom.xml` files (reactor + out-of-reactor + static-repo publisher):
+
+| Area | Paths |
+|------|--------|
+| Root | `pom.xml` |
+| Framework | `fwk/pom.xml`, `fwk/api/pom.xml`, `fwk/framework/pom.xml` |
+| Application | `application/pom.xml`, `application/core/pom.xml`, `application/consoleView/pom.xml`, `application/trayView/pom.xml`, `application/habiTv/pom.xml`, `application/habiTv-linux/pom.xml`, `application/habiTv-windows/pom.xml` |
+| Plugins aggregator | `plugins/pom.xml` + 22 plugin modules + `plugins/plugin-tester/pom.xml` |
+| Build | `build/static-repo-publisher/pom.xml` (profile `static-repo-publish` only) |
+
+### Parent `dependencyManagement` (root `pom.xml`)
+
+Central versions for third-party libraries (children omit versions when
+they import from parent):
+
+| Artifact | Version | Notes |
+|----------|---------|--------|
+| `com.dabi.habitv:api` / `framework` | `${project.parent.version}` | Internal |
+| `javax.mail:mail` | 1.4.7 | Legacy JavaMail |
+| `com.google.guava:guava` | 20.0 | Pre-Java-8-module era |
+| `commons-cli:commons-cli` | 1.11.0 | |
+| `rome:rome` | 1.0 | Very old RSS |
+| `org.jsoup:jsoup` | 1.22.2 | HTML parsing |
+| `jackson-core` / `jackson-databind` | 2.21.3 | JSON |
+| `jaxb-api` | 2.3.1 | javax namespace |
+| `jaxb-runtime` | 2.3.9 | GlassFish runtime |
+| `commons-codec` | 1.22.0 | |
+| `commons-lang:commons-lang` | 2.6 | **2.x line (not commons-lang3)** |
+| `log4j:log4j` | 1.2.17 | **Log4j 1.x (EOL)** |
+| `junit:junit` | 4.13.2 | JUnit 4 |
+
+No `xstream` coordinates appear in the repository POMs (grep baseline).
+
+### Root build plugins (not in `pluginManagement`)
+
+Declared directly under `<build><plugins>` in root `pom.xml`:
+
+| Plugin | Version |
+|--------|---------|
+| `maven-compiler-plugin` | 3.15.0 |
+| `maven-jar-plugin` | 2.6 |
+| `maven-deploy-plugin` | 3.1.2 |
+| `maven-surefire-plugin` | 3.2.5 |
+
+### Notable child-only plugin versions
+
+| Module | Plugin | Version |
+|--------|--------|---------|
+| `application/core` | `maven-jaxb-plugin` (XJC) | 1.1.1 |
+| `application/core` | `build-helper-maven-plugin` | 3.6.0 |
+| `application/habiTv`, `application/consoleView` | `maven-assembly-plugin` | 2.4.3 |
+| `application/trayView` | (plugin) | 2.0 |
+| `application/habiTv-linux` / `habiTv-windows` | JavaFX / bundling plugins | 2.8, 1.6 |
+| `build/static-repo-publisher` | (plugin) | 3.5.0 |
+
+### Repositories
+
+Root `pom.xml` declares **HTTPS** `habitv-static-repo` at
+`https://mika3578.github.io/habitv-repo/repository`. Legacy HTTP/FTP
+hosts were removed under `legacy-url-migration`; keep resolution
+HTTPS-only in future security PRs.
+
+### Direct dependencies without parent version
+
+Most modules inherit versions from parent `dependencyManagement`. Modules
+that declare `com.dabi.habitv:*` artifacts typically use
+`${project.version}` or `${project.parent.version}`. Own-version plugin
+modules (`beinsport`, `francetv`, `ffmpeg`, etc.) pin internal artifacts
+explicitly — see `own-version-deps-align` notes.
+
+## Recommended remediation order
+
+1. **Fix build reproducibility first** — deterministic `mvn validate` /
+   `compile`, no blocked HTTP repositories, CI green on `develop`.
+2. **Replace or isolate known abandoned dependencies** — e.g. `log4j` 1.x,
+   `rome` 1.0, `commons-lang` 2.6, ancient JavaMail.
+3. **Upgrade Maven plugins safely** — compiler, surefire, jar, assembly,
+   JAXB plugin (highest risk: XSD/codegen compatibility).
+4. **Upgrade runtime dependencies module by module** — `fwk/framework`,
+   `application/core`, then individual plugins with focused tests.
+5. **Re-run Dependabot and Maven validation** after each focused PR.
+
+## First fix candidates
+
+| Area | Rationale |
+|------|-----------|
+| Maven plugins and build-only dependencies | Limited runtime blast radius; improves CI and reproducibility |
+| Log4j 1.x migration or containment plan | EOL logging; many Dependabot alerts reference logging stacks |
+| HTTP repository removal / HTTPS-only resolution | Prevents MITM and blocked-resolution failures |
+| Provider/plugin dependencies that are unreachable or obsolete | Align with `provider-inventory`; drop dead coordinates before version bumps |
+
+Use `scripts/security/maven-dependency-inventory.ps1` to regenerate
+`target/dependency-tree.txt` before each remediation PR.
+
+## Out of scope
+
+- Java 17 / 21 migration
+- Provider rewrite
+- UI rewrite
+- `yt-dlp` integration (`ytdlp-migration`)
+- Runtime updater redesign (`static-repo-publish` behavior)
+
+## Validation commands
+
+```bash
+mvn -B -ntp -DskipTests validate
+mvn -B -ntp dependency:tree -DoutputFile=target/dependency-tree.txt
+```
+
+See the opening PR **Validation** section for exact command output from
+the baseline branch.

--- a/scripts/security/maven-dependency-inventory.ps1
+++ b/scripts/security/maven-dependency-inventory.ps1
@@ -1,0 +1,64 @@
+param(
+    [switch]$DependencyTree
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    $scriptDirectory = Split-Path -Parent $PSCommandPath
+    return (Resolve-Path (Join-Path $scriptDirectory "..\..")).Path
+}
+
+function Invoke-Maven {
+    param(
+        [string]$RepoRootPath,
+        [string[]]$Arguments
+    )
+
+    Push-Location $RepoRootPath
+    try {
+        Write-Host ("mvn " + ($Arguments -join " "))
+        & mvn @Arguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "Maven failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+$repoRoot = Get-RepoRoot
+Write-Host "Repository root: $repoRoot"
+
+$pomFiles = Get-ChildItem -Path $repoRoot -Filter pom.xml -Recurse -File |
+    Where-Object { $_.FullName -notmatch '\\target\\' } |
+    Sort-Object FullName
+
+Write-Host ""
+Write-Host "pom.xml inventory ($($pomFiles.Count) files):"
+foreach ($pom in $pomFiles) {
+    $relative = $pom.FullName.Substring($repoRoot.Length).TrimStart('\', '/')
+    Write-Host "  $relative"
+}
+
+$targetDir = Join-Path $repoRoot "target"
+if (-not (Test-Path -Path $targetDir -PathType Container)) {
+    New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
+}
+
+Invoke-Maven -RepoRootPath $repoRoot -Arguments @(
+    "-B", "-ntp", "-DskipTests", "validate"
+)
+
+if ($DependencyTree) {
+    $treeOutput = Join-Path $targetDir "dependency-tree.txt"
+    Invoke-Maven -RepoRootPath $repoRoot -Arguments @(
+        "-B", "-ntp", "dependency:tree",
+        "-DoutputFile=$treeOutput"
+    )
+    Write-Host "Wrote dependency tree to $treeOutput"
+}
+
+Write-Host "Maven dependency inventory completed successfully."

--- a/scripts/security/maven-dependency-inventory.ps1
+++ b/scripts/security/maven-dependency-inventory.ps1
@@ -33,7 +33,7 @@ $repoRoot = Get-RepoRoot
 Write-Host "Repository root: $repoRoot"
 
 $pomFiles = Get-ChildItem -Path $repoRoot -Filter pom.xml -Recurse -File |
-    Where-Object { $_.FullName -notmatch '\\target\\' } |
+    Where-Object { $_.FullName -notmatch '[\\/]target[\\/]' } |
     Sort-Object FullName
 
 Write-Host ""


### PR DESCRIPTION
## Summary
- Documents the current Dependabot vulnerability warning reported by GitHub.
- Adds a dependency security audit baseline for the legacy Maven multi-module project.
- Defines a safe remediation order without mass dependency upgrades.

## Scope
This PR is intentionally documentation-first. It does not upgrade dependencies or change runtime behavior.

## Why
GitHub currently reports 294 vulnerabilities on the default branch:
- 87 critical
- 90 high
- 89 moderate
- 28 low

Because Habitv is a legacy Java 8 Maven project with many plugin modules, mass upgrades could break JAXB generation, JavaFX runtime behavior, plugin loading, or provider tests.

## Tracker
- Work item: `dependency-security-audit` (HBTV-015)
- Doc: `docs/security-dependency-audit.md`

## Validation
```text
git status --short
(clean after three commits)

mvn -B -ntp -DskipTests validate
[INFO] BUILD SUCCESS
[INFO] Total time:  0.466 s
(33 reactor modules)

mvn -B -ntp dependency:tree -DoutputFile=target/dependency-tree.txt
[INFO] BUILD SUCCESS
[INFO] Total time:  6.977 s
```

Optional helper:
```powershell
pwsh -File scripts/security/maven-dependency-inventory.ps1 -DependencyTree
```

Dependabot API export (local, gitignored): `gh api --paginate /repos/Mika3578/habitv/dependabot/alerts` succeeded during branch prep (`target/dependabot-alerts.json`).

## Test plan
- [ ] Review `docs/security-dependency-audit.md` scope and remediation order
- [ ] Confirm tracker slug `dependency-security-audit` appears in both `dev-tracker.md` and `dev-tracker.json`
- [ ] CI `mvn -B -ntp -DskipTests validate` on Ubuntu/Windows
