### PR TITLE
fix(youtube): remove mkdir side-effect from diagnostics logging

### DIFF
--- a/.github/workflows/ci-maven.yml
+++ b/.github/workflows/ci-maven.yml
@@ -160,9 +160,11 @@ jobs:
       - name: Maven validate diagnostic
         run: mvn -B -ntp -DskipTests validate
 
-      # Java 11+ package diagnostics are non-blocking by design.
+      # Java 11+ package diagnostics exclude JavaFX-dependent modules until the
+      # JavaFX migration is complete (trayView and habiTv directly import the
+      # javafx.* packages bundled only in Liberica JDK 8 with jdk+fx).
       - name: Maven package diagnostic
-        run: mvn -B -ntp -DskipTests package
+        run: mvn -B -ntp -DskipTests -pl '!application/trayView,!application/habiTv' package
 
       - name: Upload Maven artifacts
         if: always()

--- a/docs/ytdlp-cli-compatibility.md
+++ b/docs/ytdlp-cli-compatibility.md
@@ -94,8 +94,8 @@ Rename-Item "$env:USERPROFILE\habitv\bin\yt-dlp.exe" "yt-dlp.exe.broken" -ErrorA
 6. Test outside Habitv:
 
 ```powershell
-$env:USERPROFILE\habitv\bin\yt-dlp.exe --version
-$env:USERPROFILE\habitv\bin\yt-dlp.exe "https://www.france.tv/france-3/nouvelle-aquitaine_la-france-en-vrai-aquitaine/8456007-oleron-la-vie-continue.html" -o "$env:USERPROFILE\habitv\Downloads\manual-francetv-test.%(ext)s" --write-sub --write-auto-sub --no-check-certificate
+& "$env:USERPROFILE\habitv\bin\yt-dlp.exe" --version
+& "$env:USERPROFILE\habitv\bin\yt-dlp.exe" "https://www.france.tv/france-3/nouvelle-aquitaine_la-france-en-vrai-aquitaine/8456007-oleron-la-vie-continue.html" -o "$env:USERPROFILE\habitv\Downloads\manual-francetv-test.%(ext)s" --write-sub --write-auto-sub --no-check-certificate
 ```
 
 7. Retry the same URL through Habitv.

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
@@ -61,7 +61,7 @@ public final class YtDlpRuntimeDiagnostics {
 		return message.toString();
 	}
 
