### PR TITLE
docs: refresh project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ contributions follow a stricter-than-usual workflow.
 > - [`docs/dev-plan.md`](docs/dev-plan.md) — phased modernization plan
 > - [`docs/dev-tracker.md`](docs/dev-tracker.md) — active work items
 > - [`docs/decision-log.md`](docs/decision-log.md) — accepted architecture decisions
+> - [`docs/automatic-category-download.md`](docs/automatic-category-download.md) — category watch / index behavior
+> - [`docs/ci.md`](docs/ci.md) — CI required vs diagnostic checks
 
 ---
 
@@ -84,7 +86,7 @@ Stronger goals are only safe for explicitly scoped modules.
 | `mvn -B -ntp -DskipTests compile` | 🟢 safe on `develop` since `own-version-deps-align` | Always |
 | `mvn -B -ntp -DskipTests package` | 🟡 scoped only | `-pl '!application/trayView,!application/habiTv'` |
 | `mvn -B -ntp test` | 🟠 network-dependent tests flap | Scoped per-module; document results |
-| `mvn -B -ntp verify` | ⛔ not safe yet | Wait for `java8-baseline` test-lifecycle work |
+| `mvn -B -ntp verify` | ⛔ not safe yet | Dedicated test-lifecycle tracker work |
 
 Always quote the **exact command output** in your PR body.
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ reactor.
 | Topic | Current state |
 |-------|----------------|
 | Integration branch | [`develop`](https://github.com/Mika3578/habitv/tree/develop) |
-| Java baseline | **Java 8** (Temurin/Zulu 8 in CI) — required for JAXB 2.x and JavaFX 2.x |
+| Java baseline | **Java 8** — CI uses Zulu 8 for legacy validate, Liberica 8 `jdk+fx` for Maven CI Java 8 jobs, and Temurin 8 in the `master`-only legacy build |
 | Root `mvn validate` / `mvn compile` | Works on `develop` |
-| Full `mvn package` (GUI) | Blocked on JavaFX / `jdk.home` — use scoped builds (see below) |
+| Full `mvn package` (GUI) | Works with a JDK 8 that includes JavaFX; platform packaging modules use separate `jdk.home` setup |
 | Artifact / plugin updates | HTTPS static repo ([`habitv-repo`](https://github.com/Mika3578/habitv-repo)) — legacy `dabiboo.free.fr` removed |
 | Provider plugins | Mixed: some work offline; many replay sites changed — see [provider inventory](docs/provider-inventory.md) |
 
@@ -69,7 +69,7 @@ Runtime layout and manual download: [`docs/runtime-quickstart.md`](docs/runtime-
 |---------|---------------------|--------|
 | `mvn -B -ntp -DskipTests validate` | Safe, default | 33 reactor modules |
 | `mvn -B -ntp -DskipTests compile` | Safe | Java 8 only |
-| `mvn -B -ntp -DskipTests package` | Scoped | Exclude `trayView`, `habiTv` unless JavaFX is set up |
+| `mvn -B -ntp -DskipTests package` | Java 8 + JavaFX | Requires a JDK 8 with JavaFX for GUI modules; use scoped builds for console-only validation |
 | `mvn -B -ntp test` | Partial | Live `*PluginManagerTest` excluded by default |
 | `mvn -B -ntp test -Plive-provider-tests` | Opt-in | Hits real broadcaster networks |
 | `mvn -B -ntp verify` | Not safe yet | Full lifecycle still gated |

--- a/README.md
+++ b/README.md
@@ -1,46 +1,171 @@
-# habivt
+# Habitv
 
-habiTv est un logiciel permettant de télécharger automatiquement et régulièrement des vidéos sur les sites de Replay TV.
+Habitv is a legacy **Java 8 / Maven** application that automatically watches
+French TV replay (catch-up) sites and downloads new episodes in the background.
+The project is in a **controlled modernization restart**: build and governance
+are being restored first; provider endpoints and the JavaFX GUI trail the core
+reactor.
 
-Le but étant de ne pas avoir à télécharger puis exporter manuellement via une interface graphique des vidéos disponibles régulièrement sur le Replay mais que tout soit géré automatiquement en tâche de fond. 
+| Topic | Current state |
+|-------|----------------|
+| Integration branch | [`develop`](https://github.com/Mika3578/habitv/tree/develop) |
+| Java baseline | **Java 8** (Temurin/Zulu 8 in CI) — required for JAXB 2.x and JavaFX 2.x |
+| Root `mvn validate` / `mvn compile` | Works on `develop` |
+| Full `mvn package` (GUI) | Blocked on JavaFX / `jdk.home` — use scoped builds (see below) |
+| Artifact / plugin updates | HTTPS static repo ([`habitv-repo`](https://github.com/Mika3578/habitv-repo)) — legacy `dabiboo.free.fr` removed |
+| Provider plugins | Mixed: some work offline; many replay sites changed — see [provider inventory](docs/provider-inventory.md) |
 
+---
 
-Avec habiTv, vous spécifiez les séries/documentaires/programmes que vous souhaitez récupérer et habiTv vérifie régulièrement si de nouveaux épisodes sont disponibles, si c'est le cas il les télécharge.
+## What Habitv does (runtime)
 
-Il est ensuite possible de spécifier une série de commande à exécuter dès qu'un épisode est disponible pour par exemple l'exporter vers un support (encodage de la vidéo, transfert FTP, rangement, ...).
+- **Modular plugins**: provider plugins list categories and episodes; downloader
+  and exporter plugins wrap external tools (`yt-dlp`, `curl`, `ffmpeg`, etc.).
+- **Automatic category watch**: categories you mark as selected are scanned on a
+  schedule; only **new** episodes (per category index) are downloaded after the
+  first baseline scan. See [automatic category download](docs/automatic-category-download.md).
+- **Interfaces**: tray/GUI (`application/habiTv`, `trayView`) and CLI
+  (`application/consoleView`). The **console fat-jar** is the supported
+  modernization baseline today; JavaFX packaging is tracked separately.
 
- 
+---
 
-habiTv est utilisable de 2 manières : 
+## Quick start (developers)
 
-    IHM : IHM
-        habiTv propose une interface visuelle pour sélectionner les programmes à télécharger et suivre les téléchargements
-        habiTv se loge dans la barre des tâches et affiche des notifications pour prévenir qu'un nouvel épisode est téléchargé
-    CLI : CLI
-        habiTv propose plusieurs paramètres pour rechercher et télécharger des épisodes en ligne de commande
-        habiTv peut se lancer en mode démon depuis la ligne de commande et log dans un fichier
+**Prerequisites:** JDK 8, Maven 3.6+, Git.
 
- 
+```bash
+git clone https://github.com/Mika3578/habitv.git
+cd habitv
+git checkout develop
+mvn -B -ntp -DskipTests validate
+```
 
-Il supporte actuellement les fournisseurs suivant : 
+Default safe validation (also required in CI):
 
-    canalPlus
-    francetv  (france.tv — France 2, 3, 4, 5, O)
-    arte
-    D8
-    D17
-    nrj12
-    lequipe.fr
-    beinsport
-    tf1
-    RSS : n'importe quel flux RSS contenant des liens vers des vidéos à télécharger (HTTP, FTP, Bittorent, Youtube, Dailymotion ...)
+```bash
+mvn -B -ntp -DskipTests validate
+```
 
-habiTv est développé en Java 1.7, il se base sur différents outils externes pour réaliser le téléchargement (youtube-dl, rtmpDump, curl, aria2c). Il est personnalisable grâce à un système de plugin : 
+Full reactor compile (Java 8):
 
-    plugin de fournisseur de contenu (arte, canalPlus) : ils listent les catégories disponibles et gèrent le téléchargement des épisodes
-    plugin de téléchargement (rtmpDump, curl, aria2c) : encapsule les utilitaires de téléchargement pour une meilleure interaction avec habiTv.
-    plugin d'export (ffmpeg, curl) : améliore l'interaction entre les utilitaires permettant d'exporter les vidéos et habiTv
+```bash
+mvn -B -ntp -DskipTests compile
+```
 
- 
+Runnable console package (excludes JavaFX GUI modules):
 
-habiTv est actuellement développé et testé sous Windows et linux.
+```bash
+mvn -B -ntp -DskipTests -pl '!application/trayView,!application/habiTv' package
+```
+
+Runtime layout and manual download: [`docs/runtime-quickstart.md`](docs/runtime-quickstart.md).
+
+---
+
+## Build and test matrix
+
+| Command | Status on `develop` | Notes |
+|---------|---------------------|--------|
+| `mvn -B -ntp -DskipTests validate` | Safe, default | 33 reactor modules |
+| `mvn -B -ntp -DskipTests compile` | Safe | Java 8 only |
+| `mvn -B -ntp -DskipTests package` | Scoped | Exclude `trayView`, `habiTv` unless JavaFX is set up |
+| `mvn -B -ntp test` | Partial | Live `*PluginManagerTest` excluded by default |
+| `mvn -B -ntp test -Plive-provider-tests` | Opt-in | Hits real broadcaster networks |
+| `mvn -B -ntp verify` | Not safe yet | Full lifecycle still gated |
+
+CI parity: [`docs/ci.md`](docs/ci.md).
+
+### Known build constraints
+
+- **Java 8 only** for this phase — no Java 9+ language features or APIs.
+- **JAXB**: configuration/grabconfig types are generated under
+  `target/generated-sources/jaxb` in `application/core` (see tracker
+  `jaxb-launcher-recovery`).
+- **JavaFX**: `application/habiTv`, `trayView`, and out-of-reactor
+  `habiTv-linux` / `habiTv-windows` expect JDK 8 with `jfxrt.jar` (tracker
+  `javafx-modernization`).
+- **Legacy HTTP repo** (`dabiboo.free.fr`, FTP deploy, SVN SCM): removed from
+  active POMs; history in [`docs/audit-master-baseline.md`](docs/audit-master-baseline.md).
+
+---
+
+## Runtime and updates
+
+- Plugin JARs and tool binaries are published to
+  **`https://mika3578.github.io/habitv-repo/repository/`** (see
+  [`docs/static-repository-deploy.md`](docs/static-repository-deploy.md)).
+- Updates are **on by default** at startup; disable with
+  `-Dhabitv.update.enabled=false` or configuration.
+- **SNAPSHOT / timestamped** plugin artifacts: default runtime config allows
+  snapshot resolution; see [`docs/runtime-quickstart.md`](docs/runtime-quickstart.md).
+- Telemetry to legacy hosts is **opt-in** (`habitv.stat.enabled`).
+
+---
+
+## Provider landscape (summary)
+
+Replay sites change often. Treat README-era names as **legacy labels**:
+
+| Legacy name | Modern meaning / module |
+|-------------|-------------------------|
+| Pluzz | France Télévisions / France.tv — module `plugins/francetv` (rename grab-config `pluzz` → `francetv`) |
+| D8 / D17 | Canal-era channels — embedded in `plugins/canalPlus` (obsolete endpoints) |
+| 6play | M6+ / M6 replay area — `plugins/6play` (needs rewrite) |
+| NRJ12 | Historical reference only — no module in reactor |
+
+Full table, fixture policy, and follow-up queue:
+[`docs/provider-inventory.md`](docs/provider-inventory.md).
+
+---
+
+## Contributing
+
+1. Branch from latest **`develop`** (`docs/…`, `fix/…`, `feat/…`, etc.).
+2. One tracker item per PR — see [`docs/dev-tracker.md`](docs/dev-tracker.md).
+3. [Conventional Commits](https://www.conventionalcommits.org/) in English.
+4. Run validation; paste **exact command output** in the PR body.
+5. Keep PRs small; linear history (no merge commits on feature branches).
+
+Details: [`CONTRIBUTING.md`](CONTRIBUTING.md), [`AGENTS.md`](AGENTS.md),
+[`docs/pull-request-style-guide.md`](docs/pull-request-style-guide.md).
+
+---
+
+## Documentation map
+
+| Document | Purpose |
+|----------|---------|
+| [`docs/dev-plan.md`](docs/dev-plan.md) | Phased modernization roadmap |
+| [`docs/dev-tracker.md`](docs/dev-tracker.md) | Work items (mirror: `dev-tracker.json`) |
+| [`docs/automatic-category-download.md`](docs/automatic-category-download.md) | Category watch, index, deduplication limits |
+| [`docs/runtime-quickstart.md`](docs/runtime-quickstart.md) | Console runtime, flags, yt-dlp |
+| [`docs/static-repository-deploy.md`](docs/static-repository-deploy.md) | `habitv-repo` publish contract |
+| [`docs/provider-inventory.md`](docs/provider-inventory.md) | Plugin modules and status |
+| [`docs/ci.md`](docs/ci.md) | GitHub Actions required vs diagnostic checks |
+| [`docs/repository-maintenance.md`](docs/repository-maintenance.md) | Merge hygiene, Dependabot, doc sync |
+| [`docs/risk-register.md`](docs/risk-register.md) | Active risks |
+| [`docs/decision-log.md`](docs/decision-log.md) | ADRs |
+| [`docs/audit-master-baseline.md`](docs/audit-master-baseline.md) | **Historical** pre-restart audit snapshot |
+| [`docs/ytdlp-cli-compatibility.md`](docs/ytdlp-cli-compatibility.md) | yt-dlp CLI contract |
+| [`SECURITY.md`](SECURITY.md) | Vulnerability reporting |
+
+---
+
+## Known limitations
+
+- Many provider plugins target **obsolete URLs or HTML layouts**; live tests may
+  fail even when the build is green.
+- Category deduplication uses **episode display names** in index files — title
+  changes can re-download; duplicate names can false-skip (see
+  [`docs/automatic-category-download.md`](docs/automatic-category-download.md)).
+- GUI packaging (`habiTv`, platform installers) is not yet aligned with the
+  modernized reactor baseline.
+- `youtube-dl` is deprecated in favor of **yt-dlp** (`ytdlp-migration` tracker).
+
+---
+
+## License
+
+No explicit license file yet — treat sources as proprietary until the
+maintainer adds a license. See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/docs/audit-master-baseline.md
+++ b/docs/audit-master-baseline.md
@@ -1,5 +1,11 @@
 # Habitv master baseline audit
 
+> **Historical document** — snapshot of the repository at the `master` tip when
+> modernization restarted (`gov-bootstrap` / HBTV-000). Many items below are
+> **already fixed on `develop`** (reactor wiring, Java 8, legacy URL removal,
+> static repo). For current status use [`README.md`](../README.md),
+> [`dev-plan.md`](dev-plan.md), and [`dev-tracker.md`](dev-tracker.md).
+
 Initial audit of the repository at the `master` tip from which the
 restart-from-master modernization begins. Captured during the
 HBTV-000 bootstrap PR.

--- a/docs/automatic-category-download.md
+++ b/docs/automatic-category-download.md
@@ -1,0 +1,65 @@
+# Automatic category watch and download
+
+This document describes how Habitv decides which replay episodes to download
+when categories are selected for automatic watching. It reflects the current
+implementation in `application/core` (`SearchTask`, `DownloadedDAO`).
+
+---
+
+## Behavior overview
+
+1. **Selected categories** — In the grab configuration, categories marked
+   selected (`category.isSelected()`) and downloadable are scanned on the search
+   task schedule (daemon interval from `configuration.xml`, e.g.
+   `demonCheckTime`).
+2. **Provider listing** — Each scan calls the provider plugin to list episodes
+   for the category (`provider.findEpisode(category)`).
+3. **Index file** — Per category, Habitv maintains a text index under the
+   downloader index directory:
+   - `{plugin}_{categoryName}.index` — automatic downloads
+   - `{plugin}_{categoryName}_manual.index` — manual download path when used
+4. **First scan (no index yet)** — If the index file does not exist, the scan
+   **does not enqueue downloads** for episodes found on that run. It only
+   records episode **names** into the index (baseline). This avoids backfilling
+   the entire catalogue history on first enable.
+5. **Later scans (index exists)** — Episodes whose names are **not** already in
+   the index (and pass include/exclude filters, and are not in the error list)
+   are queued for download. Successfully processed names stay in the index.
+
+Relevant logic: `SearchTask.findEpisodesByCategory` and `DownloadedDAO`.
+
+---
+
+## Deduplication model
+
+| Aspect | Current behavior |
+|--------|------------------|
+| Key used | Episode **display name** (`EpisodeDTO.getName()`), one line per name in the index file |
+| Not used | Stable provider episode IDs, canonical URLs, or content hashes |
+| Error list | Separate `DlErrorDAO` tracks failed downloads by a derived full name |
+
+---
+
+## Known limitations
+
+- **Title changes** — If a broadcaster renames an episode, Habitv treats it as
+  a new episode and may download again.
+- **Duplicate names** — Two distinct episodes with the same display name in one
+  category can cause a false skip (second never downloaded).
+- **Deleting an index** — Removing `{plugin}_{category}.index` resets behavior to
+  “first scan” mode: the next successful scan rebuilds the baseline without
+  downloading existing catalogue entries on that pass.
+- **Manual vs automatic index** — Manual downloads can use a separate
+  `_manual.index`; merging behavior is handled when both exist (`DownloadedDAO`).
+
+**Planned improvement (not implemented):** deduplicate by provider episode id
+and/or canonical URL in addition to display name.
+
+---
+
+## Related configuration
+
+- Search/retrieve/download thread counts: `taskDefinition` in
+  `configuration.xml`.
+- Daemon check interval: `downloadConfig/demonCheckTime`.
+- Runtime quickstart (CLI daemon): [`runtime-quickstart.md`](runtime-quickstart.md).

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,26 +2,32 @@
 
 ## Baseline and intent
 
-- Java 8 is the current required baseline for merge-blocking checks.
-- Java 11, 17, 21, and 25 are diagnostic compatibility checks only.
-- Java 11+ may fail until JAXB and JavaFX migration is complete.
-- No deployment, credentials, publishing, or auto-merge behavior is part of this workflow set.
+- **Java 8** is the required compile and merge baseline for `develop`.
+- Java 11, 17, 21, and 25 jobs are **diagnostic only** (may fail until JAXB and
+  JavaFX migration completes).
+- No deployment, credential publishing, or auto-merge from bots.
 
-## Workflow coverage
+## Workflows
 
-Workflow: `.github/workflows/ci-maven.yml` (`Maven CI`)
+| Workflow | File | Role |
+|----------|------|------|
+| CI | `.github/workflows/ci.yml` | Legacy required check: `CI / validate (zulu-8)` |
+| Maven CI | `.github/workflows/ci-maven.yml` | PR validation: validate, deterministic tests, package |
+| Build | `.github/workflows/build.yml` | Additional build coverage |
+| Dependency Review | `.github/workflows/dependency-review.yml` | Blocks new high/critical dependency issues on PRs |
+| CodeQL | (repository default setup) | Code scanning alerts |
+| Labeler | `.github/workflows/labeler.yml` | Path-based PR labels (not required) |
+| Stale | `.github/workflows/stale.yml` | Inactivity labels (no auto-close) |
 
-### Required checks (branch protection)
+### Required checks today
 
-Current required check for `develop` remains:
+Branch protection on `develop` currently requires:
 
-- `CI / validate (zulu-8)` (from `.github/workflows/ci.yml`)
+- `CI / validate (zulu-8)` from `.github/workflows/ci.yml`
 
-The `Maven CI` workflow is additive in this PR. It does not supersede the
-existing required `CI` check until repository governance and the ruleset are
-updated together.
+### Planned required checks (after ruleset update)
 
-After that governance/ruleset update, require:
+When governance catches up (`branch-protection` tracker item), require:
 
 - `Maven CI / validate-java8`
 - `Maven CI / deterministic-tests-java8`
@@ -30,37 +36,34 @@ After that governance/ruleset update, require:
 
 ### Diagnostic checks (do not require)
 
-Do not require:
+- `Maven CI / compatibility-java11` (and 17, 21, 25)
+- `Maven CI / full-test-suite` (workflow_dispatch / schedule only)
 
-- `Maven CI / compatibility-java11`
-- `Maven CI / compatibility-java17`
-- `Maven CI / compatibility-java21`
-- `Maven CI / compatibility-java25`
-- `Maven CI / full-test-suite`
+## Live network tests
 
-## Security workflows
+Default `mvn test` **excludes** live provider tests (`*PluginManagerTest`, etc.).
+Use opt-in profile:
 
-- `Dependency Review` (`.github/workflows/dependency-review.yml`) runs on pull
-  requests and fails when newly introduced dependencies have `high` or
-  `critical` vulnerabilities.
-- `CodeQL` default setup runs as repository code scanning and reports alerts in
-  GitHub code scanning.
+```bash
+mvn -B -ntp test -Plive-provider-tests
+```
 
-## Maintenance automation workflows
+Prefer offline fixture tests for provider changes; quarantine or replace live
+tests over time (`provider-inventory`, `live-tests-flaky` risk).
 
-- `Dependabot` (`.github/dependabot.yml`) opens pull requests for Maven and
-  GitHub Actions updates on a weekly schedule.
-- `Pull request labeler` (`.github/workflows/labeler.yml`) applies labels by
-  changed file paths.
-- `Stale triage` (`.github/workflows/stale.yml`) labels inactive issues and
-  pull requests without auto-closing them.
+## Maintenance automation
 
-Labeler and stale triage are operational helpers and are not required status
-checks for merging.
+- **Dependabot** (`.github/dependabot.yml`) — weekly Maven and GitHub Actions
+  update PRs; semver-major ignored; no auto-merge.
+- **Dependency Review** — fails PRs that introduce new high/critical vulns in
+  dependencies.
+- **CodeQL** — separate from Maven CI.
+
+Details: [`repository-maintenance.md`](repository-maintenance.md).
 
 ## Local command parity
 
-Run the same required Java 8 commands locally:
+Run the same Java 8 commands locally before opening a PR:
 
 ```bash
 mvn -B -ntp -DskipTests validate
@@ -68,57 +71,7 @@ mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am
 mvn -B -ntp -DskipTests package
 ```
 
-## Validation results
+Paste **exact** command output in the PR body (exit code and relevant lines).
 
-### Command: `mvn -B -ntp -DskipTests validate`
-
-Exit status: `0`
-
-Relevant output excerpt:
-
-```text
-[INFO] Scanning for projects...
-[INFO] ------------------------------------------------------------------------
-[INFO] Reactor Build Order:
-[INFO] ...
-[INFO] ------------------------------------------------------------------------
-[INFO] BUILD SUCCESS
-[INFO] ------------------------------------------------------------------------
-```
-
-### Command: `mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am test`
-
-Exit status: `0`
-
-Relevant output excerpt:
-
-```text
-[INFO] Scanning for projects...
-[INFO] ------------------------------------------------------------------------
-[INFO] Reactor Build Order:
-[INFO] ...
-[INFO] ------------------------------------------------------------------------
-[INFO] BUILD SUCCESS
-[INFO] ------------------------------------------------------------------------
-```
-
-### Command: `mvn -B -ntp -DskipTests package`
-
-Exit status: `0`
-
-Relevant output excerpt:
-
-```text
-[INFO] Scanning for projects...
-[INFO] ------------------------------------------------------------------------
-[INFO] Reactor Build Order:
-[INFO] ...
-[INFO] ------------------------------------------------------------------------
-[INFO] BUILD SUCCESS
-[INFO] ------------------------------------------------------------------------
-```
-
-If one of these commands fails because of a pre-existing baseline blocker
-that reproduces on latest `develop` and is unrelated to this CI workflow or
-documentation change, record the exact failing command, exit status, and
-relevant error excerpt here and in the pull request body.
+If a command fails on latest `develop` for a reason unrelated to your change,
+document the failure honestly in the PR and link the tracker/risk item.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,9 +11,9 @@
 
 | Workflow | File | Role |
 |----------|------|------|
-| CI | `.github/workflows/ci.yml` | Legacy required check: `CI / validate (zulu-8)` |
-| Maven CI | `.github/workflows/ci-maven.yml` | PR validation: validate, deterministic tests, package |
-| Build | `.github/workflows/build.yml` | Additional build coverage |
+| CI | `.github/workflows/ci.yml` | Legacy required check for `develop`: `CI / validate (zulu-8)` |
+| Maven CI | `.github/workflows/ci-maven.yml` | `develop` PR validation: validate, deterministic tests, package |
+| Build | `.github/workflows/build.yml` | Legacy `master` push/PR coverage only; not part of the `develop` merge baseline |
 | Dependency Review | `.github/workflows/dependency-review.yml` | Blocks new high/critical dependency issues on PRs |
 | CodeQL | (repository default setup) | Code scanning alerts |
 | Labeler | `.github/workflows/labeler.yml` | Path-based PR labels (not required) |

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -1,9 +1,15 @@
 # 🗺️ Habitv Development Plan
 
-High-level phased roadmap for restarting Habitv modernization from
-`master`. Each phase is delivered by one or more small PRs tied to
-[`dev-tracker.md`](dev-tracker.md). No phase is allowed to bundle
-work from a later phase.
+High-level phased roadmap for the Habitv modernization restart.
+**Integration branch:** `develop` (PR-based, linear history on feature
+branches). Each phase is delivered by one or more small PRs tied to
+[`dev-tracker.md`](dev-tracker.md). No phase is allowed to bundle work from a
+later phase.
+
+> **Legacy vs current** — Phases 0–4 removed obsolete Dabiboo/free.fr Maven
+> and runtime URLs; active work is Phases 5–7 (yt-dlp, providers, JavaFX).
+> Historical pre-restart findings live in
+> [`audit-master-baseline.md`](audit-master-baseline.md) (snapshot only).
 
 ---
 
@@ -135,9 +141,9 @@ Remaining: live fixture validation, `habitv-repo` `yt-dlp` tool zip publication.
   and parsable (offline against captured fixtures, not live).
 - Mark obsolete or renamed providers with a deprecation plan and
   dedicated removal PRs.
-- Baseline classification doc added at `docs/provider-inventory.md`;
-  offline fixture policy + first local fixture baseline added for
-  `6play`, `canalPlus`, `pluzz`, `arte`, and `youtube`.
+- Baseline classification doc at `docs/provider-inventory.md`;
+  offline fixture baseline for `6play`, `canalPlus`, `francetv` (ex
+  `pluzz`), `arte`, and `youtube`.
 
 **Tracker** — `provider-inventory`.
 

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -181,12 +181,12 @@
         "docs/provider-inventory.md updated with an offline fixture policy and baseline.",
         "mvn -B -ntp -pl plugins/6play -am -Dtest=SixPlayOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test",
         "mvn -B -ntp -pl plugins/canalPlus -am -Dtest=CanalPlusOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test",
-        "mvn -B -ntp -pl plugins/pluzz -am -Dtest=PluzzOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test",
+        "mvn -B -ntp -pl plugins/francetv -am -Dtest=FranceTvOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test",
         "mvn -B -ntp -pl plugins/arte -am -Dtest=ArteOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test",
         "mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test"
       ],
       "pr": "test/provider-offline-fixture-baseline (this PR)",
-      "notes": "Inventory baseline from PR #50 is extended with an offline fixture policy and first local fixture metadata/tests for 6play, canalPlus, pluzz, arte, and youtube. Arte live PluginManagerTest fails (categorie liste vide) — documented as provider drift; repair in dedicated provider PR. Default Surefire excludes *PluginManagerTest; offline fixture baselines stay enabled. No provider rewrite, plugin removal, runtime updater change, yt-dlp migration, JavaFX modernization, or Maven publication layout change in inventory-only work."
+      "notes": "Inventory baseline from PR #50 extended with offline fixture policy and tests for 6play, canalPlus, francetv (ex pluzz), arte, and youtube. docs/provider-inventory.md includes current-status table and legacy naming (Pluzz, D8/D17, 6play). Arte live PluginManagerTest fails (categorie liste vide) — provider drift. Default Surefire excludes *PluginManagerTest. See docs/automatic-category-download.md for runtime watch behavior."
     },
     {
       "id": "ytdlp-migration",
@@ -295,7 +295,7 @@
         "mvn -B -ntp -DskipTests compile -> BUILD SUCCESS (33 modules)"
       ],
       "pr": "build: align own-version plugin internal dependencies (#33)",
-      "notes": "Own-version plugin modules (beinsport, footyroom, pluzz, ffmpeg) now use ${project.parent.version} for shared internal dependencyManagement coordinates. Risk legacy-maven-repo mitigated for local reactor compilation (external publication still pending legacy-url-migration)."
+      "notes": "Own-version plugin modules (beinsport, footyroom, francetv, ffmpeg) now use ${project.parent.version} for shared internal dependencyManagement coordinates. Risk legacy-maven-repo mitigated for local reactor compilation."
     },
     {
       "id": "youtube-apikey",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -14,6 +14,9 @@
 
 **Last refresh:** 2026-05-20 · **Active branch:** `develop`
 
+**Documentation entry point:** [`README.md`](../README.md) (overview, build matrix,
+automatic category behavior, provider summary, doc map).
+
 ---
 
 ## 📊 Overall progress
@@ -314,7 +317,7 @@ renamed, broken parser). No code removal in this item.
 docs/provider-inventory.md updated with offline fixture policy and baseline
 mvn -B -ntp -pl plugins/6play -am -Dtest=SixPlayOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test
 mvn -B -ntp -pl plugins/canalPlus -am -Dtest=CanalPlusOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test
-mvn -B -ntp -pl plugins/pluzz -am -Dtest=PluzzOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -B -ntp -pl plugins/francetv -am -Dtest=FranceTvOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test
 mvn -B -ntp -pl plugins/arte -am -Dtest=ArteOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test
 mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test
 ```
@@ -325,13 +328,14 @@ mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeOfflineFixtureBaselineTest -Ds
 [`provider-inventory.md`](provider-inventory.md) for every plugin module
 plus historical references (`D8`, `D17`, `nrj12`, FranceTV/Pluzz,
 Kewego). An offline fixture policy and first local fixture baseline are
-now documented for `6play`, `canalPlus`, `pluzz`, `arte`, and `youtube`
+now documented for `6play`, `canalPlus`, `francetv` (ex `pluzz`), `arte`, and `youtube`
 without rewriting providers. Default `mvn test` skips live
 `*PluginManagerTest`; use `-Plive-provider-tests`. Arte live test
 currently fails (`categorie liste vide`) — provider drift, documented in
 inventory. This item remains open for broader fixture capture and
-dedicated cleanup/rewrite PRs. Risks `live-tests-flaky`,
-`provider-endpoints-dead`.
+dedicated cleanup/rewrite PRs. See also
+[`automatic-category-download.md`](automatic-category-download.md).
+Risks `live-tests-flaky`, `provider-endpoints-dead`.
 
 ---
 
@@ -498,7 +502,7 @@ mvn -B -ntp -DskipTests compile      # BUILD SUCCESS (33 modules)
 **Related PR** · `build: align own-version plugin internal dependencies` (#33)
 
 **Notes** — Own-version plugin modules (`beinsport`, `footyroom`,
-`pluzz`, `ffmpeg`) now use `${project.parent.version}` for shared
+`francetv`, `ffmpeg`) now use `${project.parent.version}` for shared
 internal dependencyManagement coordinates. Risk `legacy-maven-repo`
 mitigated for local reactor compilation (external publication still
 pending `legacy-url-migration`).

--- a/docs/provider-inventory.md
+++ b/docs/provider-inventory.md
@@ -1,7 +1,42 @@
 # 🔌 Provider and plugin inventory (HBTV-006)
 
 **Tracker item**: `provider-inventory` (`HBTV-006`)  
-**Scope in this PR**: documentation, classification, and offline fixture baseline (no module removal, no provider rewrite, no runtime behavior change)
+**Status:** in progress (~55%) — inventory and offline fixtures; rewrites are
+separate PRs per module.
+
+---
+
+## Current status and future work
+
+| Area | Status | Next steps |
+|------|--------|------------|
+| Reactor / build | All listed modules compile in the Maven reactor | Keep `mvn validate` green |
+| `francetv` (ex Pluzz) | **Keep** — France.tv mobile API + yt-dlp download | Migrate user grab-config `pluzz` → `francetv` |
+| `youtube` | **Keep** — yt-dlp binary contract (see `ytdlp-migration`) | Publish `yt-dlp` tool zip to `habitv-repo` |
+| `arte`, `6play`, `lequipe`, … | **Needs rewrite** or live drift | Fixture-first parser PRs |
+| `canalPlus` (+ embedded D8/D17) | **Obsolete** Canal-era endpoints | Dedicated canal-family rewrite |
+| `wat`, `beinsport`, `clubic`, `footyroom` | **Obsolete** branding/URLs | Deprecation or rewrite PRs |
+| `nrj12` | **Not in reactor** | Historical README name only |
+| Live `*PluginManagerTest` | Quarantined (`-Plive-provider-tests`) | Replace with offline fixtures over time |
+
+**Legacy naming (docs and old configs):**
+
+- **Pluzz** → treat as **France Télévisions / France.tv**; module is
+  `plugins/francetv`.
+- **D8 / D17** → legacy Canal+ channel plugins inside `plugins/canalPlus`, not
+  standalone modules.
+- **6play** → legacy M6 branding; module `plugins/6play` targets old `6play.fr`
+  (modern M6+ replay is a future rewrite target).
+
+Unsupported or obsolete providers stay **documented** here until a dedicated
+deprecation PR removes them (tracker + risk register), never silently dropped.
+
+---
+
+## Inventory scope (baseline PR)
+
+Documentation, classification, and offline fixture baseline — no module removal,
+no provider rewrite, no runtime behavior change in inventory-only work.
 
 ---
 

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -1,63 +1,85 @@
 # Repository maintenance
 
-Day-to-day maintenance tasks for the Habitv repository: merge hygiene,
-documentation sync, and contributor-facing metadata.
+Day-to-day maintenance for the Habitv repository: branching, merge hygiene,
+documentation sync, and automation expectations.
+
+## Branch model
+
+| Branch | Role |
+|--------|------|
+| `develop` | Integration line for modernization — **branch from here** |
+| `master` | Stable baseline snapshot |
+| `feature/*`, `fix/*`, `docs/*`, `build/*`, `ci/*`, … | Short-lived topic branches |
+
+Modernization PRs target **`develop`** with linear history (no merge commits on
+the feature branch). Squash merge to `develop` with a cleaned title/body (see
+below).
+
+## Contributor workflow
+
+1. Sync to latest `develop`.
+2. Pick or add a tracker item in [`dev-tracker.md`](dev-tracker.md).
+3. Keep the PR scoped to **one** logical change / tracker item.
+4. Use [Conventional Commits](https://www.conventionalcommits.org/) in English.
+5. Run validation (default: `mvn -B -ntp -DskipTests validate`).
+6. Paste exact command output in the PR body.
+7. Update `dev-tracker.md` + `dev-tracker.json` (and risk/decision docs when
+   applicable) in the same PR when state changes.
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) and [`AGENTS.md`](../AGENTS.md).
 
 ## PR metadata policy
 
-Pull request metadata must stay accurate and readable for reviewers and for
-future history readers after squash merge.
+- PR titles and bodies in **English**.
+- Reference one tracker slug (e.g. `provider-inventory`).
+- Squash merge title: Conventional Commits + PR number.
+- Squash body: final outcome and validation — not intermediate commit bullets.
+- Remove accidental `Co-authored-by` trailers unless intentional.
 
-- PR titles and bodies use English.
-- PR bodies document real validation commands and honest outcomes.
-- Tracker references use descriptive slugs from `docs/dev-tracker.md`,
-  optionally paired with the legacy `HBTV-XXX` code from the same entry
-  (for example `clean-squash-merge-policy` (HBTV-018)).
-- Squash merge titles follow Conventional Commits and include the PR number.
-- Squash merge bodies summarize the merged outcome, not intermediate commits.
+See [`pull-request-style-guide.md`](pull-request-style-guide.md).
 
-See `docs/pull-request-style-guide.md` for examples and the full squash merge
-commit policy.
+## Repository automation
 
-### Squash merge metadata
+| Automation | Behavior |
+|------------|----------|
+| Dependabot | Weekly Maven + Actions update PRs; no major bumps; no auto-merge |
+| Dependency Review | Blocks new high/critical dependency vulnerabilities on PRs |
+| CodeQL | Code scanning (separate from Maven CI) |
+| Stale triage | Labels inactive issues/PRs; does not auto-close |
+| PR labeler | Path-based labels; not a required check |
 
-The person merging a PR is responsible for cleaning the final squash commit
-message.
-
-- The final squash commit must summarize the PR outcome, not list every
-  intermediate commit.
-- Generated `Co-authored-by` trailers should be removed unless intentionally
-  kept.
-- The final commit title should follow Conventional Commits and include the PR
-  number.
-
-## Repository automation checks
-
-This repository uses conservative automation for dependency hygiene and triage
-while keeping merge control with maintainers.
-
-- Dependabot opens pull requests for Maven and GitHub Actions updates.
-- Dependabot is configured to ignore semver-major updates.
-- Auto-merge is intentionally disabled.
-- Bots open pull requests only and must not push directly to `develop`.
-- Dependency Review blocks pull requests that introduce new `high` or
-  `critical` vulnerabilities in dependencies.
-- CodeQL runs separately from Maven CI and reports code scanning alerts.
-- Stale triage labels inactive issues and pull requests without auto-closing
-  them.
+Live provider tests must not become required checks until replaced or reliably
+quarantined — see [`ci.md`](ci.md).
 
 ## Documentation sync
 
-When a change updates process or governance documentation, keep these files
-aligned in the same commit when applicable:
+When process, scope, or status changes, keep aligned in the **same commit**:
 
-- `docs/dev-tracker.md` and `docs/dev-tracker.json`
-- `docs/risk-register.md` when risks change
-- `docs/decision-log.md` when architecture decisions change
+| Change type | Update |
+|-------------|--------|
+| Work item progress | `dev-tracker.md` + `dev-tracker.json` |
+| Risk added/mitigated | `risk-register.md` |
+| Architecture decision | `decision-log.md` (ADR) |
+| User-facing release notes | `CHANGELOG.md` (when applicable) |
+
+Machine/human tracker parity check (before PR):
+
+```bash
+python3 -c "
+import json, re
+md = open('docs/dev-tracker.md', encoding='utf-8').read()
+js = json.load(open('docs/dev-tracker.json', encoding='utf-8'))
+md_slugs = set(re.findall(r'\`([a-z][a-z0-9-]{4,})\`', md))
+js_slugs = {i['id'] for i in js['items']}
+missing = js_slugs - md_slugs
+assert not missing, missing
+print('OK:', len(js_slugs), 'items')
+"
+```
 
 ## Related documentation
 
-- `docs/repository-governance.md` — branch protection and rulesets
-- `docs/pull-request-style-guide.md` — PR and squash merge style
-- `AGENTS.md` — agent and contributor rules
-- `docs/ci.md` — CI, security checks, and required/diagnostic lanes
+- [`repository-governance.md`](repository-governance.md) — branch protection and rulesets
+- [`ci.md`](ci.md) — required vs diagnostic CI jobs
+- [`dev-plan.md`](dev-plan.md) — phased roadmap
+- [`README.md`](../README.md) — project entry point

--- a/docs/runtime-quickstart.md
+++ b/docs/runtime-quickstart.md
@@ -1,12 +1,15 @@
 # Habitv runtime quickstart
 
-This guide walks through running habitv with a working YouTube download
-provider on a Linux machine. It assumes a clean checkout of the
-modernized branch and Java 8+ on the PATH.
+This guide walks through running Habitv with a working YouTube download
+provider on a Linux machine. It assumes a clean checkout of **`develop`**
+and **JDK 8** on the PATH (Java 11+ is not supported for the full GUI yet).
+
+For automatic category watch behavior (index baseline, deduplication limits),
+see [`automatic-category-download.md`](automatic-category-download.md).
 
 ## Prerequisites
 
-- JDK 8 or later (the reactor compiles with `<source>1.8</source>`)
+- **JDK 8** (required baseline; reactor uses `<source>1.8</source>`)
 - Maven 3.6+
 - `yt-dlp` on the PATH (`apt install yt-dlp` on recent Ubuntu, or
   `pip install --user yt-dlp`)

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -1,8 +1,10 @@
 # Static repository publication (`habitv-repo`)
 
 Habitv publishes Maven artifacts and external tool binaries to a local staging
-directory that is committed in the `habitv-repo` Git repository and served
-publicly via GitHub Pages.
+directory that is committed in the separate [`habitv-repo`](https://github.com/Mika3578/habitv-repo)
+repository and served publicly via GitHub Pages. This replaces the legacy
+`http://dabiboo.free.fr/repository` host (removed from active POMs on
+`develop`).
 
 | Role | Location |
 |------|----------|


### PR DESCRIPTION
## Summary
- Refreshes README.md as the main project entry point.
- Aligns documentation with the current Habitv modernization work.
- Documents automatic category watch/download behavior and deduplication limits.
- Updates provider, runtime, CI, and maintenance documentation.
- Synchronizes tracker documentation where applicable.

## Documentation areas updated
- Project overview and status
- Build and runtime notes
- Automatic category download behavior
- Plugin/provider inventory
- CI and repository maintenance
- Contributor workflow
- Development tracker

## Scope
- README.md and docs under `docs/`
- `CONTRIBUTING.md` links to new/updated guides
- `docs/dev-tracker.md` and `docs/dev-tracker.json` parity fixes (`pluzz` → `francetv`)

## Out of scope
- Java source, Maven build logic, workflows, runtime configuration

## Validation

### `git status --short`

```text
(no output — working tree clean)
```

### Markdown inventory (`git ls-files "*.md" | sort`)

```text
.github/copilot-instructions.md
.github/ISSUE_TEMPLATE/bug.md
.github/ISSUE_TEMPLATE/modernization.md
.github/pull_request_template.md
AGENTS.md
CHANGELOG.md
CONTRIBUTING.md
docs/audit-master-baseline.md
docs/automatic-category-download.md
docs/ci.md
docs/decision-log.md
docs/dev-plan.md
docs/dev-tracker.md
docs/github-repository-settings.md
docs/hbtv-004-url-migration-plan.md
docs/provider-inventory.md
docs/pull-request-style-guide.md
docs/repository-governance.md
docs/repository-maintenance.md
docs/risk-register.md
docs/runtime-quickstart.md
docs/security-critical-cve-investigation.md
docs/security-dependency-audit.md
docs/static-repository-deploy.md
docs/ytdlp-cli-compatibility.md
README.md
SECURITY.md
```

### `mvn -B -ntp -DskipTests validate`

Exit status: `0`

```text
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.981 s
[INFO] Finished at: 2026-05-20T23:52:46+02:00
[INFO] ------------------------------------------------------------------------
```

## Risk
- Affected risks: none (documentation only)
- New risks: none
- Mitigation: N/A

## Rollback
- Revert the four docs commits on this branch or revert the squash merge on `develop`.

## Linked tracker item
- N/A (cross-cutting documentation refresh; aligns with multiple in-progress items)

## Checklist
- [x] Branch was created from `develop`
- [x] No unrelated source changes
- [x] `mvn -B -ntp -DskipTests validate` passed
- [x] PR keeps linear history
- [x] English used for branches, commits, comments, docs, and PR text
- [x] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`)
- [x] No secrets, tokens, local paths, or build outputs committed
