### PR TITLE
build: use maintained JAXB generator for core

### DIFF
--- a/application/core/pom.xml
+++ b/application/core/pom.xml
@@ -47,50 +47,50 @@
 		</resources>
 		<plugins>
 			<plugin>
-				<groupId>com.sun.tools.xjc.maven2</groupId>
-				<artifactId>maven-jaxb-plugin</artifactId>
-				<version>1.1.1</version>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>jaxb2-maven-plugin</artifactId>
+				<version>2.5.0</version>
 				<executions>
 					<execution>
-						<id>config</id>
+						<id>generate-config-model</id>
 						<goals>
-							<goal>generate</goal>
+							<goal>xjc</goal>
 						</goals>
 						<configuration>
-							<generatePackage>com.dabi.habitv.config.entities</generatePackage>
-							<schemaDirectory>xsd</schemaDirectory>
-							<generateDirectory>${jaxb.generated.dir}</generateDirectory>
-							<includeSchemas>
-								<includeSchema>config.xsd</includeSchema>
-							</includeSchemas>
+							<sources>
+								<source>${project.basedir}/xsd/config.xsd</source>
+							</sources>
+							<packageName>com.dabi.habitv.config.entities</packageName>
+							<outputDirectory>${jaxb.generated.dir}</outputDirectory>
+							<clearOutputDir>true</clearOutputDir>
 						</configuration>
 					</execution>
 					<execution>
-						<id>configuration</id>
+						<id>generate-configuration-model</id>
 						<goals>
-							<goal>generate</goal>
+							<goal>xjc</goal>
 						</goals>
 						<configuration>
-							<generatePackage>com.dabi.habitv.configuration.entities</generatePackage>
-							<schemaDirectory>xsd</schemaDirectory>
-							<generateDirectory>${jaxb.generated.dir}</generateDirectory>
-							<includeSchemas>
-								<includeSchema>configuration.xsd</includeSchema>
-							</includeSchemas>
+							<sources>
+								<source>${project.basedir}/xsd/configuration.xsd</source>
+							</sources>
+							<packageName>com.dabi.habitv.configuration.entities</packageName>
+							<outputDirectory>${jaxb.generated.dir}</outputDirectory>
+							<clearOutputDir>false</clearOutputDir>
 						</configuration>
 					</execution>					
 					<execution>
-						<id>grabconfig</id>
+						<id>generate-grabconfig-model</id>
 						<goals>
-							<goal>generate</goal>
+							<goal>xjc</goal>
 						</goals>
 						<configuration>
-							<generatePackage>com.dabi.habitv.grabconfig.entities</generatePackage>
-							<schemaDirectory>xsd</schemaDirectory>
-							<generateDirectory>${jaxb.generated.dir}</generateDirectory>
-							<includeSchemas>
-								<includeSchema>grab-config.xsd</includeSchema>
-							</includeSchemas>
+							<sources>
+								<source>${project.basedir}/xsd/grab-config.xsd</source>
+							</sources>
+							<packageName>com.dabi.habitv.grabconfig.entities</packageName>
+							<outputDirectory>${jaxb.generated.dir}</outputDirectory>
+							<clearOutputDir>false</clearOutputDir>
 						</configuration>
 					</execution>
 				</executions>

