### PR TITLE
docs: add clean squash merge policy

### DIFF
--- a/.cursor/rules/pr-style.mdc
+++ b/.cursor/rules/pr-style.mdc
@@ -1,0 +1,56 @@
+---
+description: Pull request and squash merge metadata rules for Habitv
+globs:
+  - ".github/**"
+  - "docs/**"
+  - "CONTRIBUTING.md"
+  - "AGENTS.md"
+---
+
+# Habitv PR and squash merge style
+
+## Pull requests
+
+- Use English for PR titles, bodies, review comments, and merge metadata.
+- Keep PRs scoped to one tracker item when applicable.
+- Document validation commands actually run; default safe command is
+  `mvn -B -ntp -DskipTests validate`.
+- Fill `.github/pull_request_template.md` sections honestly.
+
+## Squash merge instructions
+
+When generating merge instructions, always include a clean squash merge title
+and body.
+
+- Never recommend keeping GitHub's default generated squash description when it
+  contains intermediate commit bullets or repeated `Co-authored-by` trailers.
+- Always provide a cleaned replacement body for the GitHub **Extended
+  description** field.
+- The squash title must use Conventional Commit style and may include the PR
+  number.
+- The squash body must describe the final result, validation, and important
+  scope notes only.
+
+### Example for PR #65
+
+**Squash title:**
+
+```text
+ci: add Maven PR validation workflow (#65)
+```
+
+**Squash body:**
+
+```text
+Establish Java 8 Maven validation as the pull request CI baseline.
+
+Includes:
+- Required Java 8 validation, deterministic test, and package jobs.
+- Non-blocking diagnostic jobs for newer Java versions.
+- CI documentation for required checks and local command parity.
+```
+
+## References
+
+- `docs/pull-request-style-guide.md`
+- `docs/repository-maintenance.md`

--- a/.cursor/rules/pr-style.mdc
+++ b/.cursor/rules/pr-style.mdc
@@ -15,7 +15,8 @@ globs:
 - Keep PRs scoped to one tracker item when applicable.
 - Document validation commands actually run; default safe command is
   `mvn -B -ntp -DskipTests validate`.
-- Fill `.github/pull_request_template.md` sections honestly.
+- Fill every required (non-optional) section of
+  `.github/pull_request_template.md` honestly.
 
 ## Squash merge instructions
 
@@ -26,8 +27,8 @@ and body.
   contains intermediate commit bullets or repeated `Co-authored-by` trailers.
 - Always provide a cleaned replacement body for the GitHub **Extended
   description** field.
-- The squash title must use Conventional Commit style and may include the PR
-  number.
+- The squash title must use Conventional Commit style and must include the PR
+  number when merging through GitHub.
 - The squash body must describe the final result, validation, and important
   scope notes only.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,8 +34,9 @@
 
 ## Linked tracker item
 