-	public static File resolveYtDlpTempDir(final String binDir) {
+	static File computeYtDlpTempDir(final String binDir) {
 		File home = new File(binDir);
 		if (home.getName().equalsIgnoreCase("bin")) {
 			final File parent = home.getParentFile();
@@ -69,7 +69,11 @@ public final class YtDlpRuntimeDiagnostics {
 				home = parent;
 			}
 		}
-		final File tempDir = new File(home, "tmp" + File.separator + "yt-dlp");
+		return new File(home, "tmp" + File.separator + "yt-dlp");
+	}
+
+	public static File resolveYtDlpTempDir(final String binDir) {
+		final File tempDir = computeYtDlpTempDir(binDir);
 		if (!tempDir.exists() && !tempDir.mkdirs()) {
 			LOG.warn("Could not create yt-dlp temp directory: " + tempDir.getAbsolutePath());
 		}
@@ -93,16 +97,16 @@ public final class YtDlpRuntimeDiagnostics {
 			LOG.info("yt-dlp executable size bytes: " + executable.length());
 			LOG.info("yt-dlp executable last modified: " + new Date(executable.lastModified()));
 		}
-		final Map<String, String> env = buildYtDlpEnvironment(binDir);
-		LOG.info("yt-dlp process TEMP: " + env.get("TEMP"));
-		LOG.info("yt-dlp process TMP: " + env.get("TMP"));
+		final String tempPath = computeYtDlpTempDir(binDir).getAbsolutePath();
+		LOG.info("yt-dlp process TEMP: " + tempPath);
+		LOG.info("yt-dlp process TMP: " + tempPath);
 	}
 
 	public static void runPreflight(final String cmdProcessor, final String executablePath, final String binDir) {
-		logExecutableDiagnostics(executablePath, binDir);
 		if (!preflightEnabled) {
 			return;
 		}
+		logExecutableDiagnostics(executablePath, binDir);
 		final String versionCmd = executablePath + " --version";
 		final Map<String, String> env = buildYtDlpEnvironment(binDir);
 		final CmdExecutor versionExecutor = new CmdExecutor(cmdProcessor, versionCmd, 1000) {

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
@@ -5,6 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.util.UUID;
+
 import org.junit.Test;
 
 import com.dabi.habitv.api.plugin.exception.ExecutorFailedException;
@@ -50,6 +53,39 @@ public class YtDlpRuntimeDiagnosticsTest {
 		assertTrue(upgraded.getLastLine().contains("clear TEMP _MEI folders"));
 		assertTrue(upgraded.getLastLine().contains("replace yt-dlp.exe"));
 		assertTrue(upgraded.getLastLine().contains("run yt-dlp.exe --version"));
+	}
+
+	@Test
+	public void computeYtDlpTempDirDoesNotCreateDirectories() {
+		final File parent = new File(System.getProperty("java.io.tmpdir"),
+				"habitv-test-" + UUID.randomUUID());
+		final File binDir = new File(parent, "bin");
+		final File expectedTemp = new File(parent, "tmp" + File.separator + "yt-dlp");
+
+		final File computed = YtDlpRuntimeDiagnostics.computeYtDlpTempDir(binDir.getAbsolutePath());
+
+		assertEquals(expectedTemp.getAbsolutePath(), computed.getAbsolutePath());
+		assertFalse("compute must not create the parent directory", parent.exists());
+		assertFalse("compute must not create the temp directory", computed.exists());
+	}
+
+	@Test
+	public void runPreflightDisabledHasNoFilesystemSideEffects() {
+		final File parent = new File(System.getProperty("java.io.tmpdir"),
+				"habitv-test-" + UUID.randomUUID());
+		final File binDir = new File(parent, "bin");
+		final File expectedTemp = new File(parent, "tmp" + File.separator + "yt-dlp");
+
+		YtDlpRuntimeDiagnostics.setPreflightEnabled(false);
+		try {
+			YtDlpRuntimeDiagnostics.runPreflight("", binDir.getAbsolutePath() + File.separator + "yt-dlp",
+					binDir.getAbsolutePath());
+		} finally {
+			YtDlpRuntimeDiagnostics.setPreflightEnabled(true);
+		}
+
+		assertFalse("disabled preflight must not create the temp directory", expectedTemp.exists());
+		assertFalse("disabled preflight must not create the parent directory", parent.exists());
 	}
 
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #76 addressing the remaining code-quality items the user flagged.

- `runPreflight` returns early before any diagnostics work when the static `preflightEnabled` flag is off, so the existing `setPreflightEnabled(false)` test scaffolding no longer touches the filesystem.
- New `computeYtDlpTempDir` pure helper used by `logExecutableDiagnostics`, so just logging never calls `mkdirs()`. `buildYtDlpEnvironment` (called at process launch) still ensures the directory exists.
- Compatibility-java package step skips `application/trayView` and `application/habiTv`, the two modules that import `javafx.*`. Temurin JDK 11+ has no `jdk+fx` bundle and these modules failed every PR — they now stop reporting a false-failure check.
- PowerShell recovery commands in `docs/ytdlp-cli-compatibility.md` use the `& "path"` invocation form so paths expanding to values with spaces still execute.
- Two new unit tests pin the no-side-effect contract for `computeYtDlpTempDir` and disabled-preflight `runPreflight`.

## Test plan

- [x] `mvn -B -ntp -DskipTests -pl '!application/trayView,!application/habiTv' package` (mirrors new compatibility-java step) — BUILD SUCCESS on JDK 21
- [x] `mvn -B -ntp -pl plugins/youtube -am test -Dtest=YtDlpRuntimeDiagnosticsTest,YoutubePluginDownloaderCmdTest,YoutubePluginDownloaderTest -Dsurefire.failIfNoSpecifiedTests=false` — 12/12 tests pass

## Notes

- Targets the PR #76 branch (`fix/ytdlp-runtime-healthcheck`) so merging here folds these fixes back into PR #76.
- The 3 Copilot review threads on PR #76 are already resolved upstream; no further action there.

https://claude.ai/code/session_01PV5EufgDSdCquZJCio8Pxv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PV5EufgDSdCquZJCio8Pxv)_