--- a/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
@@ -471,15 +471,15 @@ public class XMLUserConfig implements UserConfig {
 	@Override
 	public boolean updateOnStartup() {
 		return config.getUpdateConfig() == null
-				|| config.getUpdateConfig().getUpdateOnStartup() == null ? true
-				: config.getUpdateConfig().getUpdateOnStartup();
+				|| config.getUpdateConfig().isUpdateOnStartup() == null ? true
+				: config.getUpdateConfig().isUpdateOnStartup();
 	}
 
 	@Override
 	public boolean autoriseSnapshot() {
 		final boolean fromConfiguration = config.getUpdateConfig() == null
-				|| config.getUpdateConfig().getAutoriseSnapshot() == null ? DEFAULT_AUTORISE_SNAPSHOT
-				: config.getUpdateConfig().getAutoriseSnapshot();
+				|| config.getUpdateConfig().isAutoriseSnapshot() == null ? DEFAULT_AUTORISE_SNAPSHOT
+				: config.getUpdateConfig().isAutoriseSnapshot();
 		return UpdateConfigResolver.resolveAutoriseSnapshot(fromConfiguration);
 	}
 

--- a/application/core/src/com/dabi/habitv/core/dao/GrabConfigDAO.java
+++ b/application/core/src/com/dabi/habitv/core/dao/GrabConfigDAO.java
@@ -186,7 +186,7 @@ public class GrabConfigDAO {
 				subCategoriesDTO = Collections.emptySet();
 			}
 
-			if (category.getDownload() == null || category.getDownload()
+			if (category.isDownload() == null || category.isDownload()
 					|| !subCategoriesDTO.isEmpty()
 					|| loadMode.equals(LoadModeEnum.ALL)) {
 				categoryDTO = buildCategoryDTO(channelName, category,
@@ -204,17 +204,17 @@ public class GrabConfigDAO {
 				category.getId(), getInclude(category), getExclude(category),
 				category.getExtension());
 
-		categoryDTO.setSelected(category.getDownload() != null
-				&& category.getDownload());
+		categoryDTO.setSelected(category.isDownload() != null
+				&& category.isDownload());
 
-		categoryDTO.setTemplate(category.getTemplate() != null
-				&& category.getTemplate());
+		categoryDTO.setTemplate(category.isTemplate() != null
+				&& category.isTemplate());
 
-		categoryDTO.setDownloadable(category.getDownloadable() == null
-				|| category.getDownloadable());
+		categoryDTO.setDownloadable(category.isDownloadable() == null
+				|| category.isDownloadable());
 
-		categoryDTO.setDeleted(category.getDeleted() != null
-				&& category.getDeleted());
+		categoryDTO.setDeleted(category.isDeleted() != null
+				&& category.isDeleted());
 
 		categoryDTO.setState(category.getStatus() == null ? StatusEnum.EXIST
 				: StatusEnum.valueOf(category.getStatus()));
@@ -299,7 +299,7 @@ public class GrabConfigDAO {
 
 		buildCategoryConfiguration(oldCategory, categoryType);
 
-		categoryType.setDownload(oldCategory.getToDownload());
+		categoryType.setDownload(oldCategory.isToDownload());
 
 		Excludes excludes = new Excludes();
 		for (String oldExclude : oldCategory.getExclude()) {
@@ -358,8 +358,8 @@ public class GrabConfigDAO {
 							plugin.getName(), buildCategoryListDTO);
 					categoryPlugin.setDownloadable(false);
 					categoryPlugin
-							.setDeleted(plugin.getDeleted() == null ? false
-									: plugin.getDeleted());
+							.setDeleted(plugin.isDeleted() == null ? false
+									: plugin.isDeleted());
 					if (plugin.getStatus() != null) {
 						categoryPlugin.setState(StatusEnum.valueOf(plugin
 								.getStatus()));


### PR DESCRIPTION
## Summary
- Replace the legacy `com.sun.tools.xjc.maven2:maven-jaxb-plugin` wiring in `application/core` with `org.codehaus.mojo:jaxb2-maven-plugin` (2.5.0).
- Keep three explicit XJC executions for `config.xsd`, `configuration.xsd`, and `grab-config.xsd`.
- Preserve generated sources under `target/generated-sources/jaxb` and register that directory via `build-helper-maven-plugin` `add-source`.
- Align `XMLUserConfig` and `GrabConfigDAO` with JAXB boolean accessor naming (`isXxx()` for optional `xs:boolean` fields); schemas unchanged.

## Why
IDE diagnostics reported unresolved types in `com.dabi.habitv.config.entities.*`, `com.dabi.habitv.configuration.entities.*`, and `com.dabi.habitv.grabconfig.entities.*` used by `XMLUserConfig` and `GrabConfigDAO`. Those packages are schema-generated; the fix is build/JAXB wiring (plus minimal caller updates where the maintained generator emits `isXxx()` instead of `getXxx()`).

## Validation results (2026-05-20, Windows, JDK 8)

Branch rebased on `origin/develop` (`fix/jaxb-generation-plugin`).

```bash
git fetch origin
git checkout fix/jaxb-generation-plugin
git rebase origin/develop

mvn -B -ntp -pl application/core -am generate-sources
mvn -B -ntp -pl application/core -am -DskipTests compile
mvn -B -ntp -DskipTests validate
mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am test
```

| Command | Result |
|---------|--------|
| `generate-sources` (core `-am`) | **BUILD SUCCESS** — `jaxb2:2.5.0:xjc` runs for `generate-config-model`, `generate-configuration-model`, `generate-grabconfig-model`; `build-helper:3.6.0:add-source` adds `target/generated-sources/jaxb` |
| `compile` (core `-am`, `-DskipTests`) | **BUILD SUCCESS** — `application/core` compiles **75** source files (hand-written + generated) |
| `validate` (reactor, `-DskipTests`) | **BUILD SUCCESS** — 33 modules |
| `test` (api, framework, core, plugin-tester `-am`) | **BUILD SUCCESS** — core: 37 tests, 0 failures, 4 skipped (pre-existing) |

### Generated package verification

After `mvn -B -ntp -pl application/core -am clean generate-sources`, these files exist:

- `application/core/target/generated-sources/jaxb/com/dabi/habitv/config/entities/Config.java`
- `application/core/target/generated-sources/jaxb/com/dabi/habitv/configuration/entities/Configuration.java`
- `application/core/target/generated-sources/jaxb/com/dabi/habitv/grabconfig/entities/GrabConfig.java`
- `application/core/target/generated-sources/jaxb/com/dabi/habitv/grabconfig/entities/CategoryType.java`

Fresh `compile` with an empty `application/core/target` also regenerates JAXB sources and compiles successfully (no stale-output dependency).

### IDE note
Import/reload the Maven project after the first `generate-sources` (or `compile`) so the IDE indexes `target/generated-sources/jaxb`. Generated sources remain gitignored.

## Risk
- **Medium (build-critical):** JAXB generation must stay aligned with the three XSDs; revert/adjust `application/core/pom.xml` if a schema/plugin compatibility issue appears.
- **Low:** `jaxb2-maven-plugin` may skip regeneration when schemas are unchanged (incremental builds); outputs remain under `target/generated-sources/jaxb`.
- **Residual:** `jaxb-mismatch` on JDK 9+ remains a separate modernization item; this PR targets Java 8 + maintained Maven XJC wiring only.

## Scope guard
No provider changes, no Java baseline migration, no unrelated dependency upgrades.
