### PR TITLE
docs: prepare community alpha release readiness

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-alpha-test-report.md
+++ b/.github/ISSUE_TEMPLATE/community-alpha-test-report.md
@@ -1,0 +1,46 @@
+---
+name: Community alpha test report
+about: Feedback from Community Alpha / Technical Preview testing
+title: "alpha: <short summary>"
+labels: ["alpha", "triage"]
+assignees: []
+---
+
+## Environment
+
+- **OS and version** (e.g. Windows 11 23H2):
+- **Java distribution and version** (output of `java -version`):
+- **Habitv alpha build version or commit SHA**:
+- **Launch method** (e.g. `java -jar habiTv-4.1.0-SNAPSHOT.jar`, custom `-Dhabitv.jfxrt.path`, console flags):
+
+## Test scope
+
+- **Provider tested** (plugin id, e.g. `francetv`, `youtube`, `RSS`):
+- **Expected result**:
+- **Actual result**:
+
+## Plugin update
+
+- **Was plugin update enabled?** (yes / no / not tested)
+- If tested, did update traffic avoid `dabiboo.free.fr`? (yes / no / unknown)
+
+## Reproducibility
+
+- **Reproducible from a clean config folder?** (yes / no / not tried)  
+  (Rename or backup `%USERPROFILE%\habitv` on Windows before retesting.)
+
+## Logs
+
+Attach the full log file (e.g. `%USERPROFILE%\habitv\habiTv.log`). Paste excerpts below if needed.
+
+```
+<paste relevant log excerpts>
+```
+
+## Screenshot
+
+If relevant, attach a screenshot (GUI error, tray notification, configuration screen).
+
+## Additional context
+
+Optional: Maven build command used, external binaries (`yt-dlp`, `ffmpeg`) paths, network/VPN notes.

