### PR TITLE
docs: add required checks roadmap

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,36 +7,40 @@
 - Java 11+ may fail until JAXB and JavaFX migration is complete.
 - No deployment, credentials, publishing, or auto-merge behavior is part of this workflow set.
 
+**Staged required-checks plan:** see [`required-checks-roadmap.md`](required-checks-roadmap.md)
+(tracker `required-checks-roadmap`, HBTV-016) for Phases 0–5, prerequisites,
+and branch-protection targets.
+
 ## Workflow coverage
 
 Workflow: `.github/workflows/ci-maven.yml` (`Maven CI`)
 
-### Required checks (branch protection)
+### Phase 0 — Required checks (branch protection target)
 
-Current required check for `develop` remains:
+Current required check for `develop` may still be:
 
 - `CI / validate (zulu-8)` (from `.github/workflows/ci.yml`)
 
-The `Maven CI` workflow is additive in this PR. It does not supersede the
-existing required `CI` check until repository governance and the ruleset are
-updated together.
+The `Maven CI` workflow does not supersede the legacy `CI` check until
+repository governance and the ruleset are updated together
+(`branch-protection`, `required-checks-roadmap`).
 
-After that governance/ruleset update, require:
+**Target required checks** (stable Java 8 baseline — Liberica JDK 8 + JavaFX):
 
 - `Maven CI / validate-java8`
 - `Maven CI / deterministic-tests-java8`
 - `Maven CI / compile-and-package-java8`
 - `Dependency Review / dependency-review`
 
-### Diagnostic checks (do not require)
+### Not required yet (Phases 1–4)
 
-Do not require:
+Do not require until the roadmap prerequisites are met:
 
-- `Maven CI / compatibility-java11`
-- `Maven CI / compatibility-java17`
-- `Maven CI / compatibility-java21`
-- `Maven CI / compatibility-java25`
-- `Maven CI / full-test-suite`
+- `Maven CI / compatibility-java11` through `compatibility-java25` (modern JDK
+  **validation** in Phase 1; **package** only after OpenJFX in Phase 2)
+- `Maven CI / full-test-suite` (Phase 3 — deterministic default tests only)
+- Live provider tests (`-Plive-tests` when introduced)
+- Dependency Review / CodeQL as required gates (Phase 4)
 
 ## Security workflows
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,7 @@
 - No deployment, credentials, publishing, or auto-merge behavior is part of this workflow set.
 
 **Staged required-checks plan:** see [`required-checks-roadmap.md`](required-checks-roadmap.md)
-(tracker `required-checks-roadmap`, HBTV-016) for Phases 0–5, prerequisites,
+(tracker `required-checks-roadmap`, HBTV-017) for Phases 0–5, prerequisites,
 and branch-protection targets.
 
 ## Workflow coverage

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -363,7 +363,7 @@
         "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS",
         "mvn -B -ntp -pl application/core -am test -> BUILD SUCCESS"
       ],