-<!-- HBTV-XXX from docs/dev-tracker.md when applicable. -->
-- HBTV-
+<!-- Descriptive slug from docs/dev-tracker.md; add (HBTV-XXX) when the entry
+     has a legacy code. Use N/A when no tracker item applies. -->
+- `tracker-slug` (HBTV-XXX)
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,3 +47,16 @@
 - [ ] English used for branches, commits, comments, docs, and PR text
 - [ ] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`, risk register, decision log as needed)
 - [ ] No secrets, tokens, local paths, or build outputs committed
+
+## Suggested squash merge commit (optional)
+
+```text
+<type>(optional-scope): short summary (#PR_NUMBER)
+
+Short final summary of the merged change.
+
+Includes:
+- Main outcome.
+- Validation or documentation update.
+- Important compatibility note if needed.
+```

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR).",
-  "lastRefresh": "2026-05-19",
+  "lastRefresh": "2026-05-20",
   "statusValues": [
     "proposed",
     "in-progress",
@@ -18,12 +18,12 @@
   ],
   "summary": {
     "done": 11,
-    "inProgress": 2,
+    "inProgress": 3,
     "proposed": 2,
     "deferred": 0,
     "blocked": 0,
-    "total": 15,
-    "overallProgressPercent": 83
+    "total": 16,
+    "overallProgressPercent": 81
   },
   "items": [
     {
@@ -365,8 +365,30 @@
         "mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am test",
         "mvn -B -ntp -DskipTests package"
       ],
-      "pr": "ci: add Maven PR validation workflow (this PR)",
+      "pr": "ci: add Maven PR validation workflow (#65)",
       "notes": "Java 8 remains the required baseline; Java 11+ stays diagnostic until JAXB and JavaFX modernization is complete."
+    },
+    {
+      "id": "clean-squash-merge-policy",
+      "legacyCode": "HBTV-018",
+      "displayTitle": "Clean squash merge policy",
+      "icon": "📝",
+      "status": "in-progress",
+      "priority": "P3",
+      "progressPercent": 50,
+      "scope": "Document clean GitHub squash merge metadata. Add Cursor rule for squash title/body cleanup. Add suggested squash merge section to the PR template.",
+      "acceptanceCriteria": [
+        "docs/pull-request-style-guide.md defines squash merge commit policy.",
+        "docs/repository-maintenance.md documents squash merge metadata duties.",
+        ".cursor/rules/pr-style.mdc guides clean squash merge instructions.",
+        ".github/pull_request_template.md includes optional suggested squash block."
+      ],
+      "validation": [
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS",
+        "Co-authored-by trailer grep: only bad example in pull-request-style-guide.md"
+      ],
+      "pr": "docs: add clean squash merge policy (this PR)",
+      "notes": "Documentation and workflow only; no application code or CI behavior changes."
     }
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -12,24 +12,24 @@
 > on each entry for compatibility with existing PRs and commits. See
 > the `descriptive-slug-ids` ADR for the rationale and full mapping.
 
-**Last refresh:** 2026-05-19 · **Active branch:** `develop`
+**Last refresh:** 2026-05-20 · **Active branch:** `develop`
 
 ---
 
 ## 📊 Overall progress
 
 ```
-█████████████████░░░  83%
+████████████████░░░░  81%
 ```
 
 | Category | Count |
 |---------|------:|
 | ✅ Delivered | **11** |
-| 🟡 In progress | **2** |
+| 🟡 In progress | **3** |
 | 🔵 Proposed | **2** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
-| **Total work items** | **15** |
+| **Total work items** | **16** |
 
 ---
 
@@ -52,6 +52,7 @@
 | 🔑 `youtube-apikey` — YouTube Data API key externalization | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧩 `jaxb-launcher-recovery` — JAXB generated sources & launcher classpath recovery | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧱 `maven-pr-validation` — Maven PR validation workflow | ✅ Done | 🟠 P1 | `████████████████████` 100% |
+| 📝 `clean-squash-merge-policy` — Clean squash merge policy | 🟡 In progress | 🟢 P3 | `██████████░░░░░░░░░░` 50% |
 
 ---
 
@@ -640,6 +641,36 @@ Recommended merge / start order (see `dev-plan.md` for phase reasoning):
 
 ---
 
+## 📝 `clean-squash-merge-policy` — Clean squash merge policy
+
+| | |
+|---|---|
+| **Status** | 🟡 In progress |
+| **Priority** | 🟢 P3 |
+| **Progress** | `██████████░░░░░░░░░░` 50% |
+| **Legacy code** | HBTV-018 |
+
+**Scope** — Document clean GitHub squash merge metadata. Add Cursor rule for
+squash title/body cleanup. Add suggested squash merge section to the PR
+template.
+
+**Acceptance criteria**
+- ⬜ `docs/pull-request-style-guide.md` defines squash merge commit policy
+- ⬜ `docs/repository-maintenance.md` documents squash merge metadata duties
+- ⬜ `.cursor/rules/pr-style.mdc` guides clean squash merge instructions
+- ⬜ `.github/pull_request_template.md` includes optional suggested squash block
+
+**Validation**
+```bash
+mvn -B -ntp -DskipTests validate
+# Co-authored-by trailer grep: only bad example in pull-request-style-guide.md
+```
+
+**Notes** — Documentation and workflow only; no application code or CI
+behavior changes.
+
+---
+
 # 🗂️ Legacy code index
 
 For incoming references in PR descriptions, commits, and external
@@ -662,3 +693,4 @@ issue trackers:
 | HBTV-013 | `youtube-apikey` |
 | HBTV-014 | `jaxb-launcher-recovery` |
 | HBTV-015 | `maven-pr-validation` |
+| HBTV-018 | `clean-squash-merge-policy` |

--- a/docs/pull-request-style-guide.md
+++ b/docs/pull-request-style-guide.md
@@ -8,8 +8,11 @@ review comments, and squash merge metadata.
 - Use a clear summary in the PR title; Conventional Commit style is preferred
   for the eventual squash merge title.
 - Keep the PR body focused on outcome, scope, validation, and risks.
-- Reference one tracker slug from `docs/dev-tracker.md` when applicable.
-- Fill every section of `.github/pull_request_template.md`.
+- Reference one tracker slug from `docs/dev-tracker.md` when applicable;
+  add the legacy `HBTV-XXX` code in parentheses when the entry defines one
+  (for example `clean-squash-merge-policy` (HBTV-018)).
+- Fill every required (non-optional) section of
+  `.github/pull_request_template.md`.
 
 ## Branch and commit hygiene
 

--- a/docs/pull-request-style-guide.md
+++ b/docs/pull-request-style-guide.md
@@ -1,0 +1,84 @@
+# Pull request style guide
+
+English-only policy applies to branches, commits, PR titles, PR bodies,
+review comments, and squash merge metadata.
+
+## PR title and description
+
+- Use a clear summary in the PR title; Conventional Commit style is preferred
+  for the eventual squash merge title.
+- Keep the PR body focused on outcome, scope, validation, and risks.
+- Reference one tracker slug from `docs/dev-tracker.md` when applicable.
+- Fill every section of `.github/pull_request_template.md`.
+
+## Branch and commit hygiene
+
+- Create short-lived branches from `develop`.
+- Keep feature-branch history linear (no merge commits on the branch).
+- Use Conventional Commits for every commit on the branch.
+- Prefer one logical change per PR; split unrelated work.
+
+## Validation
+
+Document commands actually run locally. Default safe validation:
+
+```bash
+git diff --check
+mvn -B -ntp -DskipTests validate
+```
+
+Do not claim success for commands that were not run.
+
+## Squash merge commit policy
+
+When using GitHub **Squash and merge**, always review and rewrite the
+generated commit message before confirming.
+
+- Do not keep GitHub's default extended description if it only lists every
+  commit from the PR.
+- Do not keep noisy generated bullet lines such as:
+  - `* ci: ...`
+  - `* docs: ...`
+- Do not keep `Co-authored-by` trailers unless co-authorship is intentional
+  and should be preserved.
+- Use one clean Conventional Commit title.
+- Use a short body explaining the final merged change, not the PR's internal
+  commit history.
+- Keep the squash commit body concise and useful for future `git log` readers.
+- Include the PR number in the squash title when merging through GitHub.
+
+### Good squash title
+
+```text
+ci: add Maven PR validation workflow (#65)
+```
+
+### Good squash body
+
+```text
+Establish Java 8 Maven validation as the pull request CI baseline.
+
+Includes:
+- Required Java 8 validation, deterministic test, and package jobs.
+- Non-blocking diagnostic jobs for newer Java versions.
+- CI documentation for required checks and local command parity.
+```
+
+### Bad squash body
+
+```text
+* ci: add Maven PR validation workflow
+
+Co-authored-by: Cursor <cursoragent@cursor.com>
+
+* docs: document Maven CI checks
+
+Co-authored-by: Cursor <cursoragent@cursor.com>
+```
+
+## Related documentation
+
+- `CONTRIBUTING.md` — contributor workflow
+- `docs/repository-maintenance.md` — merge metadata responsibilities
+- `docs/repository-governance.md` — branch and merge model
+- `.github/pull_request_template.md` — PR checklist and suggested squash block

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -10,7 +10,9 @@ future history readers after squash merge.
 
 - PR titles and bodies use English.
 - PR bodies document real validation commands and honest outcomes.
-- Tracker references use descriptive slugs from `docs/dev-tracker.md`.
+- Tracker references use descriptive slugs from `docs/dev-tracker.md`,
+  optionally paired with the legacy `HBTV-XXX` code from the same entry
+  (for example `clean-squash-merge-policy` (HBTV-018)).
 - Squash merge titles follow Conventional Commits and include the PR number.
 - Squash merge bodies summarize the merged outcome, not intermediate commits.
 

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -1,0 +1,45 @@
+# Repository maintenance
+
+Day-to-day maintenance tasks for the Habitv repository: merge hygiene,
+documentation sync, and contributor-facing metadata.
+
+## PR metadata policy
+
+Pull request metadata must stay accurate and readable for reviewers and for
+future history readers after squash merge.
+
+- PR titles and bodies use English.
+- PR bodies document real validation commands and honest outcomes.
+- Tracker references use descriptive slugs from `docs/dev-tracker.md`.
+- Squash merge titles follow Conventional Commits and include the PR number.
+- Squash merge bodies summarize the merged outcome, not intermediate commits.
+
+See `docs/pull-request-style-guide.md` for examples and the full squash merge
+commit policy.
+
+### Squash merge metadata
+
+The person merging a PR is responsible for cleaning the final squash commit
+message.
+
+- The final squash commit must summarize the PR outcome, not list every
+  intermediate commit.
+- Generated `Co-authored-by` trailers should be removed unless intentionally
+  kept.
+- The final commit title should follow Conventional Commits and include the PR
+  number.
+
+## Documentation sync
+
+When a change updates process or governance documentation, keep these files
+aligned in the same commit when applicable:
+
+- `docs/dev-tracker.md` and `docs/dev-tracker.json`
+- `docs/risk-register.md` when risks change
+- `docs/decision-log.md` when architecture decisions change
+
+## Related documentation
+
+- `docs/repository-governance.md` — branch protection and rulesets
+- `docs/pull-request-style-guide.md` — PR and squash merge style
+- `AGENTS.md` — agent and contributor rules


### PR DESCRIPTION
## Summary

This PR documents how to clean GitHub squash merge metadata before confirming a merge.

## Changes

- Add a clean squash merge commit policy.
- Document how to replace GitHub's generated extended description.
- Add Cursor rules for generating clean squash merge titles and bodies.
- Add a suggested squash merge section to the PR template.
- Update the development tracker (`clean-squash-merge-policy` / HBTV-018).

## Test plan

- [ ] Review `docs/pull-request-style-guide.md` squash section and examples.
- [ ] Confirm `.cursor/rules/pr-style.mdc` applies to docs and `.github` paths.
- [ ] Verify PR template optional squash block is clear for merge authors.

## Validation

```text
git status --short

(empty)
```

```text
mvn -B -ntp -DskipTests validate
...
BUILD SUCCESS
Total time:  0.617 s
```

```text
grep -RIn "Co-authored-by: Cursor" docs .github .cursor || true
docs/pull-request-style-guide.md:72:Co-authored-by: Cursor <cursoragent@cursor.com>
docs/pull-request-style-guide.md:76:Co-authored-by: Cursor <cursoragent@cursor.com>
```

## Risk

Low. This PR changes documentation, PR templates, and Cursor rules only.

## Out of scope

- Application code changes.
- CI behavior changes.
- Maven dependency changes.
- Java migration.
- Provider fixes.
- Runtime updater changes.

## Linked tracker item

- `clean-squash-merge-policy` (HBTV-018)

## Suggested squash merge commit

**Title:**

```text
docs: add clean squash merge policy (#PR_NUMBER)
```

**Body:**

```text
Document how to clean GitHub-generated squash merge metadata.

Includes:
- Clean squash title and body examples.
- Guidance to remove noisy intermediate commit bullets.
- Cursor rules for future merge instructions.
```