--- a/docs/community-alpha-release.md
+++ b/docs/community-alpha-release.md
@@ -1,0 +1,170 @@
+# Community Alpha / Technical Preview
+
+**Release type:** Community Alpha — technical preview for testers and contributors.  
+**Not** a stable public release. Provider compatibility, packaging polish, and dependency
+remediation are still in progress.
+
+**Tracker:** `community-alpha-release-readiness` (HBTV-016)
+
+---
+
+## Supported runtime
+
+| Requirement | Detail |
+|-------------|--------|
+| Java | **Java 8** only (repository baseline; no Java 11+ support in this alpha) |
+| JavaFX | Bundled **JavaFX 2.x** via `jfxrt.jar` on the JDK 8 install |
+| Recommended JDK | [Azul Zulu 8](https://www.azul.com/downloads/?version=java-8-lts&package=jdk-fx) or another **JDK 8 distribution that includes JavaFX** (not a headless JRE) |
+| Unsupported for alpha | Java 11/17/21-only runtimes, headless JRE without `jfxrt.jar`, OpenJFX-only layouts (tracked under `javafx-modernization`) |
+
+The launcher resolves JavaFX from `java.home` or `-Dhabitv.jfxrt.path=<path-to-jfxrt.jar>`.
+See `JavaFxRuntimeLocator` in `application/habiTv`.
+
+---
+
+## Build from source
+
+From the repository root (Maven 3.6+, network for dependencies):
+
+```bash
+mvn -B -ntp clean package
+```
+
+Primary artifact (shaded application JAR):
+
+```text
+application/habiTv/target/habiTv-4.1.0-SNAPSHOT.jar
+```
+
+Copy external download tools (`yt-dlp`, `ffmpeg`, `curl`, etc.) into a `bin\` folder next to
+the JAR or configure paths in `configuration.xml` (see sample under `application/core/configuration.xml`).
+
+---
+
+## Validation (maintainers and advanced testers)
+
+Default CI-safe check:
+
+```bash
+mvn -B -ntp -DskipTests validate
+```
+
+Full unit test lifecycle (offline-focused; live provider tests excluded by default):
+
+```bash
+mvn -B -ntp test
+```
+
+Opt-in live provider tests (network required; not part of alpha acceptance):
+
+```bash
+mvn -B -ntp test -Plive-provider-tests
+```
+
+---
+
+## Windows launch (GUI)
+
+Prerequisites: JDK 8 with JavaFX, built or downloaded `habiTv-4.1.0-SNAPSHOT.jar`.
+
+1. Open **Command Prompt** or **PowerShell**.
+2. `cd` to the folder containing the JAR (and optional `bin\` tools).
+3. Verify Java:
+
+   ```bat
+   java -version
+   ```
+
+   Output must report version **1.8** / **8**.
+
+4. Start the tray GUI (no arguments):
+
+   ```bat
+   java -jar habiTv-4.1.0-SNAPSHOT.jar
+   ```
+
+5. If JavaFX is not found, set the runtime explicitly (adjust path to your JDK):
+
+   ```bat
+   java -Dhabitv.jfxrt.path="C:\Program Files\Zulu\zulu-8\jre\lib\ext\jfxrt.jar" -jar habiTv-4.1.0-SNAPSHOT.jar
+   ```
+
+6. **Console mode** (no GUI; useful when JavaFX is missing):
+
+   ```bat
+   java -jar habiTv-4.1.0-SNAPSHOT.jar --help
+   ```
+
+   See `ConsoleLauncher` for CLI options.
+
+### Configuration and logs (Windows)
+
+| Path | Purpose |
+|------|---------|
+| `%USERPROFILE%\habitv\configuration.xml` | User configuration |
+| `%USERPROFILE%\habitv\grabconfig.xml` | Grab / provider subscriptions |
+| `%USERPROFILE%\habitv\habiTv.log` | Application log (attach to issues) |
+
+For a clean test, rename `%USERPROFILE%\habitv` before launching.
+
+### Plugin updates
+
+Default update repository: `https://mika3578.github.io/habitv-repo/repository/`  
+(legacy `http://dabiboo.free.fr/repository` was removed — see `legacy-url-migration`).
+
+Verify in logs or network traces that updates do **not** contact `dabiboo.free.fr`.
+
+---
+
+## Known limitations (alpha)
+
+- **Providers:** Many French replay providers still target legacy HTTP/HTML endpoints.
+  See [`provider-status.md`](provider-status.md) for alpha classification.
+- **France TV / Pluzz:** Module id is `francetv`; legacy `pluzz` grab-config entries may need manual rename.
+- **Canal+ / D8 / D17:** Embedded in `canalPlus` plugin; endpoints are obsolete pending rewrite.
+- **6play / M6:** `6play` plugin targets legacy `6play.fr` markup; modern SPA site likely broken.
+- **WAT / TF1-era:** `wat` plugin uses TF1/WAT-era URLs.
+- **External tools:** `yt-dlp`, `ffmpeg`, `rtmpdump`, `aria2c`, `curl` must be installed and
+  paths configured; versions are not bundled in the alpha JAR.
+- **Security / dependencies:** Transitive dependency audit and remediation are **in progress**
+  (`jaxb-launcher-recovery` notes; no full OWASP/SBOM gate yet).
+- **Packaging:** No polished Windows installer in this alpha (`javafx-modernization` tracks native packaging).
+- **Statistics:** Usage statistics to legacy hosts are disabled by default (`legacy-url-migration`).
+
+---
+
+## What testers should exercise
+
+| Area | What to verify |
+|------|----------------|
+| Startup | GUI opens on JDK 8 + JavaFX; or console mode runs with `--help` |
+| Configuration | `configuration.xml` loads; changes persist after restart |
+| Plugin update | Update check uses GitHub Pages repo, not `dabiboo.free.fr` |
+| YouTube / yt-dlp | Download path works when `bin\yt-dlp.exe` (or configured path) is present |
+| RSS / manual URL | RSS plugin or manual URL flows if used in your setup |
+| Reporting | Open issues with the **Community alpha test report** template; attach `habiTv.log` |
+
+Prioritize providers listed as **Testable for alpha** in [`provider-status.md`](provider-status.md).
+
+---
+
+## What testers should not expect
+
+- Stable compatibility across all TV providers listed in the legacy README.
+- DRM bypass or circumvention of provider protections.
+- Subscription-only or authenticated replay without your own credentials/setup.
+- Production-grade installer, auto-update UX, or signed binaries.
+- Complete dependency vulnerability remediation.
+
+---
+
+## Related documentation
+
+- [`provider-status.md`](provider-status.md) — alpha provider matrix
+- [`release-checklist.md`](release-checklist.md) — maintainer pre-release checklist
+- [`provider-inventory.md`](provider-inventory.md) — full module inventory (HBTV-006)
+- [`AGENTS.md`](../AGENTS.md) — build and validation policy
+
+## Feedback
+
+Use the GitHub issue template **Community alpha test report** (`.github/ISSUE_TEMPLATE/community-alpha-test-report.md`).

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -18,12 +18,12 @@
   ],
   "summary": {
     "done": 11,
-    "inProgress": 3,
+    "inProgress": 4,
     "proposed": 2,
     "deferred": 0,
     "blocked": 0,
-    "total": 16,
-    "overallProgressPercent": 81
+    "total": 17,
+    "overallProgressPercent": 79
   },
   "items": [
     {
@@ -367,6 +367,30 @@
       ],
       "pr": "ci: add Maven PR validation workflow (#65)",
       "notes": "Java 8 remains the required baseline; Java 11+ stays diagnostic until JAXB and JavaFX modernization is complete."
+    },
+    {
+      "id": "community-alpha-release-readiness",
+      "legacyCode": "HBTV-016",
+      "displayTitle": "Community alpha release readiness",
+      "icon": "🧪",
+      "status": "in-progress",
+      "priority": "P1",
+      "progressPercent": 35,
+      "scope": "Documentation and release readiness for the first community alpha / technical preview. No provider rewrites, no Java baseline change, no dependency mass-upgrade.",
+      "acceptanceCriteria": [
+        "docs/community-alpha-release.md describes alpha scope, Java 8 + JavaFX runtime, build/validate commands, Windows launch, limitations, and tester expectations.",
+        "docs/provider-status.md classifies providers for alpha testing.",
+        "docs/release-checklist.md covers pre-release validation and GitHub draft steps.",
+        ".github/ISSUE_TEMPLATE/community-alpha-test-report.md collects structured alpha feedback.",
+        "Tracker entry community-alpha-release-readiness (HBTV-016) present in dev-tracker.md and dev-tracker.json."
+      ],
+      "validation": [
+        "git status --short",
+        "mvn -B -ntp -DskipTests validate",
+        "mvn -B -ntp test"
+      ],
+      "pr": "docs: prepare community alpha release readiness (this PR)",
+      "notes": "Alpha is honest and limited; provider compatibility claims stay in provider-status.md. Security dependency audit remains in progress."
     },
     {
       "id": "clean-squash-merge-policy",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -19,17 +19,17 @@
 ## 📊 Overall progress
 
 ```
-████████████████░░░░  81%
+████████████████░░░░  79%
 ```
 
 | Category | Count |
 |---------|------:|
 | ✅ Delivered | **11** |
-| 🟡 In progress | **3** |
+| 🟡 In progress | **4** |
 | 🔵 Proposed | **2** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
-| **Total work items** | **16** |
+| **Total work items** | **17** |
 
 ---
 
@@ -52,6 +52,7 @@
 | 🔑 `youtube-apikey` — YouTube Data API key externalization | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧩 `jaxb-launcher-recovery` — JAXB generated sources & launcher classpath recovery | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧱 `maven-pr-validation` — Maven PR validation workflow | ✅ Done | 🟠 P1 | `████████████████████` 100% |
+| 🧪 `community-alpha-release-readiness` — Community alpha release readiness | 🟡 In progress | 🟠 P1 | `███████░░░░░░░░░░░░░` 35% |
 | 📝 `clean-squash-merge-policy` — Clean squash merge policy | 🟡 In progress | 🟢 P3 | `██████████░░░░░░░░░░` 50% |
 
 ---
@@ -641,6 +642,40 @@ Recommended merge / start order (see `dev-plan.md` for phase reasoning):
 
 ---
 
+## 🧪 `community-alpha-release-readiness` — Community alpha release readiness
+
+| | |
+|---|---|
+| **Status** | 🟡 In progress |
+| **Priority** | 🟠 P1 |
+| **Progress** | `███████░░░░░░░░░░░░░` 35% |
+| **Legacy code** | HBTV-016 |
+
+**Scope** — Documentation and release readiness for the first community alpha /
+technical preview. No provider rewrites, no Java baseline change, no dependency
+mass-upgrade.
+
+**Acceptance criteria**
+- ⬜ `docs/community-alpha-release.md` — alpha scope, runtime, build, Windows launch, limitations
+- ⬜ `docs/provider-status.md` — alpha provider classification
+- ⬜ `docs/release-checklist.md` — GitHub pre-release checklist
+- ⬜ `.github/ISSUE_TEMPLATE/community-alpha-test-report.md` — structured tester feedback
+- ⬜ Tracker mirrors updated (`community-alpha-release-readiness`)
+
+**Validation**
+```bash
+git status --short
+mvn -B -ntp -DskipTests validate
+mvn -B -ntp test
+```
+
+**Related PR** · `docs: prepare community alpha release readiness` (this PR)
+
+**Notes** — Alpha must not claim full provider support. Security dependency audit
+remains in progress (`jaxb-launcher-recovery` follow-up). See also `provider-inventory`.
+
+---
+
 ## 📝 `clean-squash-merge-policy` — Clean squash merge policy
 
 | | |
@@ -693,4 +728,5 @@ issue trackers:
 | HBTV-013 | `youtube-apikey` |
 | HBTV-014 | `jaxb-launcher-recovery` |
 | HBTV-015 | `maven-pr-validation` |
+| HBTV-016 | `community-alpha-release-readiness` |
 | HBTV-018 | `clean-squash-merge-policy` |

--- a/docs/provider-status.md
+++ b/docs/provider-status.md
@@ -1,0 +1,92 @@
+# Provider status for Community Alpha
+
+Alpha-oriented view of plugin modules. Detailed evidence lives in
+[`provider-inventory.md`](provider-inventory.md) (HBTV-006). **No provider code is removed**
+in the alpha documentation track.
+
+**Legend**
+
+| Alpha class | Meaning |
+|-------------|---------|
+| **Testable for alpha** | Reasonable first target for community testers; offline tests and/or recent maintenance |
+| **Present but unverified** | Shipped in reactor; live compatibility not confirmed offline |
+| **Known broken / obsolete** | Legacy endpoints or branding; rewrite or deprecation expected |
+| **Out of scope for alpha** | Infrastructure, not a broadcaster provider |
+
+---
+
+## Testable for alpha
+
+| Plugin id | Module | Notes |
+|-----------|--------|-------|
+| `youtube` | `plugins/youtube` | yt-dlp binary contract; offline tests; needs local `yt-dlp` / `yt-dlp.exe` |
+| `francetv` | `plugins/francetv` | Mobile API + yt-dlp delegation; replaces legacy `pluzz` module |
+| `RSS` | `plugins/RSS` | Generic RSS / manual URL flows; depends on feed content |
+| `file` | `plugins/file` | Local file-driven input; no remote endpoint |
+| `arte` | `plugins/arte` | Offline fixture baseline; **live** site may fail (parser drift) — report both outcomes |
+
+---
+
+## Present but unverified
+
+| Plugin id | Module | Notes |
+|-----------|--------|-------|
+| `globalnews` | `plugins/globalnews` | HTTPS URLs; live-only test evidence |
+| `mlssoccer` | `plugins/mlssoccer` | HTTPS URLs; compatibility not validated offline |
+| `sfr` | `plugins/sfr` | `sport.sfr.fr` API path; live-network tests only |
+| `email` | `plugins/email` | Mailbox integration; environment-dependent |
+| `footyroom` | `plugins/footyroom` | Legacy site URLs; rewrite likely needed |
+| `lequipe` | `plugins/lequipe` | HTML scraping; historical stream stack references |
+
+---
+
+## Known broken / obsolete
+
+| Plugin id | Module | Notes |
+|-----------|--------|-------|
+| `canalPlus` | `plugins/canalPlus` | Canal+ legacy services; includes embedded **D8** / **D17** sub-providers |
+| `6play` | `plugins/6play` | Legacy HTTP `6play.fr` / M6-style markup; SPA site not supported |
+| `wat` | `plugins/wat` | TF1 / WAT-era URLs (README “tf1”) |
+| `beinsport` | `plugins/beinsport` | Legacy beinsports.com / Dailymotion mapping |
+| `clubic` | `plugins/clubic` | Legacy Clubic video pages |
+
+### Historical names (no standalone module)
+
+| Name | Status |
+|------|--------|
+| `D8`, `D17` | Embedded in `canalPlus`; obsolete with canal family |
+| `pluzz` | Renamed to `francetv`; update grab-config plugin ids |
+| `nrj12` / `NRJ12` | Documented historically; **no module** in reactor |
+| `tf1` | README alias; implementation is `wat` plugin |
+
+---
+
+## Out of scope for alpha
+
+Downloader / exporter / tooling plugins (validate via binary wiring, not replay providers):
+
+| Plugin id | Role |
+|-----------|------|
+| `adobeHDS`, `aria2`, `rtmpDump` | Downloaders |
+| `cmd`, `curl`, `ffmpeg` | Exporters / command wrappers |
+| `plugin-tester` | Test harness |
+| `plugins` (aggregator) | Maven POM only |
+
+---
+
+## Alpha testing guidance
+
+1. Start with **Testable for alpha** providers and document Java + launch method.
+2. Do **not** treat **Known broken / obsolete** failures as regressions without a rewrite PR.
+3. For **Present but unverified**, file reports with logs even if behaviour is inconclusive.
+4. Use [`community-alpha-release.md`](community-alpha-release.md) for Windows launch and log paths.
+
+---
+
+## Maintainer cross-reference
+
+| Doc | Purpose |
+|-----|---------|
+| [`provider-inventory.md`](provider-inventory.md) | Full module table, fixture policy, live-test profile |
+| [`release-checklist.md`](release-checklist.md) | Pre-release verification |
+| [`dev-tracker.md`](dev-tracker.md) | `provider-inventory`, `ytdlp-migration`, `javafx-modernization` |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,100 @@
+# GitHub pre-release checklist (Community Alpha)
+
+Use this checklist before publishing a **Community Alpha / Technical Preview** GitHub
+pre-release. It complements [`community-alpha-release.md`](community-alpha-release.md).
+
+**Tracker:** `community-alpha-release-readiness` (HBTV-016)
+
+---
+
+## Build validation
+
+- [ ] Branch is based on current `develop` (or release branch agreed with maintainers).
+- [ ] `git status --short` is clean (no accidental local artifacts staged).
+- [ ] `mvn -B -ntp -DskipTests validate` → **BUILD SUCCESS** on Java 8.
+- [ ] `mvn -B -ntp clean package` → **BUILD SUCCESS**; shaded JAR exists at  
+      `application/habiTv/target/habiTv-4.1.0-SNAPSHOT.jar`.
+- [ ] Release notes state **Java 8 + JavaFX** requirement (Zulu 8 FX or equivalent).
+- [ ] Version string in docs matches `${project.version}` (`4.1.0-SNAPSHOT` until version bump PR).
+
+---
+
+## Test validation
+
+- [ ] `mvn -B -ntp test` executed; results pasted in PR / release notes (failures documented).
+- [ ] Failing modules classified as **release blocker** vs **known alpha limitation**.
+- [ ] Live provider tests (`-Plive-provider-tests`) **not** required for alpha tag (opt-in only).
+- [ ] Deterministic subset green: `fwk/api`, `fwk/framework`, `application/core`, `plugins/plugin-tester` (CI parity).
+
+---
+
+## Runtime launch validation
+
+- [ ] Windows: `java -jar habiTv-4.1.0-SNAPSHOT.jar` opens tray GUI on JDK 8 with JavaFX.
+- [ ] Windows: console mode starts with CLI args (no GUI).
+- [ ] JavaFX missing path documented (`-Dhabitv.jfxrt.path=...`).
+- [ ] Config folder `%USERPROFILE%\habitv\` created; `configuration.xml` load/save verified.
+- [ ] Log file `%USERPROFILE%\habitv\habiTv.log` written on activity.
+
+---
+
+## Plugin update validation
+
+- [ ] Default `UPDATE_URL` is `https://mika3578.github.io/habitv-repo/repository/` (no `dabiboo.free.fr`).
+- [ ] Plugin update smoke test on Windows (optional snapshot channel if enabled in config).
+- [ ] `UpdateRepositoryUrlsTest` / framework update tests still pass offline.
+
+---
+
+## Provider status review
+
+- [ ] [`provider-status.md`](provider-status.md) reviewed and matches current code.
+- [ ] Release notes **do not** claim all README providers work.
+- [ ] Obsolete providers (`canalPlus`, `6play`, `wat`, `beinsport`, `clubic`, …) called out.
+- [ ] `francetv` vs legacy `pluzz` id migration noted for existing configs.
+
+---
+
+## Known issues review
+
+- [ ] [`docs/risk-register.md`](risk-register.md) open risks referenced where relevant.
+- [ ] Security / dependency audit status: **in progress**, not fully remediated.
+- [ ] `javafx-modernization` blocker for native installer documented.
+- [ ] yt-dlp binary path documented; `ytdlp-migration` wiring called out.
+
+---
+
+## GitHub release draft
+
+- [ ] Tag name agreed (e.g. `v4.1.0-alpha.1` — separate version PR if needed).
+- [ ] Mark release as **pre-release** in GitHub UI.
+- [ ] Title includes "Community Alpha" or "Technical Preview".
+- [ ] Body links to `docs/community-alpha-release.md` and `docs/provider-status.md`.
+- [ ] Limitations section copied or summarized from alpha release doc.
+- [ ] No secrets, tokens, or local absolute paths in notes.
+
+---
+
+## Artifact upload
+
+- [ ] Upload `habiTv-4.1.0-SNAPSHOT.jar` (and optional `bin\` README for external tools).
+- [ ] SHA-256 checksum recorded in release notes (optional but recommended).
+- [ ] Do **not** upload `target/`, `.class`, or full Maven reactor zips unless intentional.
+- [ ] Confirm artifact size reasonable (shaded JAR only for alpha).
+
+---
+
+## Community announcement
+
+- [ ] Issue template **Community alpha test report** enabled (`.github/ISSUE_TEMPLATE/`).
+- [ ] Short announcement: alpha scope, Java 8 requirement, provider limitations.
+- [ ] Point testers to Windows launch section and log attachment requirement.
+- [ ] Set expectations: feedback welcome; stable release not promised.
+
+---
+
+## Post-publish
+
+- [ ] Update `community-alpha-release-readiness` tracker progress / status.
+- [ ] Triage incoming alpha issues with `alpha` label.
+- [ ] Schedule follow-up PRs (provider rewrites, dependency audit, installer).


### PR DESCRIPTION
## Summary

- Add Community Alpha / Technical Preview documentation (`docs/community-alpha-release.md`).
- Add alpha tester issue template, release checklist, and provider status matrix for honest alpha scope.
- Track work under `community-alpha-release-readiness` (HBTV-016).

## Scope

- Documentation and GitHub issue template only.
- Provider classification derived from `docs/provider-inventory.md` (no code changes).
- Tracker mirrors updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`).

## Out of scope

- Provider rewrites or removals.
- Java baseline change (stays Java 8).
- Dependency mass-upgrade or OWASP/SBOM plugins.
- JavaFX native installer / version bump for GitHub release tag.
- Publishing the GitHub pre-release (checklist only).

## Validation results

### `git status --short` (before commits; working tree now clean on branch)

```
 M docs/dev-tracker.json
 M docs/dev-tracker.md
?? .github/ISSUE_TEMPLATE/community-alpha-test-report.md
?? docs/community-alpha-release.md
?? docs/provider-status.md
?? docs/release-checklist.md
```

Post-commit: clean working tree (four linear commits).

### `mvn -B -ntp -DskipTests validate`

```
[INFO] BUILD SUCCESS
[INFO] Total time:  0.483 s
```

All 33 reactor modules SUCCESS.

### `mvn -B -ntp test`

```
[INFO] BUILD SUCCESS
[INFO] Total time:  01:59 min
```

All 33 reactor modules SUCCESS (live `*PluginManagerTest` excluded by default Surefire config).

**Alpha limitation (not a default-test failure):** live provider tests remain opt-in via `-Plive-provider-tests`; Arte live drift documented in `docs/provider-inventory.md`.

## Known blockers before publishing an alpha

- No signed Windows installer (`javafx-modernization`).
- Many replay providers classified **Known broken / obsolete** in `docs/provider-status.md`.
- GitHub Dependabot reports open dependency vulnerabilities (294 on default branch at push time); remediation not complete.
- External binaries (`yt-dlp`, `ffmpeg`, etc.) not bundled in JAR.
- Release tag/version policy (e.g. `v4.1.0-alpha.1`) may need a separate chore PR.

## Tester instructions

1. Read [`docs/community-alpha-release.md`](docs/community-alpha-release.md).
2. Build: `mvn -B -ntp clean package`.
3. Windows GUI: `java -jar application/habiTv/target/habiTv-4.1.0-SNAPSHOT.jar` (JDK 8 with JavaFX).
4. File feedback using the **Community alpha test report** issue template; attach `%USERPROFILE%\habitv\habiTv.log`.
5. Prefer providers listed as **Testable for alpha** in [`docs/provider-status.md`](docs/provider-status.md).

## Follow-up PRs needed

- Version bump + GitHub pre-release artifact upload (after checklist sign-off).
- Provider endpoint rewrites (`canalPlus`, `6play`, `wat`, …) per `provider-inventory` queue.
- Dependency / security audit remediation PR.
- `javafx-modernization` for installer and packaging polish.
- Complete `ytdlp-migration` validation with published binaries.

**Tracker:** `community-alpha-release-readiness` (HBTV-016)