-      "pr": "fix/jaxb-config-model-alignment (this PR)",
+      "pr": "build: use maintained JAXB generator for core (#70)",
       "notes": "Builds on jaxb2-maven-plugin migration (#70). Reload Java workspace after mvn generate-sources so target/generated-sources/jaxb is indexed. Optional local java.import.exclusions for application/core/generated/** when .vscode/settings.json exists locally."
     },
     {

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -19,11 +19,11 @@
   "summary": {
     "done": 12,
     "inProgress": 4,
-    "proposed": 2,
+    "proposed": 3,
     "deferred": 0,
     "blocked": 0,
-    "total": 18,
-    "overallProgressPercent": 78
+    "total": 19,
+    "overallProgressPercent": 74
   },
   "items": [
     {
@@ -345,6 +345,28 @@
       "notes": "application/habiTv now uses a small Java 8-compatible local URLClassLoader helper instead of the unavailable Utils4J.addToClasspath API. Incompatible utils4j Java 17 bytecode and broader transitive dependency vulnerability cleanup remain out of scope for a dedicated security PR."
     },
     {
+      "id": "jaxb-config-model-alignment",
+      "legacyCode": "HBTV-020",
+      "displayTitle": "JAXB config/grab-config model & IDE alignment",
+      "icon": "🧬",
+      "status": "done",
+      "priority": "P1",
+      "progressPercent": 100,
+      "scope": "Align application/core config and grab-config Java callers with XSD-backed JAXB output; prevent stale application/core/generated trees from shadowing target/generated-sources/jaxb in Maven and IDE Java resolution.",
+      "acceptanceCriteria": [
+        "configuration.xsd and grab-config.xsd retain updateOnStartup, autoriseSnapshot, and grab-config boolean flags.",
+        "XMLUserConfig and GrabConfigDAO use isXxx() accessors emitted by jaxb2-maven-plugin for optional xs:boolean fields.",
+        "Maven removes legacy application/core/generated on initialize."
+      ],
+      "validation": [
+        "mvn -B -ntp -DskipTests generate-sources -> BUILD SUCCESS",
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS",
+        "mvn -B -ntp -pl application/core -am test -> BUILD SUCCESS"
+      ],
+      "pr": "fix/jaxb-config-model-alignment (this PR)",
+      "notes": "Builds on jaxb2-maven-plugin migration (#70). Reload Java workspace after mvn generate-sources so target/generated-sources/jaxb is indexed. Optional local java.import.exclusions for application/core/generated/** when .vscode/settings.json exists locally."
+    },
+    {
       "id": "maven-pr-validation",
       "legacyCode": "HBTV-015",
       "displayTitle": "Maven PR validation workflow",
@@ -433,6 +455,28 @@
       ],
       "pr": "docs: add clean squash merge policy (this PR)",
       "notes": "Documentation and workflow only; no application code or CI behavior changes."
+    },
+    {
+      "id": "required-checks-roadmap",
+      "legacyCode": "HBTV-017",
+      "displayTitle": "Required CI checks roadmap",
+      "icon": "🛣️",
+      "status": "proposed",
+      "priority": "P1",
+      "progressPercent": 0,
+      "scope": "Document the staged path to make Maven CI, JDK compatibility, deterministic tests, and security gates required on develop. CI governance and documentation only; no runtime behavior changes and no JavaFX migration.",
+      "acceptanceCriteria": [
+        "docs/required-checks-roadmap.md defines Phases 0-5 with required vs not-yet-required checks.",
+        "docs/ci.md links the roadmap and reflects Phase 0 baseline checks.",
+        "Warning states required checks must be stable, deterministic, and actionable.",
+        "docs/dev-tracker.md and docs/dev-tracker.json stay in sync."
+      ],
+      "validation": [
+        "git status --short",
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS"
+      ],
+      "pr": "docs: add required checks roadmap (this PR)",
+      "notes": "Planned roadmap (status proposed). Modern JDK package compatibility must not be marked done until OpenJFX packaging works (javafx-modernization). Full test suite required only after -Plive-tests isolation (provider-inventory). This PR does not change runtime behavior or migrate JavaFX."
     }
   ]
 }

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -19,17 +19,17 @@
 ## 📊 Overall progress
 
 ```
-███████████████▌░░░░  78%
+██████████████░░░░░░  74%
 ```
 
 | Category | Count |
 |---------|------:|
 | ✅ Delivered | **12** |
 | 🟡 In progress | **4** |
-| 🔵 Proposed | **2** |
+| 🔵 Proposed | **3** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
-| **Total work items** | **18** |
+| **Total work items** | **19** |
 
 ---
 
@@ -51,10 +51,12 @@
 | 🔗 `own-version-deps-align` — Own-version plugin dependency alignment | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 🔑 `youtube-apikey` — YouTube Data API key externalization | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧩 `jaxb-launcher-recovery` — JAXB generated sources & launcher classpath recovery | ✅ Done | 🟠 P1 | `████████████████████` 100% |
+| 🧬 `jaxb-config-model-alignment` — JAXB config/grab-config model & IDE alignment | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧱 `maven-pr-validation` — Maven PR validation workflow | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🔒 `dependency-security-audit` — Dependency security audit & remediation | 🟡 In progress | 🟠 P1 | `███░░░░░░░░░░░░░░░░░` 15% |
 | 📝 `clean-squash-merge-policy` — Clean squash merge policy | 🟡 In progress | 🟢 P3 | `██████████░░░░░░░░░░` 50% |
 | 🔒 `critical-log4j-cve-remediation` — Critical Log4j 1.x CVE remediation | ✅ Done | 🔴 P0 | `████████████████████` 100% |
+| 🛣️ `required-checks-roadmap` — Required CI checks roadmap | 🔵 Proposed | 🟠 P1 | `░░░░░░░░░░░░░░░░░░░░` 0% |
 
 ---
 
