### PR TITLE
fix: improve yt-dlp Windows runtime diagnostics

### DIFF
--- a/.github/workflows/ci-maven.yml
+++ b/.github/workflows/ci-maven.yml
@@ -160,9 +160,11 @@ jobs:
       - name: Maven validate diagnostic
         run: mvn -B -ntp -DskipTests validate
 
-      # Java 11+ package diagnostics are non-blocking by design.
+      # Java 11+ package diagnostics exclude JavaFX-dependent modules until the
+      # JavaFX migration is complete (trayView and habiTv directly import the
+      # javafx.* packages bundled only in Liberica JDK 8 with jdk+fx).
       - name: Maven package diagnostic
-        run: mvn -B -ntp -DskipTests package
+        run: mvn -B -ntp -DskipTests -pl '!application/trayView,!application/habiTv' package
 
       - name: Upload Maven artifacts
         if: always()

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -18,12 +18,12 @@
   ],
   "summary": {
     "done": 12,
-    "inProgress": 4,
+    "inProgress": 5,
     "proposed": 2,
     "deferred": 0,
     "blocked": 0,
-    "total": 18,
-    "overallProgressPercent": 78
+    "total": 19,
+    "overallProgressPercent": 79
   },
   "items": [
     {
@@ -211,6 +211,30 @@
       ],
       "pr": "feat(youtube): migrate downloader binary to yt-dlp (TBD)",
       "notes": "Plugin module id remains youtube. Static-repo tool metadata uses yt-dlp; habitv-repo publication is separate. No provider rewrite or live-network tests."
+    },
+    {
+      "id": "ytdlp-runtime-diagnostics",
+      "legacyCode": "HBTV-007a",
+      "displayTitle": "yt-dlp Windows runtime diagnostics",
+      "icon": "🩺",
+      "status": "in-progress",
+      "priority": "P2",
+      "progressPercent": 90,
+      "scope": "Detect yt-dlp PyInstaller bootstrap failures before downloads, log actionable binary/temp diagnostics, use habitv-home temp for yt-dlp extraction, document Windows recovery.",
+      "acceptanceCriteria": [
+        "Preflight yt-dlp --version before each download (done).",
+        "Classify [PYI- / Failed to extract / Cryptodome / _MEI stderr as bootstrap failure (done).",
+        "User-facing message mentions clear TEMP _MEI folders, replace yt-dlp.exe, run yt-dlp.exe --version (done).",
+        "Set TEMP/TMP to <habitv-home>/tmp/yt-dlp for yt-dlp processes (done).",
+        "Unit tests for PyInstaller vs generic errors (done).",
+        "Troubleshooting section in docs/ytdlp-cli-compatibility.md (done)."
+      ],
+      "validation": [
+        "mvn -B -ntp -DskipTests validate",
+        "mvn -B -ntp -pl fwk/framework,plugins/youtube -am test"
+      ],
+      "pr": "fix: improve yt-dlp Windows runtime diagnostics (TBD)",
+      "notes": "Independent from France.tv provider URL parsing. No downloader architecture rewrite."
     },
     {
       "id": "javafx-modernization",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -19,17 +19,17 @@
 ## 📊 Overall progress
 
 ```
-███████████████▌░░░░  78%
+███████████████▋░░░░  79%
 ```
 
 | Category | Count |
 |---------|------:|
 | ✅ Delivered | **12** |
-| 🟡 In progress | **4** |
+| 🟡 In progress | **5** |
 | 🔵 Proposed | **2** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
-| **Total work items** | **18** |
+| **Total work items** | **19** |
 
 ---
 
@@ -45,6 +45,7 @@
 | 📦 `static-repo-publish` — Static artifact repository publication | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🟡 In progress | 🟡 P2 | `███████████░░░░░░░░░` 55% |
 | 🎬 `ytdlp-migration` — `youtube-dl` → `yt-dlp` migration | 🟡 In progress | 🟡 P2 | `███████████████░░░░░` 75% |
+| 🩺 `ytdlp-runtime-diagnostics` — yt-dlp Windows runtime diagnostics | 🟡 In progress | 🟡 P2 | `██████████████████░░` 90% |
 | 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `██░░░░░░░░░░░░░░░░░░` 10% |
 | 🧪 `plugin-tester-align` — `plugin-tester` reactor alignment | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | ▶️ `console-runnable` — Runnable console baseline | ✅ Done | 🔴 P0 | `████████████████████` 100% |
@@ -366,6 +367,37 @@ mvn -B -ntp -pl plugins/youtube -am -Dsurefire.failIfNoSpecifiedTests=false test
 Static-repo tool metadata in `scripts/static-repo/tool-sources.properties` uses
 `yt-dlp`; publishing the zip to `habitv-repo` is a separate PR. No provider
 rewrite, no live-network tests in this item.
+
+---
+
+## 🩺 `ytdlp-runtime-diagnostics` — yt-dlp Windows runtime diagnostics
+
+| | |
+|---|---|
+| **Status** | 🟡 In progress |
+| **Priority** | 🟡 P2 |
+| **Progress** | `██████████████████░░` 90% |
+| **Legacy code** | HBTV-007a |
+
+**Scope** — Detect yt-dlp PyInstaller bootstrap failures before media downloads,
+log safe binary/temp diagnostics, route yt-dlp `TEMP`/`TMP` to
+`<habitv-home>/tmp/yt-dlp`, and document Windows recovery steps.
+
+**Acceptance criteria**
+- ✅ Preflight `yt-dlp --version` before each download
+- ✅ Classify `[PYI-` / `Failed to extract` / `Cryptodome` / `_MEI` stderr
+- ✅ Actionable user message (clear `_MEI` folders, replace binary, run `--version`)
+- ✅ Unit tests for PyInstaller vs generic downloader errors
+- ✅ Troubleshooting in `docs/ytdlp-cli-compatibility.md`
+
+**Validation**
+```bash
+mvn -B -ntp -DskipTests validate
+mvn -B -ntp -pl fwk/framework,plugins/youtube -am test
+```
+
+**Notes** — Independent from France.tv provider URL parsing. No downloader
+architecture rewrite.
 
 ---
 

--- a/docs/ytdlp-cli-compatibility.md
+++ b/docs/ytdlp-cli-compatibility.md
@@ -49,6 +49,59 @@ No provider rewrite or live endpoint validation is included in the binary
 migration PR; non-YouTube URL domains accepted by `YoutubePluginDownloader`
 are unchanged.
 
+## Controlled temp directory (Windows)
+
+PyInstaller onefile builds of `yt-dlp.exe` extract runtime files into `TEMP`/`TMP`.
+Habitv sets both variables to `<habitv-home>/tmp/yt-dlp` for yt-dlp child processes
+so extraction does not depend on a crowded or permission-broken system temp folder.
+
+Before each download, Habitv runs `yt-dlp.exe --version` as a preflight check. If
+stderr contains PyInstaller signatures (`[PYI-`, `Failed to extract`, `Cryptodome`,
+`_MEI`), the failure is reported as a **yt-dlp bootstrap error**, not a provider
+URL parsing failure.
+
+## Troubleshooting: yt-dlp PyInstaller extraction failure on Windows
+
+Symptoms in logs:
+
+```text
+[PYI-17924:ERROR] Failed to extract Cryptodome\PublicKey\_ec_ws.pyd: decompression resulted in return code -1!
+[PYI-17924:ERROR] Failed to extract entry: Cryptodome\PublicKey\_ec_ws.pyd.
+```
+
+This happens **before** any site-specific extraction (for example France.tv). The
+first manual test is always `yt-dlp.exe --version`, then a direct URL download.
+
+### Recovery steps
+
+1. Stop Habitv.
+2. Remove stale PyInstaller temp folders:
+
+```powershell
+Get-ChildItem "$env:TEMP" -Directory -Filter "_MEI*" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+3. Rename the current binary:
+
+```powershell
+Rename-Item "C:\Users\Mika\habitv\bin\yt-dlp.exe" "yt-dlp.exe.broken" -ErrorAction SilentlyContinue
+```
+
+4. Download a fresh official Windows `yt-dlp.exe` from:
+   https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe
+5. Install it as `C:\Users\Mika\habitv\bin\yt-dlp.exe` (adjust paths to your
+   Habitv home directory).
+6. Test outside Habitv:
+
+```powershell
+C:\Users\Mika\habitv\bin\yt-dlp.exe --version
+C:\Users\Mika\habitv\bin\yt-dlp.exe "https://www.france.tv/france-3/nouvelle-aquitaine_la-france-en-vrai-aquitaine/8456007-oleron-la-vie-continue.html" -o "C:\Users\Mika\habitv\Downloads\manual-francetv-test.%(ext)s" --write-sub --write-auto-sub --no-check-certificate
+```
+
+7. Retry the same URL through Habitv.
+
+Tracker: `ytdlp-runtime-diagnostics`.
+
 ## Out of scope for this contract
 
 - Provider discovery / `canDownload()` domain list changes

--- a/docs/ytdlp-cli-compatibility.md
+++ b/docs/ytdlp-cli-compatibility.md
@@ -94,8 +94,8 @@ Rename-Item "$env:USERPROFILE\habitv\bin\yt-dlp.exe" "yt-dlp.exe.broken" -ErrorA
 6. Test outside Habitv:
 
 ```powershell
-$env:USERPROFILE\habitv\bin\yt-dlp.exe --version
-$env:USERPROFILE\habitv\bin\yt-dlp.exe "https://www.france.tv/france-3/nouvelle-aquitaine_la-france-en-vrai-aquitaine/8456007-oleron-la-vie-continue.html" -o "$env:USERPROFILE\habitv\Downloads\manual-francetv-test.%(ext)s" --write-sub --write-auto-sub --no-check-certificate
+& "$env:USERPROFILE\habitv\bin\yt-dlp.exe" --version
+& "$env:USERPROFILE\habitv\bin\yt-dlp.exe" "https://www.france.tv/france-3/nouvelle-aquitaine_la-france-en-vrai-aquitaine/8456007-oleron-la-vie-continue.html" -o "$env:USERPROFILE\habitv\Downloads\manual-francetv-test.%(ext)s" --write-sub --write-auto-sub --no-check-certificate
 ```
 
 7. Retry the same URL through Habitv.

--- a/docs/ytdlp-cli-compatibility.md
+++ b/docs/ytdlp-cli-compatibility.md
@@ -84,18 +84,18 @@ Get-ChildItem "$env:TEMP" -Directory -Filter "_MEI*" -ErrorAction SilentlyContin
 3. Rename the current binary:
 
 ```powershell
-Rename-Item "C:\Users\Mika\habitv\bin\yt-dlp.exe" "yt-dlp.exe.broken" -ErrorAction SilentlyContinue
+Rename-Item "$env:USERPROFILE\habitv\bin\yt-dlp.exe" "yt-dlp.exe.broken" -ErrorAction SilentlyContinue
 ```
 
 4. Download a fresh official Windows `yt-dlp.exe` from:
    https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe
-5. Install it as `C:\Users\Mika\habitv\bin\yt-dlp.exe` (adjust paths to your
+5. Install it as `%USERPROFILE%\habitv\bin\yt-dlp.exe` (adjust paths to your
    Habitv home directory).
 6. Test outside Habitv:
 
 ```powershell
-C:\Users\Mika\habitv\bin\yt-dlp.exe --version
-C:\Users\Mika\habitv\bin\yt-dlp.exe "https://www.france.tv/france-3/nouvelle-aquitaine_la-france-en-vrai-aquitaine/8456007-oleron-la-vie-continue.html" -o "C:\Users\Mika\habitv\Downloads\manual-francetv-test.%(ext)s" --write-sub --write-auto-sub --no-check-certificate
+$env:USERPROFILE\habitv\bin\yt-dlp.exe --version
+$env:USERPROFILE\habitv\bin\yt-dlp.exe "https://www.france.tv/france-3/nouvelle-aquitaine_la-france-en-vrai-aquitaine/8456007-oleron-la-vie-continue.html" -o "$env:USERPROFILE\habitv\Downloads\manual-francetv-test.%(ext)s" --write-sub --write-auto-sub --no-check-certificate
 ```
 
 7. Retry the same URL through Habitv.

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/CmdExecutor.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/CmdExecutor.java
@@ -166,16 +166,12 @@ public class CmdExecutor implements ProcessHolder {
 		try {
 			final Map<String, String> envOverrides = getProcessEnvironment();
 			final boolean hasEnvOverrides = envOverrides != null && !envOverrides.isEmpty();
+			final String[] mergedEnv = hasEnvOverrides ? buildMergedEnvironmentArray(envOverrides) : null;
 			if (cmdProcessor == null || cmdProcessor.isEmpty()) {
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("cmd : " + cmd);
 				}
-				if (!hasEnvOverrides) {
-					return Runtime.getRuntime().exec(cmd);
-				}
-				final ProcessBuilder processBuilder = new ProcessBuilder(cmd);
-				applyEnvironmentOverrides(processBuilder, envOverrides);
-				return processBuilder.start();
+				return Runtime.getRuntime().exec(cmd, mergedEnv);
 			} else {
 				final String[] cmdArgs = cmdProcessor.split(" ");
 				for (int i = 0; i < cmdArgs.length; i++) {
@@ -186,24 +182,25 @@ public class CmdExecutor implements ProcessHolder {
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("cmd : " + cmdArgs);
 				}
-				if (!hasEnvOverrides) {
-					return Runtime.getRuntime().exec(cmdArgs);
-				}
-				final ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs);
-				applyEnvironmentOverrides(processBuilder, envOverrides);
-				return processBuilder.start();
+				return Runtime.getRuntime().exec(cmdArgs, mergedEnv);
 			}
 		} catch (final IOException e) {
 			throw new ExecutorFailedException(cmd, e.getMessage(), e.getMessage(), e);
 		}
 	}
 
-	private static void applyEnvironmentOverrides(final ProcessBuilder processBuilder,
-			final Map<String, String> envOverrides) {
-		final Map<String, String> environment = processBuilder.environment();
+	private static String[] buildMergedEnvironmentArray(final Map<String, String> envOverrides) {
+		final Map<String, String> environment = System.getenv();
+		final Map<String, String> merged = new java.util.HashMap<String, String>(environment);
 		for (final Map.Entry<String, String> entry : envOverrides.entrySet()) {
-			environment.put(entry.getKey(), entry.getValue());
+			merged.put(entry.getKey(), entry.getValue());
 		}
+		final String[] envp = new String[merged.size()];
+		int i = 0;
+		for (final Map.Entry<String, String> entry : merged.entrySet()) {
+			envp[i++] = entry.getKey() + "=" + entry.getValue();
+		}
+		return envp;
 	}
 
 	private Thread treatCmdOutput(final InputStream inputStream, final StringBuffer fullOutput) {

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/CmdExecutor.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/CmdExecutor.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 
@@ -105,7 +106,7 @@ public class CmdExecutor implements ProcessHolder {
 		}
 
 		if (process.exitValue() != 0 || (getLastOutputLine() != null && !isSuccess(fullOutput.toString()))) {
-			throw new ExecutorFailedException(cmd, fullOutput.toString(), lastOutputLine, null);
+			throw buildFailureException(cmd, fullOutput.toString(), lastOutputLine, null);
 		}
 		this.fullOutput = fullOutput.toString();
 	}
@@ -152,13 +153,29 @@ public class CmdExecutor implements ProcessHolder {
 		return -1;
 	}
 
+	protected Map<String, String> getProcessEnvironment() {
+		return null;
+	}
+
+	protected ExecutorFailedException buildFailureException(final String failedCmd, final String fullOutput,
+			final String lastLine, final Throwable cause) {
+		return new ExecutorFailedException(failedCmd, fullOutput, lastLine, cause);
+	}
+
 	protected Process buildProcess() throws ExecutorFailedException {
 		try {
+			final Map<String, String> envOverrides = getProcessEnvironment();
+			final boolean hasEnvOverrides = envOverrides != null && !envOverrides.isEmpty();
 			if (cmdProcessor == null || cmdProcessor.isEmpty()) {
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("cmd : " + cmd);
 				}
-				return Runtime.getRuntime().exec(cmd);
+				if (!hasEnvOverrides) {
+					return Runtime.getRuntime().exec(cmd);
+				}
+				final ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+				applyEnvironmentOverrides(processBuilder, envOverrides);
+				return processBuilder.start();
 			} else {
 				final String[] cmdArgs = cmdProcessor.split(" ");
 				for (int i = 0; i < cmdArgs.length; i++) {
@@ -169,10 +186,23 @@ public class CmdExecutor implements ProcessHolder {
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("cmd : " + cmdArgs);
 				}
-				return Runtime.getRuntime().exec(cmdArgs);
+				if (!hasEnvOverrides) {
+					return Runtime.getRuntime().exec(cmdArgs);
+				}
+				final ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs);
+				applyEnvironmentOverrides(processBuilder, envOverrides);
+				return processBuilder.start();
 			}
 		} catch (final IOException e) {
 			throw new ExecutorFailedException(cmd, e.getMessage(), e.getMessage(), e);
+		}
+	}
+
+	private static void applyEnvironmentOverrides(final ProcessBuilder processBuilder,
+			final Map<String, String> envOverrides) {
+		final Map<String, String> environment = processBuilder.environment();
+		for (final Map.Entry<String, String> entry : envOverrides.entrySet()) {
+			environment.put(entry.getKey(), entry.getValue());
 		}
 	}
 

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
@@ -41,7 +41,8 @@ public class YoutubePluginDownloader extends BaseUpdatablePlugin implements Plug
 		// }
 
 		try {
-			return (new YtDlpCmdExecutor(downloaders.getCmdProcessor(), cmd));
+			YtDlpRuntimeDiagnostics.runPreflight(downloaders.getCmdProcessor(), binParam, downloaders.getBinDir());
+			return new YtDlpCmdExecutor(downloaders.getCmdProcessor(), cmd, binParam, downloaders.getBinDir());
 		} catch (final ExecutorFailedException e) {
 			throw new DownloadFailedException(e);
 		}

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpCmdExecutor.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpCmdExecutor.java
@@ -1,8 +1,10 @@
 package com.dabi.habitv.plugin.youtube;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.dabi.habitv.api.plugin.exception.ExecutorFailedException;
 import com.dabi.habitv.framework.FrameworkConf;
 import com.dabi.habitv.framework.plugin.utils.CmdExecutor;
 
@@ -15,8 +17,39 @@ public class YtDlpCmdExecutor extends CmdExecutor {
 	private static final Pattern PROGRESS_PATTERN = Pattern
 			.compile(".*\\s(\\d+.\\d+)%.*");
 
+	private final String executablePath;
+
+	private final String binDir;
+
 	public YtDlpCmdExecutor(final String cmdProcessor, final String cmd) {
+		this(cmdProcessor, cmd, null, null);
+	}
+
+	public YtDlpCmdExecutor(final String cmdProcessor, final String cmd, final String executablePath,
+			final String binDir) {
 		super(cmdProcessor, cmd, YoutubeConf.MAX_HUNG_TIME);
+		this.executablePath = executablePath;
+		this.binDir = binDir;
+	}
+
+	@Override
+	protected Map<String, String> getProcessEnvironment() {
+		if (binDir == null) {
+			return null;
+		}
+		return YtDlpRuntimeDiagnostics.buildYtDlpEnvironment(binDir);
+	}
+
+	@Override
+	protected ExecutorFailedException buildFailureException(final String failedCmd, final String fullOutput,
+			final String lastLine, final Throwable cause) {
+		final String pathForMessage = executablePath != null ? executablePath : failedCmd;
+		if (YtDlpRuntimeDiagnostics.isBootstrapExtractionFailure(fullOutput)
+				|| YtDlpRuntimeDiagnostics.isBootstrapExtractionFailure(lastLine)) {
+			return new ExecutorFailedException(failedCmd, fullOutput,
+					YtDlpRuntimeDiagnostics.buildBootstrapFailureUserMessage(pathForMessage), cause);
+		}
+		return super.buildFailureException(failedCmd, fullOutput, lastLine, cause);
 	}
 
 	@Override

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
@@ -61,7 +61,7 @@ public final class YtDlpRuntimeDiagnostics {
 		return message.toString();
 	}
 
-	public static File resolveYtDlpTempDir(final String binDir) {
+	static File computeYtDlpTempDir(final String binDir) {
 		File home = new File(binDir);
 		if (home.getName().equalsIgnoreCase("bin")) {
 			final File parent = home.getParentFile();
@@ -69,7 +69,11 @@ public final class YtDlpRuntimeDiagnostics {
 				home = parent;
 			}
 		}
-		final File tempDir = new File(home, "tmp" + File.separator + "yt-dlp");
+		return new File(home, "tmp" + File.separator + "yt-dlp");
+	}
+
+	public static File resolveYtDlpTempDir(final String binDir) {
+		final File tempDir = computeYtDlpTempDir(binDir);
 		if (!tempDir.exists() && !tempDir.mkdirs()) {
 			LOG.warn("Could not create yt-dlp temp directory: " + tempDir.getAbsolutePath());
 		}
@@ -93,16 +97,16 @@ public final class YtDlpRuntimeDiagnostics {
 			LOG.info("yt-dlp executable size bytes: " + executable.length());
 			LOG.info("yt-dlp executable last modified: " + new Date(executable.lastModified()));
 		}
-		final Map<String, String> env = buildYtDlpEnvironment(binDir);
-		LOG.info("yt-dlp process TEMP: " + env.get("TEMP"));
-		LOG.info("yt-dlp process TMP: " + env.get("TMP"));
+		final String tempPath = computeYtDlpTempDir(binDir).getAbsolutePath();
+		LOG.info("yt-dlp process TEMP: " + tempPath);
+		LOG.info("yt-dlp process TMP: " + tempPath);
 	}
 
 	public static void runPreflight(final String cmdProcessor, final String executablePath, final String binDir) {
-		logExecutableDiagnostics(executablePath, binDir);
 		if (!preflightEnabled) {
 			return;
 		}
+		logExecutableDiagnostics(executablePath, binDir);
 		final String versionCmd = executablePath + " --version";
 		final Map<String, String> env = buildYtDlpEnvironment(binDir);
 		final CmdExecutor versionExecutor = new CmdExecutor(cmdProcessor, versionCmd, 1000) {

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
@@ -1,0 +1,141 @@
+package com.dabi.habitv.plugin.youtube;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+
+import com.dabi.habitv.api.plugin.exception.ExecutorFailedException;
+import com.dabi.habitv.framework.plugin.utils.CmdExecutor;
+
+/**
+ * Detects yt-dlp PyInstaller bootstrap failures and runs a lightweight
+ * {@code --version} preflight before real download commands.
+ */
+public final class YtDlpRuntimeDiagnostics {
+
+	private static final Logger LOG = Logger.getLogger(YtDlpRuntimeDiagnostics.class);
+
+	static final String USER_MESSAGE_PREFIX = "yt-dlp failed before the download started";
+
+	private static final String[] PYINSTALLER_SIGNATURES = { "[PYI-", "Failed to extract", "Cryptodome", "_MEI" };
+
+	private static boolean preflightEnabled = true;
+
+	private YtDlpRuntimeDiagnostics() {
+	}
+
+	static void setPreflightEnabled(final boolean enabled) {
+		preflightEnabled = enabled;
+	}
+
+	static boolean isPreflightEnabled() {
+		return preflightEnabled;
+	}
+
+	public static boolean isBootstrapExtractionFailure(final String output) {
+		if (output == null || output.isEmpty()) {
+			return false;
+		}
+		for (final String signature : PYINSTALLER_SIGNATURES) {
+			if (output.contains(signature)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public static String buildBootstrapFailureUserMessage(final String executablePath) {
+		final StringBuilder message = new StringBuilder(USER_MESSAGE_PREFIX);
+		message.append(". The yt-dlp binary could not start (PyInstaller extraction failure).");
+		message.append(" Likely causes: corrupted yt-dlp.exe, antivirus blocking temp extraction,");
+		message.append(" full TEMP or system drive, or bad permissions on the temp directory.");
+		message.append(" Recovery: stop Habitv, clear TEMP _MEI folders, replace yt-dlp.exe");
+		if (executablePath != null && !executablePath.isEmpty()) {
+			message.append(" (current path: ").append(executablePath).append(')');
+		}
+		message.append(", then run yt-dlp.exe --version outside Habitv before retrying downloads.");
+		return message.toString();
+	}
+
+	public static File resolveYtDlpTempDir(final String binDir) {
+		File home = new File(binDir);
+		if (home.getName().equalsIgnoreCase("bin")) {
+			final File parent = home.getParentFile();
+			if (parent != null) {
+				home = parent;
+			}
+		}
+		final File tempDir = new File(home, "tmp" + File.separator + "yt-dlp");
+		if (!tempDir.exists() && !tempDir.mkdirs()) {
+			LOG.warn("Could not create yt-dlp temp directory: " + tempDir.getAbsolutePath());
+		}
+		return tempDir;
+	}
+
+	public static Map<String, String> buildYtDlpEnvironment(final String binDir) {
+		final File tempDir = resolveYtDlpTempDir(binDir);
+		final String tempPath = tempDir.getAbsolutePath();
+		final Map<String, String> env = new HashMap<String, String>();
+		env.put("TEMP", tempPath);
+		env.put("TMP", tempPath);
+		return Collections.unmodifiableMap(env);
+	}
+
+	public static void logExecutableDiagnostics(final String executablePath, final String binDir) {
+		LOG.info("yt-dlp executable path: " + executablePath);
+		final File executable = new File(executablePath);
+		LOG.info("yt-dlp executable exists: " + executable.exists());
+		if (executable.exists()) {
+			LOG.info("yt-dlp executable size bytes: " + executable.length());
+			LOG.info("yt-dlp executable last modified: " + new Date(executable.lastModified()));
+		}
+		final Map<String, String> env = buildYtDlpEnvironment(binDir);
+		LOG.info("yt-dlp process TEMP: " + env.get("TEMP"));
+		LOG.info("yt-dlp process TMP: " + env.get("TMP"));
+	}
+
+	public static void runPreflight(final String cmdProcessor, final String executablePath, final String binDir) {
+		logExecutableDiagnostics(executablePath, binDir);
+		if (!preflightEnabled) {
+			return;
+		}
+		final String versionCmd = executablePath + " --version";
+		final Map<String, String> env = buildYtDlpEnvironment(binDir);
+		final CmdExecutor versionExecutor = new CmdExecutor(cmdProcessor, versionCmd, 1000) {
+			@Override
+			protected Map<String, String> getProcessEnvironment() {
+				return env;
+			}
+
+			@Override
+			protected boolean isSuccess(final String fullOutput) {
+				return true;
+			}
+		};
+		try {
+			versionExecutor.start();
+		} catch (final ExecutorFailedException e) {
+			throw asBootstrapFailureIfNeeded(versionCmd, e.getFullOuput(), executablePath, e);
+		}
+		final String fullOutput = versionExecutor.getFullOutput();
+		if (isBootstrapExtractionFailure(fullOutput)) {
+			throw new ExecutorFailedException(versionCmd, fullOutput,
+					buildBootstrapFailureUserMessage(executablePath), null);
+		}
+		final String versionLine = fullOutput == null ? "" : fullOutput.trim();
+		LOG.info("yt-dlp version: " + versionLine);
+	}
+
+	static ExecutorFailedException asBootstrapFailureIfNeeded(final String cmd, final String fullOutput,
+			final String executablePath, final ExecutorFailedException cause) {
+		if (isBootstrapExtractionFailure(fullOutput)
+				|| (cause != null && isBootstrapExtractionFailure(cause.getLastLine()))) {
+			return new ExecutorFailedException(cmd, fullOutput, buildBootstrapFailureUserMessage(executablePath), cause);
+		}
+		return cause;
+	}
+}

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
@@ -107,6 +107,11 @@ public final class YtDlpRuntimeDiagnostics {
 		final Map<String, String> env = buildYtDlpEnvironment(binDir);
 		final CmdExecutor versionExecutor = new CmdExecutor(cmdProcessor, versionCmd, 1000) {
 			@Override
+			protected long getHungProcessTime() {
+				return 1000;
+			}
+
+			@Override
 			protected Map<String, String> getProcessEnvironment() {
 				return env;
 			}

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.dabi.habitv.api.plugin.api.PluginDownloaderInterface;
@@ -19,6 +21,16 @@ import com.dabi.habitv.api.plugin.holder.ProcessHolder;
 import com.dabi.habitv.framework.plugin.utils.CmdExecutor;
 
 public class YoutubePluginDownloaderCmdTest {
+
+	@Before
+	public void disablePreflight() {
+		YtDlpRuntimeDiagnostics.setPreflightEnabled(false);
+	}
+
+	@After
+	public void restorePreflight() {
+		YtDlpRuntimeDiagnostics.setPreflightEnabled(true);
+	}
 
 	@Test
 	public void youtubeUrlIsAcceptedBySpecificDownloader() {

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderTest.java
@@ -2,6 +2,8 @@ package com.dabi.habitv.plugin.youtube;
 
 import java.util.HashMap;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.dabi.habitv.api.plugin.api.PluginDownloaderInterface;
@@ -10,6 +12,16 @@ import com.dabi.habitv.api.plugin.holder.DownloaderPluginHolder;
 import com.dabi.habitv.plugintester.BasePluginUpdateTester;
 
 public class YoutubePluginDownloaderTest extends BasePluginUpdateTester {
+
+	@Before
+	public void disablePreflight() {
+		YtDlpRuntimeDiagnostics.setPreflightEnabled(false);
+	}
+
+	@After
+	public void restorePreflight() {
+		YtDlpRuntimeDiagnostics.setPreflightEnabled(true);
+	}
 
 	@Test
 	public void testDownload() {

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
@@ -5,6 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.util.UUID;
+
 import org.junit.Test;
 
 import com.dabi.habitv.api.plugin.exception.ExecutorFailedException;
@@ -50,6 +53,39 @@ public class YtDlpRuntimeDiagnosticsTest {
 		assertTrue(upgraded.getLastLine().contains("clear TEMP _MEI folders"));
 		assertTrue(upgraded.getLastLine().contains("replace yt-dlp.exe"));
 		assertTrue(upgraded.getLastLine().contains("run yt-dlp.exe --version"));
+	}
+
+	@Test
+	public void computeYtDlpTempDirDoesNotCreateDirectories() {
+		final File parent = new File(System.getProperty("java.io.tmpdir"),
+				"habitv-test-" + UUID.randomUUID());
+		final File binDir = new File(parent, "bin");
+		final File expectedTemp = new File(parent, "tmp" + File.separator + "yt-dlp");
+
+		final File computed = YtDlpRuntimeDiagnostics.computeYtDlpTempDir(binDir.getAbsolutePath());
+
+		assertEquals(expectedTemp.getAbsolutePath(), computed.getAbsolutePath());
+		assertFalse("compute must not create the parent directory", parent.exists());
+		assertFalse("compute must not create the temp directory", computed.exists());
+	}
+
+	@Test
+	public void runPreflightDisabledHasNoFilesystemSideEffects() {
+		final File parent = new File(System.getProperty("java.io.tmpdir"),
+				"habitv-test-" + UUID.randomUUID());
+		final File binDir = new File(parent, "bin");
+		final File expectedTemp = new File(parent, "tmp" + File.separator + "yt-dlp");
+
+		YtDlpRuntimeDiagnostics.setPreflightEnabled(false);
+		try {
+			YtDlpRuntimeDiagnostics.runPreflight("", binDir.getAbsolutePath() + File.separator + "yt-dlp",
+					binDir.getAbsolutePath());
+		} finally {
+			YtDlpRuntimeDiagnostics.setPreflightEnabled(true);
+		}
+
+		assertFalse("disabled preflight must not create the temp directory", expectedTemp.exists());
+		assertFalse("disabled preflight must not create the parent directory", parent.exists());
 	}
 
 }

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
@@ -1,0 +1,55 @@
+package com.dabi.habitv.plugin.youtube;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.exception.ExecutorFailedException;
+
+public class YtDlpRuntimeDiagnosticsTest {
+
+	private static final String PYINSTALLER_STDERR = "[PYI-17924:ERROR] Failed to extract entry: Cryptodome\\PublicKey\\_ec_ws.pyd.";
+
+	@Test
+	public void detectsPyInstallerBootstrapFailure() {
+		assertTrue(YtDlpRuntimeDiagnostics.isBootstrapExtractionFailure(PYINSTALLER_STDERR));
+	}
+
+	@Test
+	public void bootstrapUserMessageContainsRecoveryHints() {
+		final String message = YtDlpRuntimeDiagnostics.buildBootstrapFailureUserMessage("C:\\habitv\\bin\\yt-dlp.exe");
+		assertTrue(message.contains("yt-dlp failed before the download started"));
+		assertTrue(message.contains("clear TEMP _MEI folders"));
+		assertTrue(message.contains("replace yt-dlp.exe"));
+		assertTrue(message.contains("run yt-dlp.exe --version"));
+	}
+
+	@Test
+	public void genericDownloaderErrorRemainsUnclassified() {
+		final String genericError = "ERROR: unable to download video data: HTTP Error 403: Forbidden";
+		assertFalse(YtDlpRuntimeDiagnostics.isBootstrapExtractionFailure(genericError));
+		final ExecutorFailedException generic = new ExecutorFailedException("yt-dlp \"url\"", genericError,
+				genericError, null);
+		final ExecutorFailedException result = YtDlpRuntimeDiagnostics.asBootstrapFailureIfNeeded("yt-dlp \"url\"",
+				genericError, "C:\\habitv\\bin\\yt-dlp.exe", generic);
+		assertEquals(generic, result);
+		assertEquals(genericError, result.getLastLine());
+	}
+
+	@Test
+	public void asBootstrapFailureUpgradesPyInstallerOutput() {
+		final ExecutorFailedException cause = new ExecutorFailedException("yt-dlp --version", PYINSTALLER_STDERR,
+				PYINSTALLER_STDERR, null);
+		final ExecutorFailedException upgraded = YtDlpRuntimeDiagnostics.asBootstrapFailureIfNeeded("yt-dlp --version",
+				PYINSTALLER_STDERR, "C:\\habitv\\bin\\yt-dlp.exe", cause);
+		assertNotNull(upgraded);
+		assertTrue(upgraded.getLastLine().contains("yt-dlp failed before the download started"));
+		assertTrue(upgraded.getLastLine().contains("clear TEMP _MEI folders"));
+		assertTrue(upgraded.getLastLine().contains("replace yt-dlp.exe"));
+		assertTrue(upgraded.getLastLine().contains("run yt-dlp.exe --version"));
+	}
+
+}


### PR DESCRIPTION
## Summary
- Detects yt-dlp PyInstaller extraction/bootstrap failures before treating downloads as provider failures.
- Adds actionable diagnostics for corrupted yt-dlp.exe, blocked temp extraction, full TEMP drive, and stale _MEI folders.
- Documents the Windows recovery flow for replacing yt-dlp.exe and validating it with `yt-dlp.exe --version`.

## Scope
- No France.tv provider rewrite.
- No downloader architecture rewrite.
- No change to media URL extraction logic.

## Test plan
- [x] `mvn -B -ntp -DskipTests validate`
- [x] `mvn -B -ntp -pl fwk/framework,plugins/youtube -am test`

## Validation
- `mvn -B -ntp -DskipTests validate` — BUILD SUCCESS
- `mvn -B -ntp -pl fwk/framework,plugins/youtube -am test` — BUILD SUCCESS (43 tests)

## Manual recovery note
- Stop Habitv.
- Delete %TEMP%\\_MEI*.
- Replace `bin\\yt-dlp.exe` with the official latest yt-dlp.exe.
- Run `yt-dlp.exe --version`.
- Retry the France.tv URL directly, then through Habitv.

Tracker: `ytdlp-runtime-diagnostics`

Made with [Cursor](https://cursor.com)