@@ -594,6 +596,43 @@ scope for a dedicated security PR.
 
 ---
 
+## 🧬 `jaxb-config-model-alignment` — JAXB config/grab-config model & IDE alignment
+
+| | |
+|---|---|
+| **Status** | ✅ Done |
+| **Priority** | 🟠 P1 |
+| **Progress** | `████████████████████` 100% |
+
+**Scope** — Align `application/core` hand-written config/grab-config
+callers with XSD-backed JAXB output and stop stale
+`application/core/generated` trees from shadowing
+`target/generated-sources/jaxb` in Maven and Cursor/VS Code Java.
+
+**Acceptance criteria**
+- ✅ `configuration.xsd` and `grab-config.xsd` retain
+  `updateOnStartup`, `autoriseSnapshot`, and grab-config boolean flags
+- ✅ `XMLUserConfig` / `GrabConfigDAO` use `isXxx()` accessors emitted
+  by `jaxb2-maven-plugin` for optional `xs:boolean` fields
+- ✅ Maven removes legacy `application/core/generated` on `initialize`
+
+**Validation**
+```bash
+mvn -B -ntp -DskipTests generate-sources
+mvn -B -ntp -DskipTests validate
+mvn -B -ntp -pl application/core -am test
+```
+
+**Related PR** · `fix/jaxb-config-model-alignment` (this branch)
+
+**Notes** — Builds on `jaxb2-maven-plugin` migration (#70). After
+`mvn generate-sources`, reload the Java workspace so
+`target/generated-sources/jaxb` is indexed. Optional local Cursor/VS
+Code setting (`.vscode/settings.json` is gitignored):
+`java.import.exclusions`: `["**/application/core/generated/**"]`.
+
+---
+
 ## 🧱 `maven-pr-validation` — Maven PR validation workflow
 
 | | |
@@ -666,6 +705,42 @@ pwsh -File scripts/security/maven-dependency-inventory.ps1 -DependencyTree
 reports **294** vulnerabilities (87 critical, 90 high, 89 moderate,
 28 low). Dependabot API export to `target/dependabot-alerts.json` is
 local-only (gitignored).
+
+---
+
+## 🛣️ `required-checks-roadmap` — Required CI checks roadmap
+
+| | |
+|---|---|
+| **Status** | 🔵 Proposed (planned) |
+| **Priority** | 🟠 P1 |
+| **Progress** | `░░░░░░░░░░░░░░░░░░░░` 0% |
+| **Legacy code** | HBTV-017 |
+
+**Scope** — Document the staged path to make Maven CI, JDK compatibility,
+deterministic tests, and security gates required on `develop`. CI governance
+and documentation only; no runtime behavior changes and no JavaFX migration in
+this item.
+
+**Acceptance criteria**
+- ⬜ `docs/required-checks-roadmap.md` defines Phases 0–5 with required vs
+  not-yet-required checks
+- ⬜ `docs/ci.md` links the roadmap and reflects Phase 0 baseline checks
+- ⬜ Warning documents that required checks must be stable, deterministic, and
+  actionable (no live network / unrepaired JavaFX gates)
+- ⬜ Tracker mirrors updated in `docs/dev-tracker.json`
+
+**Validation**
+```bash
+git status --short
+mvn -B -ntp -DskipTests validate
+```
+
+**Notes** — Depends on `maven-pr-validation` for workflow job names. Modern
+JDK package compatibility must not be marked done until OpenJFX packaging
+works (`javafx-modernization`). Full test suite becomes required only after
+`-Plive-tests` isolation (`provider-inventory`). See
+`docs/required-checks-roadmap.md`.
 
 ---
 
@@ -766,5 +841,6 @@ issue trackers:
 | HBTV-014 | `jaxb-launcher-recovery` |
 | HBTV-015 | `maven-pr-validation` |
 | HBTV-016 | `dependency-security-audit` |
+| HBTV-017 | `required-checks-roadmap` |
 | HBTV-018 | `clean-squash-merge-policy` |
 | HBTV-019 | `critical-log4j-cve-remediation` |

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -603,6 +603,7 @@ scope for a dedicated security PR.
 | **Status** | ✅ Done |
 | **Priority** | 🟠 P1 |
 | **Progress** | `████████████████████` 100% |
+| **Legacy code** | `HBTV-020` |
 
 **Scope** — Align `application/core` hand-written config/grab-config
 callers with XSD-backed JAXB output and stop stale

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -624,7 +624,7 @@ mvn -B -ntp -DskipTests validate
 mvn -B -ntp -pl application/core -am test
 ```
 
-**Related PR** · `fix/jaxb-config-model-alignment` (this branch)
+**Related PR** · `build: use maintained JAXB generator for core` (#70)
 
 **Notes** — Builds on `jaxb2-maven-plugin` migration (#70). After
 `mvn generate-sources`, reload the Java workspace so
@@ -845,3 +845,4 @@ issue trackers:
 | HBTV-017 | `required-checks-roadmap` |
 | HBTV-018 | `clean-squash-merge-policy` |
 | HBTV-019 | `critical-log4j-cve-remediation` |
+| HBTV-020 | `jaxb-config-model-alignment` |

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -55,8 +55,16 @@ aligned in the same commit when applicable:
 - `docs/risk-register.md` when risks change
 - `docs/decision-log.md` when architecture decisions change
 
+## CI governance
+
+When changing required checks, branch protection, or workflow job semantics,
+update `docs/required-checks-roadmap.md` and tracker item
+`required-checks-roadmap` in the same PR when the staged plan changes.
+
 ## Related documentation
 
+- `docs/required-checks-roadmap.md` — phased path to required CI and security checks
+- `docs/ci.md` — Maven CI workflow and local command parity
 - `docs/repository-governance.md` — branch protection and rulesets
 - `docs/pull-request-style-guide.md` — PR and squash merge style
 - `AGENTS.md` — agent and contributor rules

--- a/docs/required-checks-roadmap.md
+++ b/docs/required-checks-roadmap.md
@@ -4,7 +4,7 @@ Staged path to make all Maven CI, JDK compatibility, test, and security
 checks **required** on `develop` (and eventually `master`) without hiding
 failures or requiring unstable gates prematurely.
 
-**Tracker item:** `required-checks-roadmap` (HBTV-016)
+**Tracker item:** `required-checks-roadmap` (HBTV-017)
 
 **Scope of this document:** CI governance and documentation only. It does
 not change application runtime behavior, Maven reactor topology, or JavaFX

--- a/docs/required-checks-roadmap.md
+++ b/docs/required-checks-roadmap.md
@@ -1,0 +1,255 @@
+# Required checks roadmap
+
+Staged path to make all Maven CI, JDK compatibility, test, and security
+checks **required** on `develop` (and eventually `master`) without hiding
+failures or requiring unstable gates prematurely.
+
+**Tracker item:** `required-checks-roadmap` (HBTV-016)
+
+**Scope of this document:** CI governance and documentation only. It does
+not change application runtime behavior, Maven reactor topology, or JavaFX
+packaging. OpenJFX migration and live-test isolation are prerequisite work
+tracked separately (`javafx-modernization`, `provider-inventory`, risks
+`javafx-jdk8`, `live-tests-flaky`).
+
+**Related automation:** `.github/workflows/ci-maven.yml` (`Maven CI`),
+`.github/workflows/ci.yml` (`CI`), `.github/dependabot.yml`
+
+---
+
+## Warning — stability before requirement
+
+Required checks must be **stable**, **deterministic**, and **actionable**.
+
+Do **not** add a check to branch protection when it:
+
+- Depends on live provider websites, replay endpoints, or other external
+  network behavior that the project does not control.
+- Fails for reasons contributors cannot fix in the PR (for example missing
+  OpenJFX on Java 11+ before migration work lands).
+- Produces noisy security alerts without a documented remediation path.
+
+Non-blocking jobs must remain visible (no `continue-on-error` used to hide
+required work; diagnostic jobs may use `continue-on-error` only while they
+are explicitly **not** required).
+
+---
+
+## Phase 0 — Current required baseline
+
+**Goal:** Keep merge-blocking checks limited to the Java 8 baseline that
+already works in CI (Liberica JDK 8 with bundled JavaFX).
+
+### Required (target for `develop` ruleset)
+
+| Check context | Job | Command |
+|---------------|-----|---------|
+| `Maven CI / validate-java8` | `validate-java8` | `mvn -B -ntp -DskipTests validate` |
+| `Maven CI / deterministic-tests-java8` | `deterministic-tests-java8` | `mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am test` |
+| `Maven CI / compile-and-package-java8` | `compile-and-package-java8` | `mvn -B -ntp -DskipTests package` |
+
+Until the repository ruleset is updated, `develop` may still list the legacy
+`CI / validate (zulu-8)` check from `.github/workflows/ci.yml`. When
+governance updates land (`branch-protection`), align required checks with the
+three `Maven CI` jobs above and drop redundant legacy-only gates once
+parity is confirmed.
+
+### Not required yet
+
+- `Maven CI / compatibility-java11` (and 17, 21, 25) — validation or package
+  on modern JDKs
+- `Maven CI / full-test-suite` — includes live provider/network tests
+- Provider live tests (any job or profile hitting real endpoints)
+- Broad dependency or static-analysis gates that are still noisy or lack
+  owner remediation playbooks
+- Deployment, release, or publish workflows
+
+### Local parity
+
+```bash
+mvn -B -ntp -DskipTests validate
+mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am test
+mvn -B -ntp -DskipTests package
+```
+
+See also [`docs/ci.md`](ci.md).
+
+---
+
+## Phase 1 — Modern JDK validation
+
+**Goal:** Prove the reactor resolves and validates on Temurin 11, 17, 21, and
+25 without requiring JavaFX packaging on those runtimes yet.
+
+**CI behavior (today):** `compatibility-java` matrix jobs run
+`mvn -B -ntp -DskipTests validate` and a **non-blocking** package diagnostic.
+Package steps stay diagnostic until Phase 2 succeeds.
+
+**When stable, make required (validation only):**
+
+| Check context | Scope |
+|---------------|--------|
+| `Maven CI / compatibility-java11` | `validate` only |
+| `Maven CI / compatibility-java17` | `validate` only |
+| `Maven CI / compatibility-java21` | `validate` only |
+| `Maven CI / compatibility-java25` | `validate` only (optional / experimental) |
+
+Name these checks clearly as **validation**, not package compatibility. Do
+not mark Java 11/17/21/25 package jobs as required while OpenJFX migration is
+incomplete.
+
+**Prerequisites:** JAXB/module-path issues tracked under `jaxb-mismatch` must
+not cause chronic false failures on `validate` for the modules in the default
+reactor.
+
+---
+
+## Phase 2 — OpenJFX migration and modern package compatibility
+
+**Goal:** Package GUI-related modules on a selected modern LTS JDK after
+OpenJFX dependencies or Maven profiles replace `${jdk.home}` / `jfxrt.jar`
+assumptions.
+
+**Prerequisite tracker:** `javafx-modernization` (risk `javafx-jdk8`).
+
+**Engineering milestones (follow-up PRs, not this roadmap PR):**
+
+1. Add OpenJFX dependencies or JDK-version profiles for Java 11+.
+2. Ensure `application/trayView` compiles and `mvn -DskipTests package`
+   succeeds on the target LTS (prefer **Java 17** or **Java 21**).
+3. Keep Java 8 compatibility until a separate ADR retires it.
+4. Leave `application/habiTv-linux` and `application/habiTv-windows` out of
+   required gates until explicitly brought into the reactor or replaced.
+
+**Only after real package success on CI**, add required checks such as:
+
+- `Maven CI / package-java17` (example name — align with workflow job names
+  when introduced)
+- Do **not** mark compatibility package matrix jobs as done in the tracker
+  until OpenJFX packaging actually works in CI artifacts.
+
+**Still not required:** experimental newest-JDK (25) package unless explicitly
+adopted as a support target.
+
+---
+
+## Phase 3 — Test isolation
+
+**Goal:** A deterministic default test suite suitable for required CI; live
+provider behavior tested separately.
+
+**Prerequisite trackers:** `provider-inventory`, risk `live-tests-flaky`.
+
+**Engineering milestones (follow-up PRs):**
+
+1. Split offline/deterministic tests from live provider tests.
+2. Move network/provider tests behind an explicit Maven profile, e.g.
+   `-Plive-tests` (name to match implementation PR).
+3. Add local fixtures for provider HTML/API parsing where feasible.
+4. Ensure default `mvn test` (no profile) is CI-safe and does not call live
+   endpoints.
+5. Retarget `full-test-suite` to run default deterministic tests when made
+   required; keep `-Plive-tests` on `workflow_dispatch` / schedule only.
+
+**When stable, make required:**
+
+| Check context | Scope |
+|---------------|--------|
+| `Maven CI / full-test-suite` (or renamed `deterministic-full-tests`) | Default offline suite on Java 8 |
+
+**Remain optional / non-required:**
+
+- `-Plive-tests` or equivalent provider live jobs
+- Weekly scheduled full legacy runs until live tests are quarantined
+
+---
+
+## Phase 4 — Security gates
+
+**Goal:** Actionable security signal on every PR without mass dependency
+upgrades.
+
+**Current state:**
+
+- Dependabot (`.github/dependabot.yml`) opens scoped Maven and GitHub Actions
+  update PRs; major bumps ignored by policy.
+- Dependency Review can run on PRs when enabled at the org/repo level.
+- CodeQL is **not** yet configured; add it before requiring analysis.
+
+**Policy (document before requiring):**
+
+| Gate | Intended use |
+|------|----------------|
+| Dependency Review | Block PRs introducing **high** or **critical** vulnerabilities in changed dependencies once noise is low |
+| Dependabot | Remediation via focused PRs; no mass-upgrade sweeps |
+| CodeQL | Required only after custom queries or paths are tuned for Java 8 legacy code |
+
+**Remediation rules:**
+
+- Fix critical/high issues in **focused** PRs per component or CVE class.
+- Do not mass-bump unrelated dependencies to green a dashboard.
+- Document accepted residual risk in `docs/risk-register.md` when deferring.
+
+**When stable, make required:** Dependency Review and CodeQL on `develop`
+PRs, in addition to Phase 0–3 checks.
+
+---
+
+## Phase 5 — Final branch protection target
+
+After Phases 0–4 prerequisites are met, the **target** required check set:
+
+| Required | Notes |
+|----------|--------|
+| `Maven CI / validate-java8` | While Java 8 remains supported |
+| `Maven CI / deterministic-tests-java8` | Or superseded by Phase 3 full deterministic suite |
+| `Maven CI / compile-and-package-java8` | Java 8 package baseline |
+| Modern JDK `validate` jobs | Phase 1 |
+| Modern LTS **package** job(s) | Phase 2 — selected 17 and/or 21 only |
+| Deterministic full test job | Phase 3 |
+| Dependency Review | Phase 4 |
+| CodeQL | Phase 4 |
+
+| Optional / non-required | Notes |
+|-------------------------|--------|
+| Live provider tests (`-Plive-tests`) | Manual or scheduled only |
+| `Maven CI / compatibility-java25` | Experimental newest JDK |
+| Deploy / release / static publish workflows | Owner-triggered |
+| Legacy `CI / validate (zulu-8)` | Remove when redundant with Maven CI |
+
+Governance application is tracked under `branch-protection` and
+`docs/repository-governance.md`.
+
+---
+
+## Phase dependency diagram
+
+```mermaid
+flowchart LR
+  P0[Phase 0 Java 8 required]
+  P1[Phase 1 JDK validate]
+  P2[Phase 2 OpenJFX package]
+  P3[Phase 3 test isolation]
+  P4[Phase 4 security gates]
+  P5[Phase 5 full protection]
+  P0 --> P1
+  P1 --> P2
+  P2 --> P3
+  P3 --> P5
+  P4 --> P5
+  P0 --> P5
+```
+
+Phase 4 can proceed in parallel with Phases 1–3 once Dependency Review and
+CodeQL configurations are stable; do not block Java 8 baseline work on
+security dashboard cleanup.
+
+---
+
+## Follow-up PRs (implementation, not this doc PR)
+
+1. OpenJFX support for modern JDK packaging (`javafx-modernization`).
+2. Split offline tests from live provider tests (`provider-inventory`).
+3. Provider fixtures for deterministic parsing tests.
+4. Progressive hardening of Dependency Review severities and CodeQL setup.
+5. Ruleset update to match Phase 0 required checks (`branch-protection`).


### PR DESCRIPTION
## Summary
- Document the staged path to make all Maven CI, compatibility, test, and security checks required.
- Keep Java 8 as the current required build/package baseline.
- Define when Java 11/17/21/25 compatibility, full tests, and security gates can become required.

## Status
Superseded by #82, which carries forward the useful `docs/required-checks-roadmap.md` content on a clean branch based on current `develop` after #78.

## Reason for closing
This branch became stale and conflicted with the documentation refresh merged in #78. Keeping it open would reintroduce old docs/tracker conflicts. Use #82 for the current replacement PR.