### PR TITLE
feat: add batch episode selection and download queue controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,9 @@ application/core/testOldGrabconfig.xml
 *.iml
 
 # Maven
+target/
 **/target/
+**/target/**
 **/dependency-reduced-pom.xml
 pom.xml.tag
 pom.xml.releaseBackup

--- a/application/consoleView/configuration.xml.sample
+++ b/application/consoleView/configuration.xml.sample
@@ -6,6 +6,7 @@
     <downloadConfig>
         <downloadOuput>./downloads/#TVSHOW_NAME#-#EPISODE_NAME_CUT#.#EXTENSION#</downloadOuput>
         <maxAttempts>1</maxAttempts>
+        <maxConcurrentDownloads>1</maxConcurrentDownloads>
         <demonCheckTime>1800</demonCheckTime>
         <fileNameCutSize>50</fileNameCutSize>
         <downloaders>

--- a/application/core/configuration.xml
+++ b/application/core/configuration.xml
@@ -5,6 +5,7 @@
     <downloadConfig>
         <downloadOuput>D:/divx/regular/#TVSHOW_NAME#-#EPISODE_NAME_CUT#.#EXTENSION#</downloadOuput>
         <maxAttempts>5</maxAttempts>
+        <maxConcurrentDownloads>1</maxConcurrentDownloads>
         <demonCheckTime>1800</demonCheckTime>
         <fileNameCutSize>50</fileNameCutSize>
         <downloaders>

--- a/application/core/src/com/dabi/habitv/core/config/UserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/UserConfig.java
@@ -29,6 +29,8 @@ public interface UserConfig {
 
 	Integer getMaxAttempts();
 
+	int getMaxConcurrentDownloads();
+
 	Integer getDemonCheckTime();
 
 	boolean updateOnStartup();
@@ -42,6 +44,8 @@ public interface UserConfig {
 	boolean getEmbedSubtitles();
 
 	void setMaxAttempts(int parseInt);
+
+	void setMaxConcurrentDownloads(int maxConcurrentDownloads);
 
 	void setUpdateOnStartup(boolean updateOnStartup);
 

--- a/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
@@ -52,6 +52,8 @@ public class XMLUserConfig implements UserConfig {
 
 	private static final int DEFAULT_MAX_ATTEMPTS = 5;
 
+	private static final int DEFAULT_MAX_CONCURRENT_DOWNLOADS = 1;
+
 	private static final int DEFAULT_CHECK_TIME = 1800;
 
 	private static final int DEFAULT_CUT_SIZE = 40;
@@ -107,6 +109,17 @@ public class XMLUserConfig implements UserConfig {
 			PropertyException {
 		saveConfig(new File(DirUtils.getConfFile()),
 				((XMLUserConfig) userConfig).config);
+	}
+
+	static XMLUserConfig readConfigForTest(final File confFile)
+			throws JAXBException, UnsupportedEncodingException,
+			FileNotFoundException {
+		return new XMLUserConfig(readConfig(confFile));
+	}
+
+	static void saveConfig(final File confFile, final XMLUserConfig userConfig)
+			throws JAXBException, PropertyException {
+		saveConfig(confFile, userConfig.config);
 	}
 
 	private static Configuration convertOldConfig(Config oldConfig) {
@@ -287,6 +300,7 @@ public class XMLUserConfig implements UserConfig {
 		downloadConfig.setDemonCheckTime(DEFAULT_CHECK_TIME);
 		downloadConfig.setDownloadOuput(DEFAULT_DL_OUTPUT);
 		downloadConfig.setMaxAttempts(DEFAULT_MAX_ATTEMPTS);
+		downloadConfig.setMaxConcurrentDownloads(DEFAULT_MAX_CONCURRENT_DOWNLOADS);
 
 		UpdateConfig updateConfig = new UpdateConfig();
 		updateConfig.setAutoriseSnapshot(DEFAULT_AUTORISE_SNAPSHOT);
@@ -457,6 +471,27 @@ public class XMLUserConfig implements UserConfig {
 	public Integer getMaxAttempts() {
 		return config.getDownloadConfig() == null ? null : config
 				.getDownloadConfig().getMaxAttempts();
+	}
+
+	@Override
+	public int getMaxConcurrentDownloads() {
+		return resolveMaxConcurrentDownloads(config.getDownloadConfig() == null
+				? null
+				: config.getDownloadConfig().getMaxConcurrentDownloads());
+	}
+
+	static int resolveMaxConcurrentDownloads(final Integer configured) {
+		if (configured == null || configured.intValue() < 1) {
+			return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
+		}
+		return configured.intValue();
+	}
+
+	@Override
+	public void setMaxConcurrentDownloads(final int maxConcurrentDownloads) {
+		final DownloadConfig downloadConfig = loadDownloadConfig();
+		downloadConfig.setMaxConcurrentDownloads(
+				resolveMaxConcurrentDownloads(Integer.valueOf(maxConcurrentDownloads)));
 	}
 
 	@Override

--- a/application/core/src/com/dabi/habitv/core/dao/DownloadedDAO.java
+++ b/application/core/src/com/dabi/habitv/core/dao/DownloadedDAO.java
@@ -25,6 +25,7 @@ import com.dabi.habitv.utils.FileUtils;
 public class DownloadedDAO {
 
 	private static final Logger LOG = Logger.getLogger(DownloadedDAO.class);
+	private static final String EPISODE_KEY_PREFIX = "episode-key|";
 
 	private final String indexDir;
 
@@ -57,19 +58,70 @@ public class DownloadedDAO {
 	}
 
 	public static String getFileIndex(String indexDir, CategoryDTO category) {
-		return (indexDir + "/" + FileUtils.sanitizeFilename(category
-				.getPlugin() + "_" + category.getName() + ".index"));
+		return indexDir + "/" + buildIndexFileName(category, ".index");
 	}
 
 	private String getManualFileIndex() {
-		return (indexDir + "/" + FileUtils.sanitizeFilename(category
-				.getPlugin() + "_" + category.getName() + "_manual.index"));
+		return indexDir + "/" + buildIndexFileName(category, "_manual.index");
+	}
+
+	private String getLegacyFileIndex() {
+		return indexDir + "/" + buildLegacyIndexFileName(".index");
+	}
+
+	private String getLegacyManualFileIndex() {
+		return indexDir + "/" + buildLegacyIndexFileName("_manual.index");
+	}
+
+	private String buildLegacyIndexFileName(final String suffix) {
+		return FileUtils.sanitizeFilename(category.getPlugin() + "_"
+				+ category.getName() + suffix);
+	}
+
+	private static String buildIndexFileName(final CategoryDTO category,
+			final String suffix) {
+		final String plugin = category.getPlugin();
+		final String name = category.getName();
+		final String id = category.getId();
+		final String categoryIdentity = plugin + "|" + id;
+		final String identityHash = Integer
+				.toHexString(categoryIdentity.hashCode());
+		return FileUtils
+				.sanitizeFilename(plugin + "_" + name + "_" + identityHash + suffix);
 	}
 
 	public Set<String> findDownloadedFiles() {
 		Set<String> dlFiles = readFile(getFileIndex());
+		dlFiles.addAll(readFile(getLegacyFileIndex()));
 		dlFiles.addAll(readFile(getManualFileIndex()));
+		dlFiles.addAll(readFile(getLegacyManualFileIndex()));
 		return dlFiles;
+	}
+
+	public static String buildEpisodeKey(final EpisodeDTO episode) {
+		if (episode == null || episode.getCategory() == null) {
+			return null;
+		}
+		final CategoryDTO category = episode.getCategory();
+		return EPISODE_KEY_PREFIX + normalize(category.getPlugin()) + "|"
+				+ normalize(category.getId()) + "|" + normalize(episode.getId())
+				+ "|" + normalize(episode.getName());
+	}
+
+	public static boolean containsEpisode(final Set<String> downloadedEntries,
+			final EpisodeDTO episode) {
+		final String episodeKey = buildEpisodeKey(episode);
+		return episodeKey != null && downloadedEntries != null
+				&& downloadedEntries.contains(episodeKey);
+	}
+
+	public static boolean containsEpisodeOrLegacyName(
+			final Set<String> downloadedEntries, final EpisodeDTO episode) {
+		if (containsEpisode(downloadedEntries, episode)) {
+			return true;
+		}
+		return downloadedEntries != null && episode != null
+				&& downloadedEntries.contains(episode.getName());
 	}
 
 	private Set<String> readFile(String file) {
@@ -143,9 +195,17 @@ public class DownloadedDAO {
 			final EpisodeDTO... episodes) {
 		Collection<String> toAddList = new ArrayList<>(episodes.length);
 		for (EpisodeDTO episodeDTO : episodes) {
-			toAddList.add(episodeDTO.getName());
+			final String episodeKey = buildEpisodeKey(episodeDTO);
+			if (episodeKey != null) {
+				toAddList.add(episodeKey);
+			}
 		}
 		return toAddList;
+	}
+
+	private static String normalize(final String value) {
+		return value == null ? "" : value.replace('\n', ' ').replace('\r', ' ')
+				.trim();
 	}
 
 	public boolean isIndexCreated() {
@@ -159,6 +219,7 @@ public class DownloadedDAO {
 	void initIndex() {
 		final String fileIndex = getFileIndex();
 		(new File(fileIndex)).delete();
+		(new File(getLegacyFileIndex())).delete();
 		LOG.info("réinitialisation de l'index " + fileIndex);
 		indexExist = false;
 	}
@@ -166,6 +227,7 @@ public class DownloadedDAO {
 	void initManualIndex() {
 		final String fileIndex = getManualFileIndex();
 		(new File(fileIndex)).delete();
+		(new File(getLegacyManualFileIndex())).delete();
 		LOG.info("réinitialisation de l'index " + fileIndex);
 		manualIndexExist = false;
 	}

--- a/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
+++ b/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
@@ -39,7 +39,8 @@ public final class CoreManager {
 		applyYoutubeApiKey(config.getYoutubeApiKey());
 		pluginManager = new PluginManager(config);
 		episodeManager = new EpisodeManager(pluginManager.getDownloadersHolder(), pluginManager.getExportersHolder(),
-		        pluginManager.getProvidersHolder(), taskName2PoolSizeMap, config.getMaxAttempts(), DirUtils.getAppDir());
+		        pluginManager.getProvidersHolder(), taskName2PoolSizeMap, config.getMaxAttempts(),
+		        config.getMaxConcurrentDownloads(), DirUtils.getAppDir());
 		categoryManager = new CategoryManager(pluginManager.getProvidersHolder(), taskName2PoolSizeMap);
 
 		setProxy(config);
@@ -150,6 +151,11 @@ public final class CoreManager {
 
 	public void restart(EpisodeDTO episode, boolean exportOnly) {
 		episodeManager.restart(episode, exportOnly);
+	}
+
+	public com.dabi.habitv.core.task.BatchEnqueueResult enqueueEpisodesForDownload(
+			final Collection<EpisodeDTO> episodes) {
+		return episodeManager.enqueueEpisodesForDownload(episodes);
 	}
 
 	public Collection<EpisodeDTO> findEpisodeByCategory(CategoryDTO category) {

--- a/application/core/src/com/dabi/habitv/core/mgr/EpisodeManager.java
+++ b/application/core/src/com/dabi/habitv/core/mgr/EpisodeManager.java
@@ -1,5 +1,6 @@
 package com.dabi.habitv.core.mgr;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -7,6 +8,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.log4j.Logger;
 
 import com.dabi.habitv.api.plugin.api.PluginProviderInterface;
 import com.dabi.habitv.api.plugin.dto.CategoryDTO;
@@ -23,7 +26,11 @@ import com.dabi.habitv.core.event.EpisodeStateEnum;
 import com.dabi.habitv.core.event.RetreiveEvent;
 import com.dabi.habitv.core.event.SearchEvent;
 import com.dabi.habitv.core.event.SearchStateEnum;
+import com.dabi.habitv.core.task.BatchEnqueueResult;
 import com.dabi.habitv.core.task.DownloadTask;
+import com.dabi.habitv.core.task.EnqueueSkipReason;
+import com.dabi.habitv.core.task.EpisodeDuplicateDetector;
+import com.dabi.habitv.core.task.EpisodeEnqueueResult;
 import com.dabi.habitv.core.task.ExportTask;
 import com.dabi.habitv.core.task.RetrieveTask;
 import com.dabi.habitv.core.task.SearchTask;
@@ -36,6 +43,10 @@ import com.dabi.habitv.core.task.TaskState;
 import com.dabi.habitv.core.task.TaskTypeEnum;
 
 public final class EpisodeManager extends AbstractManager implements TaskAdder {
+
+	private static final Logger LOG = Logger.getLogger(EpisodeManager.class);
+
+	private static final String DOWNLOAD_POOL_CATEGORY = "default";
 
 	private final TaskMgr<RetrieveTask, Object> retreiveMgr;
 
@@ -62,15 +73,15 @@ public final class EpisodeManager extends AbstractManager implements TaskAdder {
 	private final Integer maxAttempts;
 
 	EpisodeManager(final DownloaderPluginHolder downloader, final ExporterPluginHolder exporter,
-			final ProviderPluginHolder providerPluginHolder, final Map<String, Integer> taskName2PoolSize, final Integer maxAttempts,
-			String appDir) {
+			final ProviderPluginHolder providerPluginHolder, final Map<String, Integer> taskName2PoolSize,
+			final Integer maxAttempts, final int maxConcurrentDownloads, String appDir) {
 		super(providerPluginHolder);
 		exportDAO = new ExportDAO(appDir);
 		// task mgrs
 		retreiveMgr = new TaskMgr<RetrieveTask, Object>(TaskTypeEnum.retreive.getPoolSize(taskName2PoolSize),
 				buildRetreiveTaskMgrListener(), taskName2PoolSize);
-		downloadMgr = new TaskMgr<DownloadTask, Object>(TaskTypeEnum.download.getPoolSize(taskName2PoolSize),
-				buildDownloadTaskMgrListener(), taskName2PoolSize);
+		downloadMgr = new TaskMgr<DownloadTask, Object>(maxConcurrentDownloads,
+				buildDownloadTaskMgrListener(), Collections.<String, Integer> emptyMap());
 		exportMgr = new TaskMgr<ExportTask, Object>(TaskTypeEnum.export.getPoolSize(taskName2PoolSize), buildExportTaskMgrListener(),
 				taskName2PoolSize);
 		searchMgr = new TaskMgr<SearchTask, Object>(TaskTypeEnum.search.getPoolSize(taskName2PoolSize), buildSearchTaskMgrListener(),
@@ -167,8 +178,63 @@ public final class EpisodeManager extends AbstractManager implements TaskAdder {
 
 	@Override
 	public TaskAdResult addDownloadTask(final DownloadTask downloadTask, final String channel) {
-		downloadMgr.addTask(downloadTask.getEpisode(), downloadTask, channel);
+		downloadMgr.addTask(downloadTask.getEpisode(), downloadTask, DOWNLOAD_POOL_CATEGORY);
 		return new TaskAdResult(TaskState.ADDED);
+	}
+
+	public synchronized BatchEnqueueResult enqueueEpisodesForDownload(
+			final Collection<EpisodeDTO> episodes) {
+		final List<EpisodeEnqueueResult> results = new ArrayList<>();
+		if (episodes == null || episodes.isEmpty()) {
+			return new BatchEnqueueResult(results);
+		}
+		final Map<String, Set<String>> downloadedEpisodesByCategory = new HashMap<>();
+		final EpisodeDuplicateDetector duplicateDetector = new EpisodeDuplicateDetector();
+		for (final EpisodeDTO episode : episodes) {
+			if (episode == null || episode.getCategory() == null) {
+				continue;
+			}
+			final EnqueueSkipReason skipReason = duplicateDetector.detectSkipReason(
+					episode, isAlreadyDownloaded(episode, downloadedEpisodesByCategory),
+					isRetrieveQueued(episode), isDownloadActive(episode));
+			if (skipReason != null) {
+				LOG.info("Duplicate skipped for " + episode + ": " + skipReason);
+				results.add(new EpisodeEnqueueResult(episode, TaskState.ALREADY_ADD,
+						skipReason));
+				continue;
+			}
+			LOG.info("Episode queued for download: " + episode);
+			restart(episode, false);
+			results.add(new EpisodeEnqueueResult(episode, TaskState.ADDED, null));
+		}
+		return new BatchEnqueueResult(results);
+	}
+
+	private boolean isAlreadyDownloaded(final EpisodeDTO episode,
+			final Map<String, Set<String>> downloadedEpisodesByCategory) {
+		final String categoryKey = getCategoryKey(episode.getCategory());
+		Set<String> downloadedEpisodes = downloadedEpisodesByCategory.get(categoryKey);
+		if (downloadedEpisodes == null) {
+			final DownloadedDAO dlDAO = new DownloadedDAO(episode.getCategory(),
+					downloader.getIndexDir());
+			downloadedEpisodes = dlDAO.findDownloadedFiles();
+			downloadedEpisodesByCategory.put(categoryKey, downloadedEpisodes);
+		}
+		return DownloadedDAO.containsEpisodeOrLegacyName(downloadedEpisodes,
+				episode);
+	}
+
+	private String getCategoryKey(final CategoryDTO category) {
+		return category.getPlugin() + "#" + category.getId();
+	}
+
+	private boolean isRetrieveQueued(final EpisodeDTO episode) {
+		return runningRetreiveTasks.contains(episode.hashCode())
+				|| retreiveMgr.hasQueuedOrActiveTask(episode);
+	}
+
+	private boolean isDownloadActive(final EpisodeDTO episode) {
+		return downloadMgr.hasQueuedOrActiveTask(episode);
 	}
 
 	private synchronized boolean isRetreiveTaskAdded(final RetrieveTask retreiveTask) {

--- a/application/core/src/com/dabi/habitv/core/task/AbstractTask.java
+++ b/application/core/src/com/dabi/habitv/core/task/AbstractTask.java
@@ -98,6 +98,14 @@ abstract class AbstractTask<R> implements Callable<R> {
 		return running;
 	}
 
+	public boolean isFinished() {
+		return future != null && future.isDone();
+	}
+
+	public boolean isQueuedOrActive() {
+		return future != null && !future.isDone();
+	}
+
 	public void cancel() {
 		canceled = true;
 		if (future != null) {

--- a/application/core/src/com/dabi/habitv/core/task/BatchEnqueueResult.java
+++ b/application/core/src/com/dabi/habitv/core/task/BatchEnqueueResult.java
@@ -1,0 +1,34 @@
+package com.dabi.habitv.core.task;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class BatchEnqueueResult {
+
+	private final List<EpisodeEnqueueResult> results;
+
+	public BatchEnqueueResult(final List<EpisodeEnqueueResult> results) {
+		Objects.requireNonNull(results, "results must not be null");
+		this.results = Collections.unmodifiableList(new ArrayList<>(results));
+	}
+
+	public List<EpisodeEnqueueResult> getResults() {
+		return results;
+	}
+
+	public int getAddedCount() {
+		int count = 0;
+		for (final EpisodeEnqueueResult result : results) {
+			if (result.wasAdded()) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	public int getSkippedCount() {
+		return results.size() - getAddedCount();
+	}
+}

--- a/application/core/src/com/dabi/habitv/core/task/DownloadTask.java
+++ b/application/core/src/com/dabi/habitv/core/task/DownloadTask.java
@@ -77,7 +77,7 @@ public class DownloadTask extends AbstractEpisodeTask {
 
 	@Override
 	protected void started() {
-		LOG.info("Download of " + getEpisode() + " is starting");
+		LOG.info("Download started for " + getEpisode());
 	}
 
 	@Override

--- a/application/core/src/com/dabi/habitv/core/task/EnqueueSkipReason.java
+++ b/application/core/src/com/dabi/habitv/core/task/EnqueueSkipReason.java
@@ -1,0 +1,8 @@
+package com.dabi.habitv.core.task;
+
+public enum EnqueueSkipReason {
+	ALREADY_DOWNLOADED,
+	ALREADY_QUEUED,
+	ALREADY_DOWNLOADING,
+	DUPLICATE_IN_BATCH
+}

--- a/application/core/src/com/dabi/habitv/core/task/EpisodeDuplicateDetector.java
+++ b/application/core/src/com/dabi/habitv/core/task/EpisodeDuplicateDetector.java
@@ -1,0 +1,34 @@
+package com.dabi.habitv.core.task;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+public final class EpisodeDuplicateDetector {
+
+	private final Set<EpisodeIdentity> seenInBatch = new HashSet<>();
+
+	public EnqueueSkipReason detectSkipReason(final EpisodeDTO episode,
+			final boolean alreadyDownloaded, final boolean alreadyQueued,
+			final boolean alreadyDownloading) {
+		if (alreadyDownloaded) {
+			return EnqueueSkipReason.ALREADY_DOWNLOADED;
+		}
+		if (alreadyDownloading) {
+			return EnqueueSkipReason.ALREADY_DOWNLOADING;
+		}
+		if (alreadyQueued) {
+			return EnqueueSkipReason.ALREADY_QUEUED;
+		}
+		final EpisodeIdentity identity = EpisodeIdentity.fromEpisode(episode);
+		if (identity != null && !seenInBatch.add(identity)) {
+			return EnqueueSkipReason.DUPLICATE_IN_BATCH;
+		}
+		return null;
+	}
+
+	public void resetBatch() {
+		seenInBatch.clear();
+	}
+}

--- a/application/core/src/com/dabi/habitv/core/task/EpisodeEnqueueResult.java
+++ b/application/core/src/com/dabi/habitv/core/task/EpisodeEnqueueResult.java
@@ -1,0 +1,37 @@
+package com.dabi.habitv.core.task;
+
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+public final class EpisodeEnqueueResult {
+
+	private final EpisodeDTO episode;
+	private final TaskState state;
+	private final EnqueueSkipReason skipReason;
+
+	public EpisodeEnqueueResult(final EpisodeDTO episode,
+			final TaskState state, final EnqueueSkipReason skipReason) {
+		this.episode = episode;
+		this.state = state;
+		this.skipReason = skipReason;
+	}
+
+	public EpisodeDTO getEpisode() {
+		return episode;
+	}
+
+	public TaskState getState() {
+		return state;
+	}
+
+	public EnqueueSkipReason getSkipReason() {
+		return skipReason;
+	}
+
+	public boolean wasAdded() {
+		return state == TaskState.ADDED;
+	}
+
+	public boolean wasSkipped() {
+		return skipReason != null;
+	}
+}

--- a/application/core/src/com/dabi/habitv/core/task/EpisodeIdentity.java
+++ b/application/core/src/com/dabi/habitv/core/task/EpisodeIdentity.java
@@ -1,0 +1,104 @@
+package com.dabi.habitv.core.task;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+/**
+ * Stable episode identity for duplicate detection across queue and index.
+ */
+public final class EpisodeIdentity {
+
+	private final String plugin;
+	private final String categoryName;
+	private final String episodeId;
+	private final String episodeName;
+
+	public EpisodeIdentity(final String plugin, final String categoryName,
+			final String episodeId, final String episodeName) {
+		this.plugin = plugin;
+		this.categoryName = categoryName;
+		this.episodeId = episodeId;
+		this.episodeName = episodeName;
+	}
+
+	public static EpisodeIdentity fromEpisode(final EpisodeDTO episode) {
+		if (episode == null) {
+			return null;
+		}
+		final CategoryDTO category = episode.getCategory();
+		final String plugin = category == null ? null : category.getPlugin();
+		final String categoryName = category == null ? null : category.getName();
+		return new EpisodeIdentity(plugin, categoryName, episode.getId(),
+				episode.getName());
+	}
+
+	public String getPlugin() {
+		return plugin;
+	}
+
+	public String getCategoryName() {
+		return categoryName;
+	}
+
+	public String getEpisodeId() {
+		return episodeId;
+	}
+
+	public String getEpisodeName() {
+		return episodeName;
+	}
+
+	public boolean matchesEpisode(final EpisodeDTO episode) {
+		if (episode == null) {
+			return false;
+		}
+		final EpisodeIdentity other = fromEpisode(episode);
+		if (episodeId != null && episodeId.equals(other.episodeId)) {
+			return true;
+		}
+		return episode.equals(buildEpisodeStub(other));
+	}
+
+	private static EpisodeDTO buildEpisodeStub(final EpisodeIdentity identity) {
+		final CategoryDTO category = new CategoryDTO(identity.plugin,
+				identity.categoryName, identity.categoryName, null);
+		return new EpisodeDTO(category, identity.episodeName, identity.episodeId);
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (!(obj instanceof EpisodeIdentity)) {
+			return false;
+		}
+		final EpisodeIdentity other = (EpisodeIdentity) obj;
+		if (episodeId != null && episodeId.equals(other.episodeId)) {
+			return true;
+		}
+		return safeEquals(plugin, other.plugin)
+				&& safeEquals(categoryName, other.categoryName)
+				&& safeEquals(episodeName, other.episodeName);
+	}
+
+	@Override
+	public int hashCode() {
+		if (episodeId != null) {
+			return episodeId.hashCode();
+		}
+		int hash = 17;
+		hash = 31 * hash + safeHash(plugin);
+		hash = 31 * hash + safeHash(categoryName);
+		hash = 31 * hash + safeHash(episodeName);
+		return hash;
+	}
+
+	private static boolean safeEquals(final String left, final String right) {
+		if (left == null) {
+			return right == null;
+		}
+		return left.equals(right);
+	}
+
+	private static int safeHash(final String value) {
+		return value == null ? 0 : value.hashCode();
+	}
+}

--- a/application/core/src/com/dabi/habitv/core/task/EpisodeMetadataFormatting.java
+++ b/application/core/src/com/dabi/habitv/core/task/EpisodeMetadataFormatting.java
@@ -1,0 +1,101 @@
+package com.dabi.habitv.core.task;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+public final class EpisodeMetadataFormatting {
+
+	private static final String UNKNOWN = "Inconnu";
+
+	private EpisodeMetadataFormatting() {
+	}
+
+	public static String formatDate(final Date date) {
+		if (date == null) {
+			return UNKNOWN;
+		}
+		return new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH).format(date);
+	}
+
+	public static String formatDuration(final Long durationSeconds) {
+		if (durationSeconds == null || durationSeconds.longValue() < 0) {
+			return UNKNOWN;
+		}
+		final long total = durationSeconds.longValue();
+		final long hours = total / 3600;
+		final long minutes = (total % 3600) / 60;
+		final long seconds = total % 60;
+		if (hours > 0) {
+			return String.format(Locale.ENGLISH, "%d:%02d:%02d", Long.valueOf(hours),
+					Long.valueOf(minutes), Long.valueOf(seconds));
+		}
+		return String.format(Locale.ENGLISH, "%d:%02d", Long.valueOf(minutes),
+				Long.valueOf(seconds));
+	}
+
+	public static String formatSize(final Long sizeBytes) {
+		if (sizeBytes == null || sizeBytes.longValue() < 0) {
+			return UNKNOWN;
+		}
+		final long bytes = sizeBytes.longValue();
+		if (bytes < 1024) {
+			return bytes + " B";
+		}
+		if (bytes < 1024 * 1024) {
+			return String.format(Locale.ENGLISH, "%.1f KB", Double.valueOf(bytes / 1024.0));
+		}
+		if (bytes < 1024L * 1024L * 1024L) {
+			return String.format(Locale.ENGLISH, "%.1f MB",
+					Double.valueOf(bytes / (1024.0 * 1024.0)));
+		}
+		return String.format(Locale.ENGLISH, "%.1f GB",
+				Double.valueOf(bytes / (1024.0 * 1024.0 * 1024.0)));
+	}
+
+	public static String formatSource(final EpisodeDTO episode) {
+		if (episode == null || episode.getId() == null
+				|| episode.getId().trim().isEmpty()) {
+			return UNKNOWN;
+		}
+		return episode.getId();
+	}
+
+	public static String formatStatusLabel(final String status) {
+		if (status == null || status.trim().isEmpty()) {
+			return UNKNOWN;
+		}
+		return status;
+	}
+
+	public static String programPageUrl(final EpisodeDTO episode) {
+		if (episode == null) {
+			return null;
+		}
+		final CategoryDTO category = episode.getCategory();
+		if (category == null) {
+			return null;
+		}
+		final String categoryId = category.getId();
+		if (categoryId != null && (categoryId.startsWith("http://")
+				|| categoryId.startsWith("https://"))) {
+			return categoryId;
+		}
+		return null;
+	}
+
+	public static String formatProgramLinkLabel(final EpisodeDTO episode) {
+		if (episode == null) {
+			return UNKNOWN;
+		}
+		final CategoryDTO category = episode.getCategory();
+		if (category == null || category.getName() == null
+				|| category.getName().trim().isEmpty()) {
+			return UNKNOWN;
+		}
+		return category.getName();
+	}
+}

--- a/application/core/src/com/dabi/habitv/core/task/SearchTask.java
+++ b/application/core/src/com/dabi/habitv/core/task/SearchTask.java
@@ -114,7 +114,8 @@ public class SearchTask extends AbstractTask<Object> {
 			int i = 0;
 			for (final EpisodeDTO episode : episodeList) {
 				episode.setNum(i);
-				isDownloaded = dlFiles.contains(episode.getName());
+				isDownloaded = DownloadedDAO.containsEpisodeOrLegacyName(dlFiles,
+						episode);
 				isErrorDownloaded = errorFiles.contains(episode.getFullNameNoNum());
 				if (indexCreated && FilterUtils.filterByIncludeExcludeAndDownloaded(episode, category.getInclude(), category.getExclude())
 						&& !isDownloaded && !isErrorDownloaded) {

--- a/application/core/src/com/dabi/habitv/core/task/TaskMgr.java
+++ b/application/core/src/com/dabi/habitv/core/task/TaskMgr.java
@@ -9,9 +9,13 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.log4j.Logger;
+
 import com.dabi.habitv.api.plugin.exception.TechnicalException;
 
 public class TaskMgr<T extends AbstractTask<R>, R> {
+
+	private static final Logger LOG = Logger.getLogger(TaskMgr.class);
 
 	private static final int DEFAULT_KEEP_ALIVE_TIME_SEC = 10;
 
@@ -45,8 +49,39 @@ public class TaskMgr<T extends AbstractTask<R>, R> {
 			executorService = initExecutor(category);
 			category2ExecutorService.put(category, executorService);
 		}
+		final ThreadPoolExecutor pool = (ThreadPoolExecutor) executorService;
+		if (pool.getActiveCount() >= pool.getMaximumPoolSize()) {
+			LOG.info("Queue waiting for " + task + " because concurrency limit "
+					+ pool.getMaximumPoolSize() + " was reached on pool "
+					+ category);
+		}
 		task.addedTo(category, executorService.submit(task));
 		object2Task.put(object, task);
+	}
+
+	public synchronized boolean hasQueuedOrActiveTask(final Object object) {
+		final T task = object2Task.get(object);
+		return task != null && task.isQueuedOrActive();
+	}
+
+	public synchronized int getActiveTaskCount() {
+		int active = 0;
+		for (final T task : object2Task.values()) {
+			if (task.isRunning()) {
+				active++;
+			}
+		}
+		return active;
+	}
+
+	public synchronized int getQueuedOrActiveTaskCount() {
+		int queuedOrActive = 0;
+		for (final T task : object2Task.values()) {
+			if (task.isQueuedOrActive()) {
+				queuedOrActive++;
+			}
+		}
+		return queuedOrActive;
 	}
 
 	private ExecutorService initExecutor(final String category) {
@@ -61,10 +96,12 @@ public class TaskMgr<T extends AbstractTask<R>, R> {
 					taskMgrListener.onAllTreatmentDone();
 				}
 
-				Iterator<Entry<Object, T>> it = object2Task.entrySet().iterator();
-				while (it.hasNext()) {
-					if (!it.next().getValue().isRunning()) {
-						it.remove();
+				synchronized (TaskMgr.this) {
+					Iterator<Entry<Object, T>> it = object2Task.entrySet().iterator();
+					while (it.hasNext()) {
+						if (it.next().getValue().isFinished()) {
+							it.remove();
+						}
 					}
 				}
 			}

--- a/application/core/src/com/dabi/habitv/core/token/TokenReplacer.java
+++ b/application/core/src/com/dabi/habitv/core/token/TokenReplacer.java
@@ -116,6 +116,22 @@ public final class TokenReplacer {
 		return toCut.substring(0, Math.min(size, toCut.length()));
 	}
 
+	/**
+	 * Compatibility bridge for stale inner classes compiled by other compilers
+	 * expecting synthetic accessors with the access$N naming.
+	 */
+	static String access$0(final String input) {
+		return ensure(input);
+	}
+
+	static String access$1(final String toCut, final List<String> params) {
+		return cut(toCut, params);
+	}
+
+	static String access$2(final int size, final String toCut) {
+		return cut(size, toCut);
+	}
+
 	public static void setCutSize(final Integer cutSize) {
 
 		for (final Entry<String, Replacer> ref2Replacer : new ArrayList<>(REF2REPLACER.entrySet())) {

--- a/application/core/test/com/dabi/habitv/core/config/XMLUserConfigTest.java
+++ b/application/core/test/com/dabi/habitv/core/config/XMLUserConfigTest.java
@@ -1,5 +1,6 @@
 package com.dabi.habitv.core.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
@@ -7,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.junit.After;
@@ -32,6 +34,49 @@ public class XMLUserConfigTest {
 		assertFalse(userConfig.getEmbedSubtitles());
 	}
 
+	@Test
+	public void maxConcurrentDownloadsDefaultsToOneWhenMissing() throws Exception {
+		final File file = File.createTempFile("habitv-config-", ".xml");
+		file.deleteOnExit();
+		Files.write(file.toPath(), minimalConfigWithoutMaxConcurrent().getBytes(
+				StandardCharsets.UTF_8));
+		assertEquals(1, XMLUserConfig.readConfigForTest(file).getMaxConcurrentDownloads());
+	}
+
+	@Test
+	public void maxConcurrentDownloadsReadsConfiguredValue() throws Exception {
+		final File file = File.createTempFile("habitv-config-", ".xml");
+		file.deleteOnExit();
+		Files.write(file.toPath(), ("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+				+ "<ns2:configuration xmlns:ns2=\"http://www.dabi.com/habitv/configuration/entities\">\n"
+				+ "    <proxies/>\n"
+				+ "    <osConfig/>\n"
+				+ "    <downloadConfig>\n"
+				+ "        <maxConcurrentDownloads>3</maxConcurrentDownloads>\n"
+				+ "        <downloadOuput>/tmp/#EPISODE#.mp4</downloadOuput>\n"
+				+ "    </downloadConfig>\n"
+				+ "</ns2:configuration>\n").getBytes(StandardCharsets.UTF_8));
+		assertEquals(3, XMLUserConfig.readConfigForTest(file).getMaxConcurrentDownloads());
+	}
+
+	@Test
+	public void maxConcurrentDownloadsFallsBackWhenInvalid() {
+		assertEquals(1, XMLUserConfig.resolveMaxConcurrentDownloads(Integer.valueOf(0)));
+		assertEquals(1, XMLUserConfig.resolveMaxConcurrentDownloads(null));
+	}
+
+	@Test
+	public void maxConcurrentDownloadsRoundTrip() throws Exception {
+		final File file = File.createTempFile("habitv-config-", ".xml");
+		file.deleteOnExit();
+		Files.write(file.toPath(), minimalConfigWithoutMaxConcurrent().getBytes(
+				StandardCharsets.UTF_8));
+		final XMLUserConfig config = XMLUserConfig.readConfigForTest(file);
+		config.setMaxConcurrentDownloads(2);
+		XMLUserConfig.saveConfig(file, config);
+		assertEquals(2, XMLUserConfig.readConfigForTest(file).getMaxConcurrentDownloads());
+	}
+
 	private static XMLUserConfig newConfigInstance() throws Exception {
 		final Method buildDefaultConfig = XMLUserConfig.class.getDeclaredMethod(
 				"buildDefaultConfig");
@@ -42,6 +87,17 @@ public class XMLUserConfigTest {
 				.getDeclaredConstructor(Configuration.class);
 		constructor.setAccessible(true);
 		return constructor.newInstance(configuration);
+	}
+
+	private static String minimalConfigWithoutMaxConcurrent() {
+		return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+				+ "<ns2:configuration xmlns:ns2=\"http://www.dabi.com/habitv/configuration/entities\">\n"
+				+ "    <proxies/>\n"
+				+ "    <osConfig/>\n"
+				+ "    <downloadConfig>\n"
+				+ "        <downloadOuput>/tmp/#EPISODE#.mp4</downloadOuput>\n"
+				+ "    </downloadConfig>\n"
+				+ "</ns2:configuration>\n";
 	}
 
 	@Test

--- a/application/core/test/com/dabi/habitv/core/dao/DownloadedDAOTest.java
+++ b/application/core/test/com/dabi/habitv/core/dao/DownloadedDAOTest.java
@@ -3,9 +3,14 @@
  */
 package com.dabi.habitv.core.dao;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.FileOutputStream;
 import java.util.Set;
 
 import org.junit.After;
@@ -16,6 +21,8 @@ import org.junit.Test;
 
 import com.dabi.habitv.api.plugin.dto.CategoryDTO;
 import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+import com.dabi.habitv.core.config.HabitTvConf;
+import com.dabi.habitv.utils.FileUtils;
 
 /**
  * @author bidou
@@ -73,9 +80,8 @@ public class DownloadedDAOTest {
 		initDAO();
 		assertTrue(dao.isIndexCreated());
 		final Set<String> toTest = dao.findDownloadedFiles();
-		assertArrayEquals(
-				new String[] { toAdd[0].getName(), toAdd[1].getName() },
-				toTest.toArray());
+		assertTrue(DownloadedDAO.containsEpisode(toTest, toAdd[0]));
+		assertTrue(DownloadedDAO.containsEpisode(toTest, toAdd[1]));
 	}
 
 	@Test
@@ -83,6 +89,72 @@ public class DownloadedDAOTest {
 		dao.initIndex();
 		final Set<String> toTest = dao.findDownloadedFiles();
 		assertTrue(toTest.isEmpty());
+	}
+
+	@Test
+	public final void doesNotShareIndexBetweenSameNamedCategories() {
+		final CategoryDTO france2Category = new CategoryDTO("francetv",
+				"La France en vrai", "france2-id", "mp4");
+		final CategoryDTO france3Category = new CategoryDTO("francetv",
+				"La France en vrai", "france3-id", "mp4");
+		final String france2Index = DownloadedDAO.getFileIndex(".",
+				france2Category);
+		final String france3Index = DownloadedDAO.getFileIndex(".",
+				france3Category);
+		assertFalse(france2Index.equals(france3Index));
+		final DownloadedDAO france2Dao = new DownloadedDAO(france2Category, ".");
+		final DownloadedDAO france3Dao = new DownloadedDAO(france3Category, ".");
+		france2Dao.initIndex();
+		france3Dao.initIndex();
+		france2Dao.initManualIndex();
+		france3Dao.initManualIndex();
+		final EpisodeDTO france2Episode = new EpisodeDTO(france2Category,
+				"episode-france2", "url");
+		france2Dao.addDownloadedFiles(false, france2Episode);
+		assertTrue(DownloadedDAO.containsEpisode(france2Dao.findDownloadedFiles(),
+				france2Episode));
+		assertTrue(france3Dao.findDownloadedFiles().isEmpty());
+	}
+
+	@Test
+	public final void readsLegacyIndexFileWhenNewIndexDoesNotExist() throws IOException {
+		final CategoryDTO legacyCategory = new CategoryDTO("legacy-plugin",
+				"legacy-show", "new-id", "mp4");
+		final File tempDir = new File(System.getProperty("java.io.tmpdir"),
+				"habitv-legacy-index-" + System.nanoTime());
+		try {
+			assertTrue(tempDir.mkdirs());
+			final String legacyIndexFile = new File(tempDir, FileUtils
+					.sanitizeFilename(legacyCategory.getPlugin() + "_"
+							+ legacyCategory.getName() + ".index")).getPath();
+			final String episodeName = "legacy-episode";
+			try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(
+					new FileOutputStream(legacyIndexFile), HabitTvConf.ENCODING))) {
+				writer.println(episodeName);
+			}
+			final DownloadedDAO legacyDao = new DownloadedDAO(legacyCategory,
+					tempDir.getPath());
+			final EpisodeDTO episode = new EpisodeDTO(legacyCategory, episodeName, "id");
+			assertTrue(DownloadedDAO.containsEpisodeOrLegacyName(
+					legacyDao.findDownloadedFiles(), episode));
+		} finally {
+			deleteRecursively(tempDir);
+		}
+	}
+
+	private void deleteRecursively(final File file) {
+		if (file == null || !file.exists()) {
+			return;
+		}
+		if (file.isDirectory()) {
+			final File[] children = file.listFiles();
+			if (children != null) {
+				for (File child : children) {
+					deleteRecursively(child);
+				}
+			}
+		}
+		assertTrue(file.delete());
 	}
 
 }

--- a/application/core/test/com/dabi/habitv/core/task/EpisodeDuplicateDetectorTest.java
+++ b/application/core/test/com/dabi/habitv/core/task/EpisodeDuplicateDetectorTest.java
@@ -1,0 +1,51 @@
+package com.dabi.habitv.core.task;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+public class EpisodeDuplicateDetectorTest {
+
+	@Test
+	public void skipsAlreadyDownloaded() {
+		final EpisodeDuplicateDetector detector = new EpisodeDuplicateDetector();
+		final EpisodeDTO episode = episode("arte", "show", "ep1", "http://x/1");
+		assertEquals(EnqueueSkipReason.ALREADY_DOWNLOADED,
+				detector.detectSkipReason(episode, true, false, false));
+	}
+
+	@Test
+	public void skipsAlreadyQueued() {
+		final EpisodeDuplicateDetector detector = new EpisodeDuplicateDetector();
+		final EpisodeDTO episode = episode("arte", "show", "ep1", "http://x/1");
+		assertEquals(EnqueueSkipReason.ALREADY_QUEUED,
+				detector.detectSkipReason(episode, false, true, false));
+	}
+
+	@Test
+	public void skipsAlreadyDownloading() {
+		final EpisodeDuplicateDetector detector = new EpisodeDuplicateDetector();
+		final EpisodeDTO episode = episode("arte", "show", "ep1", "http://x/1");
+		assertEquals(EnqueueSkipReason.ALREADY_DOWNLOADING,
+				detector.detectSkipReason(episode, false, false, true));
+	}
+
+	@Test
+	public void skipsDuplicateInBatch() {
+		final EpisodeDuplicateDetector detector = new EpisodeDuplicateDetector();
+		final EpisodeDTO episode = episode("arte", "show", "ep1", "http://x/1");
+		assertNull(detector.detectSkipReason(episode, false, false, false));
+		assertEquals(EnqueueSkipReason.DUPLICATE_IN_BATCH,
+				detector.detectSkipReason(episode, false, false, false));
+	}
+
+	private static EpisodeDTO episode(final String plugin, final String category,
+			final String name, final String id) {
+		return new EpisodeDTO(new CategoryDTO(plugin, category, category, null),
+				name, id);
+	}
+}

--- a/application/core/test/com/dabi/habitv/core/task/EpisodeMetadataFormattingTest.java
+++ b/application/core/test/com/dabi/habitv/core/task/EpisodeMetadataFormattingTest.java
@@ -1,0 +1,58 @@
+package com.dabi.habitv.core.task;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+public class EpisodeMetadataFormattingTest {
+
+	@Test
+	public void formatDateHandlesNull() {
+		assertEquals("Inconnu", EpisodeMetadataFormatting.formatDate(null));
+	}
+
+	@Test
+	public void formatDurationHandlesNull() {
+		assertEquals("Inconnu", EpisodeMetadataFormatting.formatDuration(null));
+	}
+
+	@Test
+	public void formatSizeHandlesNull() {
+		assertEquals("Inconnu", EpisodeMetadataFormatting.formatSize(null));
+	}
+
+	@Test
+	public void sortByNameUsesComparable() {
+		final EpisodeDTO first = episode("b");
+		final EpisodeDTO second = episode("a");
+		assertEquals(-1, second.compareTo(first));
+	}
+
+	@Test
+	public void missingMetadataDoesNotThrow() {
+		final EpisodeDTO episode = episode("test");
+		EpisodeMetadataFormatting.formatDate(episode.getEpisodeDate());
+		EpisodeMetadataFormatting.formatDuration(episode.getDurationSeconds());
+		EpisodeMetadataFormatting.formatSize(episode.getSizeBytes());
+		EpisodeMetadataFormatting.formatSource(episode);
+	}
+
+	private static EpisodeDTO episode(final String name) {
+		return new EpisodeDTO(new CategoryDTO("plugin", "cat", "cat", null), name,
+				"http://example/" + name);
+	}
+
+	@Test
+	public void formatDateFormatsValue() {
+		final Calendar calendar = new GregorianCalendar(2024, Calendar.JANUARY, 15);
+		final Date date = calendar.getTime();
+		assertEquals("2024-01-15", EpisodeMetadataFormatting.formatDate(date));
+	}
+}

--- a/application/core/test/com/dabi/habitv/core/task/SearchTaskTest.java
+++ b/application/core/test/com/dabi/habitv/core/task/SearchTaskTest.java
@@ -251,7 +251,8 @@ public class SearchTaskTest {
 			@Override
 			public Set<String> findDownloadedFiles() {
 				final Set<String> dlFiles = new HashSet<>();
-				dlFiles.add("episodeDl");
+				dlFiles.add(DownloadedDAO.buildEpisodeKey(
+						new EpisodeDTO(category, "episodeDl", "videoUrl")));
 				return dlFiles;
 			}
 

--- a/application/core/test/com/dabi/habitv/core/task/TaskMgrTest.java
+++ b/application/core/test/com/dabi/habitv/core/task/TaskMgrTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.concurrent.Callable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -245,15 +246,154 @@ public class TaskMgrTest {
 	}
 
 	@Test
+	public final void enforcesMaxConcurrentDownloadsOfOne() {
+		taskMgr = new TaskMgr<AbstractTask<Object>, Object>(1, new TaskMgrListener() {
+
+			@Override
+			public void onAllTreatmentDone() {
+				allTreatmentDone = true;
+			}
+
+			@Override
+			public void onFailed(final Throwable throwable) {
+				allTreatmentDone = false;
+			}
+		}, null);
+		taskMgr.addTask(buildSleepTask("t1", 500), buildSleepTask("t1", 500));
+		taskMgr.addTask(buildSleepTask("t2", 500), buildSleepTask("t2", 500));
+		assertTrue(waitForCondition(new Callable<Boolean>() {
+			@Override
+			public Boolean call() {
+				return taskMgr.getActiveTaskCount() == 1
+						&& taskMgr.getQueuedOrActiveTaskCount() >= 2;
+			}
+		}, 1000));
+		assertEquals(1, taskMgr.getActiveTaskCount());
+		assertTrue(taskMgr.getQueuedOrActiveTaskCount() >= 2);
+		taskMgr.shutdown(2000);
+	}
+
+	@Test
+	public final void enforcesMaxConcurrentDownloadsOfTwo() {
+		taskMgr = new TaskMgr<AbstractTask<Object>, Object>(2, new TaskMgrListener() {
+
+			@Override
+			public void onAllTreatmentDone() {
+				allTreatmentDone = true;
+			}
+
+			@Override
+			public void onFailed(final Throwable throwable) {
+				allTreatmentDone = false;
+			}
+		}, null);
+		for (int i = 0; i < 3; i++) {
+			final AbstractTask<Object> task = buildSleepTask("task" + i, 400);
+			taskMgr.addTask(task, task);
+		}
+		assertTrue(waitForCondition(new Callable<Boolean>() {
+			@Override
+			public Boolean call() {
+				return taskMgr.getActiveTaskCount() <= 2
+						&& taskMgr.getQueuedOrActiveTaskCount() >= 2;
+			}
+		}, 1000));
+		assertTrue(taskMgr.getQueuedOrActiveTaskCount() >= 2);
+		taskMgr.shutdown(2000);
+	}
+
+	private boolean waitForCondition(final Callable<Boolean> condition,
+			final long timeoutMillis) {
+		final long end = System.currentTimeMillis() + timeoutMillis;
+		while (System.currentTimeMillis() < end) {
+			try {
+				if (Boolean.TRUE.equals(condition.call())) {
+					return true;
+				}
+				Thread.sleep(25);
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new AssertionError("Interrupted while waiting for condition", e);
+			} catch (final Exception e) {
+				throw new AssertionError("Failed while waiting for condition", e);
+			}
+		}
+		return false;
+	}
+
+	private AbstractTask<Object> buildSleepTask(final String name, final long sleepMs) {
+		return new AbstractTaskForTest() {
+
+			@Override
+			protected Object doCall() {
+				try {
+					Thread.sleep(sleepMs);
+				} catch (final InterruptedException e) {
+					fail();
+				}
+				return null;
+			}
+
+			@Override
+			protected void failed(final Throwable e) {
+				throw new TechnicalException(e);
+			}
+
+			@Override
+			public String toString() {
+				return name;
+			}
+		};
+	}
+
+	@Test
+	public final void queuedOrActiveCountExcludesFinishedTasks() {
+		taskMgr = new TaskMgr<AbstractTask<Object>, Object>(1, new TaskMgrListener() {
+
+			@Override
+			public void onAllTreatmentDone() {
+				allTreatmentDone = true;
+			}
+
+			@Override
+			public void onFailed(final Throwable throwable) {
+				allTreatmentDone = false;
+			}
+		}, null);
+		final AbstractTask<Object> task = buildSleepTask("done-task", 50);
+		taskMgr.addTask(task, task);
+		assertTrue(waitForCondition(new Callable<Boolean>() {
+			@Override
+			public Boolean call() {
+				return taskMgr.getQueuedOrActiveTaskCount() >= 1;
+			}
+		}, 1000));
+		taskMgr.shutdown(2000);
+		assertTrue(waitForCondition(new Callable<Boolean>() {
+			@Override
+			public Boolean call() {
+				return taskMgr.getQueuedOrActiveTaskCount() == 0;
+			}
+		}, 2000));
+	}
+
+	@Test
 	public final void indicateWhenAllTreatmentAreDone() {
 		buildSimultaneousTask(2, null, null, false);
 		assertFalse(allTreatmentDone);
-		try {
-			Thread.sleep(1000);
-		} catch (final InterruptedException e) {
-			fail();
-		}
-		assertTrue(allTreatmentDone);
+		assertTrue(waitForAllTreatmentDone(3000));
 		taskMgr.shutdown(0);
+	}
+
+	private boolean waitForAllTreatmentDone(final long timeoutMs) {
+		final long deadline = System.currentTimeMillis() + timeoutMs;
+		while (!allTreatmentDone && System.currentTimeMillis() < deadline) {
+			try {
+				Thread.sleep(25);
+			} catch (final InterruptedException e) {
+				fail();
+			}
+		}
+		return allTreatmentDone;
 	}
 }

--- a/application/core/xsd/configuration-sample.xml
+++ b/application/core/xsd/configuration-sample.xml
@@ -16,6 +16,7 @@
   <downloadConfig>
     <downloadOuput>downloadOuput</downloadOuput>
     <maxAttempts>0</maxAttempts>
+    <maxConcurrentDownloads>1</maxConcurrentDownloads>
     <demonCheckTime>0</demonCheckTime>
     <fileNameCutSize>0</fileNameCutSize>
     <downloaders/>

--- a/application/core/xsd/configuration.xsd
+++ b/application/core/xsd/configuration.xsd
@@ -25,6 +25,7 @@
 						<all>
 							<element name="downloadOuput" type="string" minOccurs="0" />
 							<element name="maxAttempts" type="int" minOccurs="0" />
+							<element name="maxConcurrentDownloads" type="int" minOccurs="0" />
 							<element name="demonCheckTime" type="int" minOccurs="0" />
 							<element name="fileNameCutSize" type="int" minOccurs="0" />
 							<element name="downloaders" maxOccurs="1" minOccurs="0">

--- a/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
@@ -24,17 +24,21 @@ public class ConfigController extends BaseController {
 
 	private TextField youtubeApiKey;
 
+	private TextField maxConcurrentDownloads;
+
 	private CheckBox embedSubtitles;
 
 	public ConfigController(TextField downloadOuput, TextField nbrMaxAttempts,
 			TextField daemonCheckTimeSec, CheckBox autoUpdate,
-			TextField youtubeApiKey, CheckBox embedSubtitles) {
+			TextField youtubeApiKey, TextField maxConcurrentDownloads,
+			CheckBox embedSubtitles) {
 		super();
 		this.downloadOuput = downloadOuput;
 		this.nbrMaxAttempts = nbrMaxAttempts;
 		this.daemonCheckTimeSec = daemonCheckTimeSec;
 		this.autoUpdate = autoUpdate;
 		this.youtubeApiKey = youtubeApiKey;
+		this.maxConcurrentDownloads = maxConcurrentDownloads;
 		this.embedSubtitles = embedSubtitles;
 	}
 
@@ -65,6 +69,8 @@ public class ConfigController extends BaseController {
 				"si coché habiTv se mettra à jour automatiquement."));
 		youtubeApiKey.setTooltip(new Tooltip(
 				"Clé API YouTube Data v3. Laissez vide pour utiliser la variable d'environnement ou l'option Java."));
+		maxConcurrentDownloads.setTooltip(new Tooltip(
+				"Nombre maximum de téléchargements d'épisodes exécutés en même temps (minimum 1)."));
 		embedSubtitles.setTooltip(new Tooltip(
 				"Intègre les sous-titres dans la vidéo téléchargée lorsqu'ils sont disponibles. Nécessite ffmpeg via le post-traitement yt-dlp."));
 	}
@@ -77,6 +83,8 @@ public class ConfigController extends BaseController {
 				.getDemonCheckTime()));
 		autoUpdate.setSelected(userConfig.updateOnStartup());
 		youtubeApiKey.setText(userConfig.getYoutubeApiKey());
+		maxConcurrentDownloads.setText(String.valueOf(Math.max(1,
+				userConfig.getMaxConcurrentDownloads())));
 		embedSubtitles.setSelected(userConfig.getEmbedSubtitles());
 	}
 
@@ -103,8 +111,16 @@ public class ConfigController extends BaseController {
 			@Override
 			public void run() {
 				UserConfig userConfig = getController().loadUserConfig();
-				final Integer maxAttempts = Integer.parseInt(nbrMaxAttempts.getText());
-				if (!userConfig.getMaxAttempts().equals(maxAttempts)) {
+				final Integer currentValue = userConfig.getMaxAttempts();
+				final Integer maxAttempts = parsePositiveInteger(nbrMaxAttempts.getText());
+				if (maxAttempts == null) {
+					nbrMaxAttempts.setText(String.valueOf(currentValue));
+					new Popin().show("Configuration invalide",
+							"Le nombre maximum de tentatives doit être un entier supérieur ou égal à 1.");
+					return;
+				}
+				nbrMaxAttempts.setText(String.valueOf(maxAttempts.intValue()));
+				if (!currentValue.equals(maxAttempts)) {
 					userConfig.setMaxAttempts(maxAttempts);
 					saveConfig(userConfig);
 				}
@@ -118,8 +134,16 @@ public class ConfigController extends BaseController {
 			@Override
 			public void run() {
 				UserConfig userConfig = getController().loadUserConfig();
-				final Integer demonCheckTime = Integer.parseInt(daemonCheckTimeSec.getText());
-				if (!userConfig.getDemonCheckTime().equals(demonCheckTime)) {
+				final Integer currentValue = userConfig.getDemonCheckTime();
+				final Integer demonCheckTime = parsePositiveInteger(daemonCheckTimeSec.getText());
+				if (demonCheckTime == null) {
+					daemonCheckTimeSec.setText(String.valueOf(currentValue));
+					new Popin().show("Configuration invalide",
+							"La période entre deux recherches doit être un entier supérieur ou égal à 1.");
+					return;
+				}
+				daemonCheckTimeSec.setText(String.valueOf(demonCheckTime.intValue()));
+				if (!currentValue.equals(demonCheckTime)) {
 					userConfig.setDemonCheckTime(demonCheckTime);
 					saveConfig(userConfig);
 				}
@@ -142,6 +166,28 @@ public class ConfigController extends BaseController {
 			}
 		};
 		triggersave(youtubeApiKey, saveYoutubeApiKey);
+
+		Runnable saveMaxConcurrent = new Runnable() {
+
+			@Override
+			public void run() {
+				UserConfig userConfig = getController().loadUserConfig();
+				final int currentValue = Math.max(1, userConfig.getMaxConcurrentDownloads());
+				final Integer newValue = parsePositiveInteger(maxConcurrentDownloads.getText());
+				if (newValue == null) {
+					maxConcurrentDownloads.setText(String.valueOf(currentValue));
+					new Popin().show("Configuration invalide",
+							"Le nombre maximum de téléchargements simultanés doit être un entier supérieur ou égal à 1.");
+					return;
+				}
+				maxConcurrentDownloads.setText(String.valueOf(newValue.intValue()));
+				if (userConfig.getMaxConcurrentDownloads() != newValue.intValue()) {
+					userConfig.setMaxConcurrentDownloads(newValue);
+					saveConfig(userConfig);
+				}
+			}
+		};
+		triggersave(maxConcurrentDownloads, saveMaxConcurrent);
 
 		autoUpdate.setOnAction(new EventHandler<ActionEvent>() {
 
@@ -192,5 +238,14 @@ public class ConfigController extends BaseController {
 		}
 		String trimmed = value.trim();
 		return trimmed.isEmpty() ? null : trimmed;
+	}
+
+	private Integer parsePositiveInteger(String value) {
+		try {
+			final int parsed = Integer.parseInt(value == null ? "" : value.trim());
+			return parsed < 1 ? Integer.valueOf(1) : Integer.valueOf(parsed);
+		} catch (NumberFormatException e) {
+			return null;
+		}
 	}
 }

--- a/application/trayView/src/com/dabi/habitv/tray/controller/ViewController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/ViewController.java
@@ -8,7 +8,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+
+import com.dabi.habitv.core.task.BatchEnqueueResult;
 
 import org.apache.log4j.Logger;
 
@@ -332,6 +335,21 @@ public class ViewController implements CoreSubscriber {
 		}
 	}
 
+	public BatchEnqueueResult downloadSelectedEpisodes(final List<EpisodeDTO> episodes) {
+		if (episodes == null || episodes.isEmpty()) {
+			Popin.error("Sélectionnez au moins un épisode à télécharger.");
+			return null;
+		}
+		try {
+			return getManager()
+					.enqueueEpisodesForDownload(episodes);
+		} catch (Exception e) {
+			LOG.error("", e);
+			Popin.error(e.getMessage());
+			return null;
+		}
+	}
+
 	public void openLogFile() {
 		open(DirUtils.getLogFile());
 	}
@@ -341,9 +359,18 @@ public class ViewController implements CoreSubscriber {
 				.setContents(new StringSelection(episode.getId()), null);
 	}
 
-	public void openInBrowser(EpisodeDTO episodeDTO) {
+	public void openInBrowser(final EpisodeDTO episodeDTO) {
+		if (episodeDTO != null) {
+			openInBrowser(episodeDTO.getId());
+		}
+	}
+
+	public void openInBrowser(final String url) {
+		if (url == null || url.trim().isEmpty()) {
+			return;
+		}
 		try {
-			Desktop.getDesktop().browse(new URI(episodeDTO.getId()));
+			Desktop.getDesktop().browse(new URI(url.trim()));
 		} catch (Exception e) {
 			LOG.error("", e);
 			Popin.error(e.getMessage());

--- a/application/trayView/src/com/dabi/habitv/tray/controller/WindowController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/WindowController.java
@@ -11,7 +11,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListView;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TableView;
@@ -96,7 +95,16 @@ public class WindowController {
 	private TreeView<CategoryDTO> toDLTree;
 
 	@FXML
-	private ListView<EpisodeDTO> episodeListView;
+	private javafx.scene.control.TableView<EpisodeDTO> episodeTableView;
+
+	@FXML
+	private Button downloadSelectedButton;
+
+	@FXML
+	private Button selectAllEpisodesButton;
+
+	@FXML
+	private Button clearSelectionButton;
 
 	@FXML
 	private TextField episodeFilter;
@@ -137,6 +145,9 @@ public class WindowController {
 
 	@FXML
 	private TextField youtubeApiKey;
+
+	@FXML
+	private TextField maxConcurrentDownloads;
 
 	@FXML
 	private CheckBox embedSubtitles;
@@ -195,16 +206,17 @@ public class WindowController {
 			ToDownloadController toDlController = new ToDownloadController(
 					searchCategoryProgress, refreshCategoryButton,
 					cleanCategoryButton, toDLTree, indicationText,
-					episodeListView, episodeFilter, categoryFilter,
-					applySavedFilters, filterTypeChoice, addFilterButton,
-					currentFilterVBox);
+					episodeTableView, downloadSelectedButton,
+					selectAllEpisodesButton, clearSelectionButton, episodeFilter,
+					categoryFilter, applySavedFilters, filterTypeChoice,
+					addFilterButton, currentFilterVBox);
 			toDlController.init(controller, manager, primaryStage);
 			manager.attach(toDlController);
 
 			new ConfigController(downloadOuput, nbrMaxAttempts,
 					daemonCheckTimeSec, autoUpdate, youtubeApiKey,
-					embedSubtitles).init(controller, manager,
-					primaryStage);
+					maxConcurrentDownloads, embedSubtitles).init(controller,
+					manager, primaryStage);
 
 			controller.startDownloadCheckDemon();
 

--- a/application/trayView/src/com/dabi/habitv/tray/controller/todl/EpisodeDownloadStatusResolver.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/todl/EpisodeDownloadStatusResolver.java
@@ -1,0 +1,38 @@
+package com.dabi.habitv.tray.controller.todl;
+
+import java.util.Set;
+
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+import com.dabi.habitv.core.dao.DownloadedDAO;
+import com.dabi.habitv.core.event.EpisodeStateEnum;
+
+final class EpisodeDownloadStatusResolver {
+
+	private EpisodeDownloadStatusResolver() {
+	}
+
+	static String resolve(final EpisodeDTO episode,
+			final Set<String> downloadedEpisodeNames,
+			final EpisodeStateEnum liveState) {
+		if (episode == null) {
+			return "Inconnu";
+		}
+		if (downloadedEpisodeNames != null
+				&& DownloadedDAO.containsEpisodeOrLegacyName(downloadedEpisodeNames,
+						episode)) {
+			return "Téléchargé";
+		}
+		if (liveState != null) {
+			if (liveState == EpisodeStateEnum.DOWNLOAD_STARTING) {
+				return "Téléchargement";
+			}
+			if (liveState == EpisodeStateEnum.TO_DOWNLOAD) {
+				return "En file";
+			}
+			if (liveState.isInProgress()) {
+				return "En cours";
+			}
+		}
+		return "Disponible";
+	}
+}

--- a/application/trayView/src/com/dabi/habitv/tray/controller/todl/ToDownloadController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/todl/ToDownloadController.java
@@ -4,6 +4,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -12,10 +15,17 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
+import com.dabi.habitv.core.task.BatchEnqueueResult;
+import com.dabi.habitv.core.task.EnqueueSkipReason;
+import com.dabi.habitv.core.task.EpisodeEnqueueResult;
+import com.dabi.habitv.core.event.EpisodeStateEnum;
+import com.dabi.habitv.core.task.EpisodeMetadataFormatting;
+
 import com.dabi.habitv.api.plugin.dto.CategoryDTO;
 import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
 import com.dabi.habitv.api.plugin.dto.StatusEnum;
 import com.dabi.habitv.api.plugin.pub.UpdatablePluginEvent;
+import com.dabi.habitv.core.dao.DownloadedDAO;
 import com.dabi.habitv.core.event.RetreiveEvent;
 import com.dabi.habitv.core.event.SearchCategoryEvent;
 import com.dabi.habitv.core.event.SearchEvent;
@@ -32,6 +42,7 @@ import com.dabi.habitv.tray.subscriber.CoreSubscriber;
 import com.dabi.habitv.utils.FilterUtils;
 
 import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
@@ -43,10 +54,14 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.CheckBoxTreeItem;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
@@ -57,7 +72,6 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
-import javafx.scene.paint.Color;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
 
@@ -75,15 +89,25 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 	private ProgressIndicator searchCategoryProgress;
 
-	private ListView<EpisodeDTO> episodeListView;
+	private TableView<EpisodeDTO> episodeTableView;
+
+	private Button downloadSelectedButton;
+
+	private Button selectAllEpisodesButton;
+
+	private Button clearSelectionButton;
 
 	private TextField episodeFilter;
+
+	private final Map<EpisodeDTO, EpisodeStateEnum> episodeLiveStates = new HashMap<>();
 
 	private Collection<EpisodeDTO> currentEpisodes;
 
 	private TextField categoryFilter;
 
 	private Set<String> downloadedEpisodes;
+
+	private volatile boolean enqueueInProgress;
 
 	private ChoiceBox<IncludeExcludeEnum> filterTypeChoice;
 
@@ -94,16 +118,19 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 	private CheckBox applySavedFilters;
 
 	public ToDownloadController(ProgressIndicator searchCategoryProgress, Button refreshCategoryButton, Button cleanCategoryButton,
-	        TreeView<CategoryDTO> toDLTree, Label indicationTextFlow, ListView<EpisodeDTO> episodeListView, TextField episodeFilter,
-	        TextField categoryFilter, CheckBox applySavedFilters, ChoiceBox<IncludeExcludeEnum> filterTypeChoice, Button addFilterButton,
-	        HBox currentFilterVBox) {
+	        TreeView<CategoryDTO> toDLTree, Label indicationTextFlow, TableView<EpisodeDTO> episodeTableView,
+	        Button downloadSelectedButton, Button selectAllEpisodesButton, Button clearSelectionButton, TextField episodeFilter, TextField categoryFilter, CheckBox applySavedFilters,
+	        ChoiceBox<IncludeExcludeEnum> filterTypeChoice, Button addFilterButton, HBox currentFilterVBox) {
 		super();
 		this.refreshCategoryButton = refreshCategoryButton;
 		this.cleanCategoryButton = cleanCategoryButton;
 		this.toDLTree = toDLTree;
 		this.indicationText = indicationTextFlow;
 		this.searchCategoryProgress = searchCategoryProgress;
-		this.episodeListView = episodeListView;
+		this.episodeTableView = episodeTableView;
+		this.downloadSelectedButton = downloadSelectedButton;
+		this.selectAllEpisodesButton = selectAllEpisodesButton;
+		this.clearSelectionButton = clearSelectionButton;
 		this.episodeFilter = episodeFilter;
 		this.categoryFilter = categoryFilter;
 		this.filterTypeChoice = filterTypeChoice;
@@ -120,10 +147,313 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 	@Override
 	protected void init() {
 		loadTree();
+		initEpisodeTable();
 		addButtonsActions();
 		addTooltips();
 		initFilters();
 		initIncludeExcludeFilterHandler();
+	}
+
+	private void initEpisodeTable() {
+		episodeTableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+		episodeTableView.getColumns().clear();
+		episodeTableView.getColumns().add(buildNameColumn());
+		episodeTableView.getColumns().add(buildDateColumn());
+		episodeTableView.getColumns().add(buildDurationColumn());
+		episodeTableView.getColumns().add(buildSizeColumn());
+		episodeTableView.getColumns().add(buildStatusColumn());
+		episodeTableView.getColumns().add(buildProgramLinkColumn());
+		episodeTableView.getColumns().add(buildQuickDownloadColumn());
+		episodeTableView.setRowFactory(tv -> new TableRow<EpisodeDTO>() {
+			@Override
+			protected void updateItem(EpisodeDTO episode, boolean empty) {
+				super.updateItem(episode, empty);
+				if (empty || episode == null) {
+					setStyle("");
+				} else if (downloadedEpisodes != null
+						&& DownloadedDAO.containsEpisodeOrLegacyName(downloadedEpisodes,
+								episode)) {
+					setStyle("-fx-text-fill: gray;");
+				} else if (isSelected()) {
+					setStyle("-fx-background-color: -fx-selection-bar;");
+				} else {
+					setStyle("");
+				}
+			}
+		});
+		episodeTableView.getSelectionModel().getSelectedItems().addListener(
+				(javafx.collections.ListChangeListener.Change<? extends EpisodeDTO> change) -> {
+					updateDownloadSelectionUi();
+				});
+		downloadSelectedButton.setOnAction(new EventHandler<ActionEvent>() {
+			@Override
+			public void handle(ActionEvent event) {
+				downloadSelectedEpisodesAsync();
+			}
+		});
+		selectAllEpisodesButton.setOnAction(new EventHandler<ActionEvent>() {
+			@Override
+			public void handle(ActionEvent event) {
+				episodeTableView.getSelectionModel().selectAll();
+				updateDownloadSelectionUi();
+			}
+		});
+		clearSelectionButton.setOnAction(new EventHandler<ActionEvent>() {
+			@Override
+			public void handle(ActionEvent event) {
+				episodeTableView.getSelectionModel().clearSelection();
+				updateDownloadSelectionUi();
+			}
+		});
+		episodeTableView.setOnKeyPressed(new EventHandler<KeyEvent>() {
+			@Override
+			public void handle(KeyEvent event) {
+				if (event.isControlDown() && event.getCode() == KeyCode.A) {
+					episodeTableView.getSelectionModel().selectAll();
+					updateDownloadSelectionUi();
+					event.consume();
+				} else if (event.getCode() == KeyCode.ESCAPE) {
+					episodeTableView.getSelectionModel().clearSelection();
+					updateDownloadSelectionUi();
+					event.consume();
+				} else if (event.getCode() == KeyCode.ENTER) {
+					downloadSelectedEpisodesAsync();
+					event.consume();
+				}
+			}
+		});
+		episodeTableView.setContextMenu(buildEpisodeContextMenu());
+		episodeTableView.getSelectionModel().selectedItemProperty()
+				.addListener(new ChangeListener<EpisodeDTO>() {
+					@Override
+					public void changed(ObservableValue<? extends EpisodeDTO> observable,
+							EpisodeDTO oldValue, EpisodeDTO newValue) {
+						if (ouvrirUrl != null) {
+							ouvrirUrl.setDisable(!isHttpUrl(newValue));
+						}
+					}
+				});
+		updateDownloadSelectionUi();
+	}
+
+	private void setManualDownloadControlsDisabled(final boolean disabled) {
+		downloadSelectedButton.setDisable(disabled);
+		selectAllEpisodesButton.setDisable(disabled);
+		clearSelectionButton.setDisable(disabled);
+	}
+
+	private void updateDownloadSelectionUi() {
+		final int selectedCount = episodeTableView.getSelectionModel().getSelectedItems()
+				.size();
+		downloadSelectedButton
+				.setText(selectedCount > 0 ? "Télécharger la sélection (" + selectedCount + ")"
+						: "Télécharger la sélection");
+		if (enqueueInProgress) {
+			setManualDownloadControlsDisabled(true);
+			return;
+		}
+		downloadSelectedButton.setDisable(selectedCount == 0);
+		clearSelectionButton.setDisable(selectedCount == 0);
+		final int itemCount = episodeTableView.getItems() == null ? 0
+				: episodeTableView.getItems().size();
+		selectAllEpisodesButton.setDisable(itemCount == 0 || selectedCount == itemCount);
+	}
+
+	private TableColumn<EpisodeDTO, String> buildNameColumn() {
+		final TableColumn<EpisodeDTO, String> column = new TableColumn<>("Épisode");
+		column.setPrefWidth(180);
+		column.setCellValueFactory(features -> new ReadOnlyObjectWrapper<>(
+				features.getValue() == null ? "" : features.getValue().getName()));
+		column.setComparator(nullsFirst(String.CASE_INSENSITIVE_ORDER));
+		column.setSortable(true);
+		return column;
+	}
+
+	private TableColumn<EpisodeDTO, Date> buildDateColumn() {
+		final TableColumn<EpisodeDTO, Date> column = new TableColumn<>("Date");
+		column.setPrefWidth(90);
+		column.setCellValueFactory(features -> new ReadOnlyObjectWrapper<>(
+				features.getValue() == null ? null : features.getValue().getEpisodeDate()));
+		column.setCellFactory(col -> new TableCell<EpisodeDTO, Date>() {
+			@Override
+			protected void updateItem(final Date item, final boolean empty) {
+				super.updateItem(item, empty);
+				setText(empty ? "" : EpisodeMetadataFormatting.formatDate(item));
+			}
+		});
+		column.setComparator(nullsFirst(Comparator.<Date>naturalOrder()));
+		column.setSortable(true);
+		return column;
+	}
+
+	private TableColumn<EpisodeDTO, Long> buildDurationColumn() {
+		return buildLongColumn("Durée", 80,
+				episode -> episode.getDurationSeconds(),
+				EpisodeMetadataFormatting::formatDuration);
+	}
+
+	private TableColumn<EpisodeDTO, Long> buildSizeColumn() {
+		return buildLongColumn("Taille", 70,
+				episode -> episode.getSizeBytes(),
+				EpisodeMetadataFormatting::formatSize);
+	}
+
+	private TableColumn<EpisodeDTO, Long> buildLongColumn(final String title,
+			final double prefWidth,
+			final java.util.function.Function<EpisodeDTO, Long> extractor,
+			final java.util.function.Function<Long, String> formatter) {
+		final TableColumn<EpisodeDTO, Long> column = new TableColumn<>(title);
+		column.setPrefWidth(prefWidth);
+		column.setCellValueFactory(features -> new ReadOnlyObjectWrapper<>(
+				features.getValue() == null ? null : extractor.apply(features.getValue())));
+		column.setCellFactory(col -> new TableCell<EpisodeDTO, Long>() {
+			@Override
+			protected void updateItem(final Long item, final boolean empty) {
+				super.updateItem(item, empty);
+				setText(empty ? "" : formatter.apply(item));
+			}
+		});
+		column.setComparator(nullsFirst(Comparator.<Long>naturalOrder()));
+		column.setSortable(true);
+		return column;
+	}
+
+	private static <T> Comparator<T> nullsFirst(final Comparator<T> base) {
+		return (left, right) -> {
+			if (left == null && right == null) {
+				return 0;
+			}
+			if (left == null) {
+				return -1;
+			}
+			if (right == null) {
+				return 1;
+			}
+			return base.compare(left, right);
+		};
+	}
+
+	private TableColumn<EpisodeDTO, String> buildStatusColumn() {
+		final TableColumn<EpisodeDTO, String> column = new TableColumn<>("Statut");
+		column.setPrefWidth(100);
+		column.setCellValueFactory(features -> {
+			final EpisodeDTO episode = features.getValue();
+			final String status = EpisodeDownloadStatusResolver.resolve(episode,
+					downloadedEpisodes, episodeLiveStates.get(episode));
+			return new javafx.beans.property.SimpleStringProperty(status);
+		});
+		column.setSortable(false);
+		return column;
+	}
+
+	private TableColumn<EpisodeDTO, Void> buildProgramLinkColumn() {
+		final TableColumn<EpisodeDTO, Void> column = new TableColumn<>("Programme");
+		column.setPrefWidth(140);
+		column.setSortable(false);
+		column.setCellFactory(col -> new ProgramLinkTableCell());
+		return column;
+	}
+
+	private TableColumn<EpisodeDTO, Void> buildQuickDownloadColumn() {
+		final TableColumn<EpisodeDTO, Void> column = new TableColumn<>("Action");
+		column.setPrefWidth(110);
+		column.setSortable(false);
+		column.setCellFactory(col -> new TableCell<EpisodeDTO, Void>() {
+			private final Button actionButton = new Button("Télécharger");
+			{
+				actionButton.setOnAction(new EventHandler<ActionEvent>() {
+					@Override
+					public void handle(ActionEvent event) {
+						final EpisodeDTO episode = episodeAtRow();
+						if (episode != null) {
+							getController().downloadEpisode(episode);
+						}
+					}
+				});
+			}
+
+			@Override
+			protected void updateItem(Void item, boolean empty) {
+				super.updateItem(item, empty);
+				setGraphic(empty || episodeAtRow() == null ? null : actionButton);
+			}
+
+			private EpisodeDTO episodeAtRow() {
+				final TableRow<?> row = getTableRow();
+				if (row == null) {
+					return null;
+				}
+				final Object rowItem = row.getItem();
+				return rowItem instanceof EpisodeDTO ? (EpisodeDTO) rowItem : null;
+			}
+		});
+		return column;
+	}
+
+	private final class ProgramLinkTableCell extends TableCell<EpisodeDTO, Void> {
+
+		private final Hyperlink link = new Hyperlink();
+
+		private ProgramLinkTableCell() {
+			link.setOnAction(event -> {
+				final String url = programPageUrl(episodeAtRow());
+				if (url != null) {
+					getController().openInBrowser(url);
+				}
+			});
+		}
+
+		@Override
+		protected void updateItem(final Void item, final boolean empty) {
+			super.updateItem(item, empty);
+			if (empty) {
+				setGraphic(null);
+				return;
+			}
+			final EpisodeDTO episode = episodeAtRow();
+			if (episode == null) {
+				setGraphic(null);
+				return;
+			}
+			final String url = programPageUrl(episode);
+			final String label = formatProgramLinkLabel(episode);
+			if (url == null) {
+				setGraphic(new Label(label));
+			} else {
+				link.setText(label);
+				setGraphic(link);
+			}
+		}
+
+		private String programPageUrl(final EpisodeDTO episode) {
+			if (episode == null || episode.getCategory() == null) {
+				return null;
+			}
+			final String categoryId = episode.getCategory().getId();
+			if (categoryId != null && (categoryId.startsWith("http://")
+					|| categoryId.startsWith("https://"))) {
+				return categoryId;
+			}
+			return null;
+		}
+
+		private String formatProgramLinkLabel(final EpisodeDTO episode) {
+			if (episode == null || episode.getCategory() == null
+					|| episode.getCategory().getName() == null
+					|| episode.getCategory().getName().trim().isEmpty()) {
+				return "Inconnu";
+			}
+			return episode.getCategory().getName();
+		}
+
+		private EpisodeDTO episodeAtRow() {
+			final TableRow<?> row = getTableRow();
+			if (row == null) {
+				return null;
+			}
+			final Object rowItem = row.getItem();
+			return rowItem instanceof EpisodeDTO ? (EpisodeDTO) rowItem : null;
+		}
 	}
 
 	private void initIncludeExcludeFilterHandler() {
@@ -231,7 +561,7 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 	private void emptyEpisodeList() {
 		ObservableList<EpisodeDTO> obsEp = FXCollections.observableArrayList();
-		episodeListView.setItems(obsEp);
+		episodeTableView.setItems(obsEp);
 	}
 
 	private void buildContextMenu(final TreeItem<CategoryDTO> treeItem) {
@@ -370,8 +700,11 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 		ObservableList<EpisodeDTO> obsEp = FXCollections.observableArrayList();
 		obsEp.addAll(Arrays.asList(new EpisodeDTO(null, "Chargement...", "")));
 
-		episodeListView.setItems(obsEp);
-		downloadedEpisodes = getController().getManager().findDownloadedEpisodes(category);
+		episodeTableView.setItems(obsEp);
+		final Set<String> resolvedDownloads = getController().getManager()
+				.findDownloadedEpisodes(category);
+		downloadedEpisodes = resolvedDownloads == null ? java.util.Collections
+				.<String> emptySet() : resolvedDownloads;
 
 		new Thread(new Runnable() {
 
@@ -382,7 +715,7 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 			        @Override
 			        public void run() {
-				        initListView(currentEpisodes);
+				        initEpisodeItems(currentEpisodes);
 				        filterEpisodeListView("");
 			        }
 		        });
@@ -392,48 +725,83 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 	}
 
-	private void initListView(final Collection<EpisodeDTO> episodes) {
+	private void initEpisodeItems(final Collection<EpisodeDTO> episodes) {
 		ObservableList<EpisodeDTO> obsEp = FXCollections.observableArrayList();
 		obsEp.addAll(episodes);
+		episodeTableView.setItems(obsEp);
+		episodeTableView.getSelectionModel().clearSelection();
+		updateDownloadSelectionUi();
+		episodeTableView.refresh();
+	}
 
-		episodeListView.setItems(obsEp);
-
-		episodeListView.setCellFactory(new Callback<ListView<EpisodeDTO>, ListCell<EpisodeDTO>>() {
+	private void downloadSelectedEpisodesAsync() {
+		if (enqueueInProgress) {
+			return;
+		}
+		final List<EpisodeDTO> selectedEpisodes = new ArrayList<>(
+				episodeTableView.getSelectionModel().getSelectedItems());
+		if (selectedEpisodes.isEmpty()) {
+			updateDownloadSelectionUi();
+			return;
+		}
+		enqueueInProgress = true;
+		setManualDownloadControlsDisabled(true);
+		updateDownloadSelectionUi();
+		new Thread(new Runnable() {
 			@Override
-			public ListCell<EpisodeDTO> call(ListView<EpisodeDTO> param) {
-				return new ListCell<EpisodeDTO>() {
-
-			        @Override
-			        protected void updateItem(EpisodeDTO episode, boolean empty) {
-				        super.updateItem(episode, empty);
-
-				        if (!empty) {
-					        setText(episode.getName());
-
-					        if (downloadedEpisodes.contains(episode.getName())) {
-						        setTextFill(Color.GRAY);
-					        } else {
-						        setTextFill(Color.BLACK);
-					        }
-				        } else {
-					        setText(null);
-				        }
-			        }
-		        };
-			}
-		});
-
-		episodeListView.setContextMenu(buildEpisodeContextMenu());
-
-		episodeListView.getSelectionModel().selectedItemProperty().addListener(new ChangeListener<EpisodeDTO>() {
-
-			@Override
-			public void changed(ObservableValue<? extends EpisodeDTO> observable, EpisodeDTO oldValue, EpisodeDTO newValue) {
-				if (ouvrirUrl != null && observable.getValue() != null) {
-					ouvrirUrl.setDisable(!observable.getValue().getId().startsWith("http:"));
+			public void run() {
+				BatchEnqueueResult result = null;
+				try {
+					result = getController().downloadSelectedEpisodes(selectedEpisodes);
+				} finally {
+					final BatchEnqueueResult finalResult = result;
+					Platform.runLater(new Runnable() {
+						@Override
+						public void run() {
+							enqueueInProgress = false;
+							updateDownloadSelectionUi();
+							if (finalResult != null) {
+								new Popin().show("File de téléchargement",
+										buildBatchQueueSummary(finalResult));
+							}
+						}
+					});
 				}
 			}
-		});
+		}).start();
+	}
+
+	private String buildBatchQueueSummary(final BatchEnqueueResult result) {
+		final StringBuilder summary = new StringBuilder();
+		summary.append("Ajoutés : ").append(result.getAddedCount()).append('\n');
+		summary.append("Ignorés : ").append(result.getSkippedCount());
+		final Map<EnqueueSkipReason, Integer> skipCounts = new HashMap<>();
+		for (EpisodeEnqueueResult item : result.getResults()) {
+			if (item.getSkipReason() != null) {
+				final Integer currentCount = skipCounts.get(item.getSkipReason());
+				skipCounts.put(item.getSkipReason(),
+						currentCount == null ? 1 : currentCount + 1);
+			}
+		}
+		if (!skipCounts.isEmpty()) {
+			summary.append("\n\nDétails des éléments ignorés :");
+			appendReason(summary, "déjà téléchargés",
+					skipCounts.get(EnqueueSkipReason.ALREADY_DOWNLOADED));
+			appendReason(summary, "déjà en file",
+					skipCounts.get(EnqueueSkipReason.ALREADY_QUEUED));
+			appendReason(summary, "téléchargement en cours",
+					skipCounts.get(EnqueueSkipReason.ALREADY_DOWNLOADING));
+			appendReason(summary, "doublons dans la sélection",
+					skipCounts.get(EnqueueSkipReason.DUPLICATE_IN_BATCH));
+		}
+		return summary.toString();
+	}
+
+	private void appendReason(final StringBuilder summary, final String reason,
+			final Integer count) {
+		if (count != null && count > 0) {
+			summary.append("\n- ").append(reason).append(": ").append(count);
+		}
 	}
 
 	MenuItem ouvrirUrl = new MenuItem("Ouvrir dans le navigateur");
@@ -445,7 +813,7 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 			@Override
 			public void handle(ActionEvent event) {
-				getController().downloadEpisode(episodeListView.getSelectionModel().getSelectedItem());
+				getController().downloadEpisode(episodeTableView.getSelectionModel().getSelectedItem());
 			}
 		});
 		contextMenu.getItems().add(telecharger);
@@ -455,7 +823,7 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 			@Override
 			public void handle(ActionEvent event) {
-				getController().copyUrl(episodeListView.getSelectionModel().getSelectedItem());
+				getController().copyUrl(episodeTableView.getSelectionModel().getSelectedItem());
 			}
 		});
 		contextMenu.getItems().add(urlCopie);
@@ -464,9 +832,11 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 			@Override
 			public void handle(ActionEvent event) {
-				getController().openInBrowser(episodeListView.getSelectionModel().getSelectedItem());
+				getController().openInBrowser(episodeTableView.getSelectionModel().getSelectedItem());
 			}
 		});
+		contextMenu.setOnShowing(event -> ouvrirUrl
+				.setDisable(!isHttpUrl(episodeTableView.getSelectionModel().getSelectedItem())));
 		contextMenu.getItems().add(ouvrirUrl);
 
 		MenuItem marquerTelecharger = new MenuItem("Marquer comme téléchargé");
@@ -474,10 +844,13 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 			@Override
 			public void handle(ActionEvent event) {
-				EpisodeDTO episode = episodeListView.getSelectionModel().getSelectedItem();
+				EpisodeDTO episode = episodeTableView.getSelectionModel().getSelectedItem();
 				getController().setDownloaded(episode);
 				filterEpisodeListView(episodeFilter.getText());
-				downloadedEpisodes.add(episode.getName());
+				final String episodeKey = DownloadedDAO.buildEpisodeKey(episode);
+				if (episodeKey != null) {
+					downloadedEpisodes.add(episodeKey);
+				}
 			}
 		});
 
@@ -566,7 +939,7 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 	}
 
 	private void filterEpisodeListView(String text) {
-		initListView(filterEpisodeList(text, this.filterTypeChoice.getValue().isInclude()));
+		initEpisodeItems(filterEpisodeList(text, this.filterTypeChoice.getValue().isInclude()));
 	}
 
 	private Collection<EpisodeDTO> filterEpisodeList(String text, boolean include) {
@@ -599,8 +972,16 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 	private void addTooltips() {
 		refreshCategoryButton.setTooltip(new Tooltip("Rafraichir l'arbre des catégories."));
 		cleanCategoryButton.setTooltip(new Tooltip("Enlever les catégories périmées."));
-		indicationText.setText(
-		        "Sélectionner les catégories à surveiller pour le téléchargement automatique \n et cliquer sur les épisodes à droite pour le téléchargement manuel.");
+		indicationText.setText("Sélectionnez des catégories pour les téléchargements automatiques. "
+				+ "Sélectionnez un ou plusieurs épisodes puis utilisez « Télécharger la sélection » "
+				+ "ou le menu contextuel.");
+		downloadSelectedButton.setTooltip(new Tooltip(
+				"Ajoute tous les épisodes sélectionnés dans la file (en ignorant les doublons)."));
+	}
+
+	private static boolean isHttpUrl(final EpisodeDTO episode) {
+		return episode != null && episode.getId() != null
+				&& DownloadUtils.isHttpUrl(episode.getId());
 	}
 
 	private void addButtonsActions() {
@@ -708,7 +1089,30 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 	}
 
 	@Override
-	public void update(RetreiveEvent event) {
+	public void update(final RetreiveEvent event) {
+		if (event == null || event.getEpisode() == null) {
+			return;
+		}
+		Platform.runLater(new Runnable() {
+			@Override
+			public void run() {
+				episodeLiveStates.put(event.getEpisode(), event.getState());
+				if (event.getState() == EpisodeStateEnum.DOWNLOADED
+						|| event.getState() == EpisodeStateEnum.READY) {
+					if (downloadedEpisodes != null) {
+						final String episodeKey = DownloadedDAO
+								.buildEpisodeKey(event.getEpisode());
+						if (episodeKey != null) {
+							downloadedEpisodes.add(episodeKey);
+						}
+					}
+					episodeLiveStates.remove(event.getEpisode());
+				}
+				if (episodeTableView != null) {
+					episodeTableView.refresh();
+				}
+			}
+		});
 	}
 
 	private int searchCount;
@@ -747,23 +1151,9 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 	private static final StringConverter<TreeItem<CategoryDTO>> STR_CONVERTER = new StringConverter<TreeItem<CategoryDTO>>() {
 		@Override
 		public String toString(TreeItem<CategoryDTO> treeItem) {
-			return (treeItem == null || treeItem.getValue() == null) ? "" : treeItem.getValue().getName();
-			// + (hasSelectedChild(treeItem.getValue()) ? "*"
-	        // : "");
+			return (treeItem == null || treeItem.getValue() == null) ? ""
+					: treeItem.getValue().getName();
 		}
-
-		// private boolean hasSelectedChild(CategoryDTO categoryDTO) {
-	    // for (CategoryDTO subCategoryDTO : categoryDTO.getSubCategories()) {
-	    // if (subCategoryDTO.isSelected()) {
-	    // return true;
-	    // } else {
-	    // if (hasSelectedChild(subCategoryDTO)) {
-	    // return true;
-	    // }
-	    // }
-	    // }
-	    // return false;
-	    // }
 
 		@Override
 		public TreeItem<CategoryDTO> fromString(String string) {

--- a/application/trayView/src/com/dabi/habitv/tray/controller/todl/ToDownloadController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/todl/ToDownloadController.java
@@ -426,24 +426,11 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 		}
 
 		private String programPageUrl(final EpisodeDTO episode) {
-			if (episode == null || episode.getCategory() == null) {
-				return null;
-			}
-			final String categoryId = episode.getCategory().getId();
-			if (categoryId != null && (categoryId.startsWith("http://")
-					|| categoryId.startsWith("https://"))) {
-				return categoryId;
-			}
-			return null;
+			return EpisodeMetadataFormatting.programPageUrl(episode);
 		}
 
 		private String formatProgramLinkLabel(final EpisodeDTO episode) {
-			if (episode == null || episode.getCategory() == null
-					|| episode.getCategory().getName() == null
-					|| episode.getCategory().getName().trim().isEmpty()) {
-				return "Inconnu";
-			}
-			return episode.getCategory().getName();
+			return EpisodeMetadataFormatting.formatProgramLinkLabel(episode);
 		}
 
 		private EpisodeDTO episodeAtRow() {

--- a/application/trayView/src/com/dabi/habitv/tray/habitv.fxml
+++ b/application/trayView/src/com/dabi/habitv/tray/habitv.fxml
@@ -151,10 +151,34 @@
 												</AnchorPane>
 												<AnchorPane>
 													<children>
-														<ListView fx:id="episodeListView"
-															AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-															AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"
-															BorderPane.alignment="CENTER" />
+														<VBox AnchorPane.bottomAnchor="0.0"
+															AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
+															AnchorPane.topAnchor="0.0">
+															<children>
+																<HBox spacing="5.0">
+																	<children>
+																		<Button fx:id="downloadSelectedButton"
+																			disable="true" mnemonicParsing="false"
+																			text="Télécharger la sélection" />
+																		<Button fx:id="selectAllEpisodesButton"
+																			mnemonicParsing="false" text="Tout sélectionner" />
+																		<Button fx:id="clearSelectionButton"
+																			disable="true" mnemonicParsing="false"
+																			text="Effacer la sélection" />
+																	</children>
+																	<padding>
+																		<Insets bottom="5.0" left="5.0" right="5.0"
+																			top="5.0" />
+																	</padding>
+																</HBox>
+																<TableView fx:id="episodeTableView"
+																	VBox.vgrow="ALWAYS">
+																	<columnResizePolicy>
+																		<TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+																	</columnResizePolicy>
+																</TableView>
+															</children>
+														</VBox>
 													</children>
 												</AnchorPane>
 											</items>
@@ -268,11 +292,16 @@
 										<TextField fx:id="youtubeApiKey"
 											BorderPane.alignment="CENTER" GridPane.columnIndex="1"
 											GridPane.rowIndex="4" />
-										<Label text="Intégrer les sous-titres lorsqu'ils sont disponibles :"
+										<Label text="Téléchargements simultanés max : "
 											GridPane.columnIndex="0" GridPane.rowIndex="5" />
+										<TextField fx:id="maxConcurrentDownloads"
+											maxWidth="50.0" prefWidth="50.0" GridPane.columnIndex="1"
+											GridPane.rowIndex="5" />
+										<Label text="Intégrer les sous-titres lorsqu'ils sont disponibles :"
+											GridPane.columnIndex="0" GridPane.rowIndex="6" />
 										<CheckBox fx:id="embedSubtitles"
 											mnemonicParsing="false" GridPane.columnIndex="1"
-											GridPane.rowIndex="5" />
+											GridPane.rowIndex="6" />
 									</children>
 									<padding>
 										<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/application/trayView/src/com/dabi/habitv/tray/model/HabitTvViewManager.java
+++ b/application/trayView/src/com/dabi/habitv/tray/model/HabitTvViewManager.java
@@ -19,6 +19,7 @@ import com.dabi.habitv.core.dao.GrabConfigDAO.LoadModeEnum;
 import com.dabi.habitv.core.event.SearchEvent;
 import com.dabi.habitv.core.event.SearchStateEnum;
 import com.dabi.habitv.core.mgr.CoreManager;
+import com.dabi.habitv.core.task.BatchEnqueueResult;
 import com.dabi.habitv.tray.subscriber.CoreSubscriber;
 import com.dabi.habitv.tray.subscriber.SubscriberAdapter;
 import com.dabi.habitv.tray.subscriber.UpdateSubscriber;
@@ -214,6 +215,11 @@ public class HabitTvViewManager extends Observable {
 
 	public void restart(EpisodeDTO episode, boolean exportOnly) {
 		coreManager.restart(episode, exportOnly);
+	}
+
+	public BatchEnqueueResult enqueueEpisodesForDownload(
+			final Collection<EpisodeDTO> episodes) {
+		return coreManager.enqueueEpisodesForDownload(episodes);
 	}
 
 	public Collection<EpisodeDTO> findEpisodeByCategory(CategoryDTO category) {

--- a/docs/batch-episode-downloads.md
+++ b/docs/batch-episode-downloads.md
@@ -6,15 +6,15 @@ plugin/category tree mapping.
 
 ## Batch selection
 
-On the downloads tab (labeled **A télécharger** in the UI), episodes are
+On the **To download** tab (French UI label: **A télécharger**), episodes are
 listed in a multi-select table.
 Users can:
 
 - Select multiple rows with mouse or keyboard (Ctrl/Cmd, Shift where supported).
-- Use **Download selected** to enqueue all selected episodes at once.
+- Use **Télécharger la sélection** to enqueue all selected episodes at once.
 - Use the context menu to download a single episode (unchanged).
 
-If nothing is selected, **Download selected** stays disabled. If every
+If nothing is selected, **Télécharger la sélection** stays disabled. If every
 selection is skipped, the UI shows an error pop-in.
 
 ## Duplicate prevention

--- a/docs/batch-episode-downloads.md
+++ b/docs/batch-episode-downloads.md
@@ -1,0 +1,86 @@
+# Batch episode downloads and queue behavior
+
+This document describes the JavaFX tray UI batch download flow, duplicate
+prevention, download concurrency, optional episode metadata, and the
+plugin/category tree mapping.
+
+## Batch selection
+
+On the downloads tab (labeled **A télécharger** in the UI), episodes are
+listed in a multi-select table.
+Users can:
+
+- Select multiple rows with mouse or keyboard (Ctrl/Cmd, Shift where supported).
+- Use **Download selected** to enqueue all selected episodes at once.
+- Use the context menu to download a single episode (unchanged).
+
+If nothing is selected, **Download selected** stays disabled. If every
+selection is skipped, the UI shows an error pop-in.
+
+## Duplicate prevention
+
+Before each episode is queued, the core checks:
+
+| Condition | Skip reason |
+|-----------|-------------|
+| Episode name already in category index | `ALREADY_DOWNLOADED` |
+| Retrieve task already queued/running | `ALREADY_QUEUED` |
+| Download task queued/running | `ALREADY_DOWNLOADING` |
+| Same episode twice in one batch | `DUPLICATE_IN_BATCH` |
+
+Identity uses plugin, category, episode id/name, and existing `EpisodeDTO`
+equality. Logs include `Episode queued`, `Duplicate skipped`, and download
+lifecycle messages from `DownloadTask` / `TaskMgr`.
+
+## `maxConcurrentDownloads`
+
+Configuration element under `downloadConfig` in `configuration.xml`:
+
+```xml
+<maxConcurrentDownloads>1</maxConcurrentDownloads>
+```
+
+- Default: **1** (same as legacy single-download behavior).
+- Minimum: **1**; invalid or missing values fall back to 1.
+- Editable in the Configuration tab (requires application restart to apply).
+- Enforced globally on the download `TaskMgr` pool (not per-plugin pools).
+
+When the limit is reached, additional downloads wait in the executor queue.
+`TaskMgr` logs `Queue waiting ... because concurrency limit was reached`.
+
+## Episode metadata (best-effort)
+
+Optional fields on `EpisodeDTO` (providers may leave them null):
+
+| Field | UI column |
+|-------|-----------|
+| `episodeDate` | Date |
+| `durationSeconds` | Duration |
+| `sizeBytes` | Size |
+| `id` (HTTP URL or id) | Source |
+
+Missing values display **Unknown**. The UI never fails when metadata is absent.
+
+## Plugin / category / show tree
+
+The tree uses existing `CategoryDTO` nesting:
+
+1. **Plugin** — top-level plugin holder (display name; no separate channel model).
+2. **Category** — first subcategory level.
+3. **Show** — deeper subcategory.
+4. **Group** — further subcategory / episode groups.
+
+Template categories keep their context menu and checkbox behavior.
+
+## Known limitations
+
+- No distinct “channel” entity in the plugin API; the plugin name stands in.
+- Metadata is not populated by most legacy providers in this PR.
+- Queue state in the episode table follows retrieve/download events; a restart clears in-memory queue hints.
+- `maxConcurrentDownloads` applies after restart; `taskDefinition/download` is no longer used for per-plugin download pools.
+
+## Follow-up
+
+- Provider-specific metadata enrichment.
+- Queue pause/resume and persistent queue recovery.
+- Richer channel/show taxonomy when plugins are modernized.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR). Legacy HBTV codes are historical-only and not for new workflow naming.",
-  "lastRefresh": "2026-05-23",
+  "lastRefresh": "2026-05-26",
   "statusValues": [
     "proposed",
     "in-progress",
@@ -17,13 +17,13 @@
     "P3"
   ],
   "summary": {
-    "done": 12,
+    "done": 13,
     "inProgress": 6,
     "proposed": 2,
     "deferred": 0,
     "blocked": 0,
-    "total": 20,
-    "overallProgressPercent": 77
+    "total": 21,
+    "overallProgressPercent": 78
   },
   "items": [
     {
@@ -435,6 +435,30 @@
       ],
       "pr": "security: fix critical dependency CVE (this PR)",
       "notes": "CVE-2019-17571, CVE-2022-23305, CVE-2022-23307 on log4j 1.2.17. See docs/security-critical-cve-investigation.md. Log4j 2 / SLF4J migration deferred."
+    },
+    {
+      "id": "batch-episode-download-ui",
+      "legacyCode": "HBTV-020",
+      "displayTitle": "Batch episode download UI & queue controls",
+      "icon": "📥",
+      "status": "done",
+      "priority": "P2",
+      "progressPercent": 100,
+      "scope": "Multi-select episode enqueue, duplicate-safe queueing, maxConcurrentDownloads config, sortable metadata columns, and plugin/category tree labels in trayView.",
+      "acceptanceCriteria": [
+        "Users can select multiple episodes and enqueue via Download selected.",
+        "Duplicates skipped when already downloaded, queued, or downloading.",
+        "downloadConfig/maxConcurrentDownloads defaults to 1 with validation.",
+        "Episode table sortable by name; metadata columns show Unknown when absent.",
+        "Tree labels reflect plugin/category/show hierarchy from CategoryDTO."
+      ],
+      "validation": [
+        "mvn -B -ntp -DskipTests validate -> BUILD SUCCESS",
+        "mvn -B -ntp -pl application/core -Dtest=TaskMgrTest,DownloadTaskTest,XMLUserConfigTest test -> BUILD SUCCESS",
+        "mvn -B -ntp -pl application/trayView -DskipTests compile -> BUILD SUCCESS"
+      ],
+      "pr": "feat: add batch episode selection and download queue controls (TBD)",
+      "notes": "See docs/batch-episode-downloads.md. Provider metadata enrichment and queue pause/resume remain follow-up."
     },
     {
       "id": "clean-squash-merge-policy",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -14,7 +14,7 @@
 > Legacy codes are historical-only and must not be used for new branch
 > names, PR titles, commit subjects, or workflow naming.
 
-**Last refresh:** 2026-05-23 · **Active branch:** `develop`
+**Last refresh:** 2026-05-26 · **Active branch:** `develop`
 
 **Documentation entry point:** [`README.md`](../README.md) (overview, build matrix,
 automatic category behavior, provider summary, doc map).
@@ -24,17 +24,17 @@ automatic category behavior, provider summary, doc map).
 ## 📊 Overall progress
 
 ```
-███████████████▌░░░░  77%
+███████████████▊░░░░  78%
 ```
 
 | Category | Count |
 |---------|------:|
-| ✅ Delivered | **12** |
+| ✅ Delivered | **13** |
 | 🟡 In progress | **6** |
 | 🔵 Proposed | **2** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
-| **Total work items** | **20** |
+| **Total work items** | **21** |
 
 ---
 
@@ -61,6 +61,7 @@ automatic category behavior, provider summary, doc map).
 | 🔒 `dependency-security-audit` — Dependency security audit & remediation | 🟡 In progress | 🟠 P1 | `███░░░░░░░░░░░░░░░░░` 15% |
 | 📝 `clean-squash-merge-policy` — Clean squash merge policy | 🟡 In progress | 🟢 P3 | `██████████░░░░░░░░░░` 50% |
 | 🔒 `critical-log4j-cve-remediation` — Critical Log4j 1.x CVE remediation | ✅ Done | 🔴 P0 | `████████████████████` 100% |
+| 📥 `batch-episode-download-ui` — Batch episode download UI & queue controls | ✅ Done | 🟡 P2 | `████████████████████` 100% |
 | 🧰 `external-tools-recommendations` — External tools recommendations & obsolescence analysis | 🟡 In progress | 🟢 P3 | `██████████░░░░░░░░░░` 50% |
 
 ---
@@ -758,6 +759,40 @@ mvn -B -ntp -DskipTests compile            # BUILD SUCCESS (33 modules)
 **Notes** — CVE-2019-17571, CVE-2022-23305, CVE-2022-23307.
 See `docs/security-critical-cve-investigation.md`. Log4j 2 / SLF4J
 migration and broader transitive cleanup deferred.
+
+---
+
+## 📥 `batch-episode-download-ui` — Batch episode download UI & queue controls
+
+| | |
+|---|---|
+| **Status** | ✅ Done |
+| **Priority** | 🟡 P2 |
+| **Progress** | `████████████████████` 100% |
+| **Legacy code** | HBTV-020 |
+
+**Scope** — Multi-select episode enqueue, duplicate-safe queueing,
+`maxConcurrentDownloads` in `downloadConfig`, sortable metadata columns, and
+plugin/category/show tree labels in `trayView`.
+
+**Acceptance criteria**
+- ✅ Multi-select table and **Download selected** action
+- ✅ Skip duplicates (downloaded, queued, downloading, batch duplicate)
+- ✅ `maxConcurrentDownloads` in XSD/XML with default 1 and UI config field
+- ✅ Sortable episode name; metadata columns show **Unknown** when absent
+- ✅ Tree labels: Plugin / Category / Show / Group from `CategoryDTO` nesting
+
+**Validation**
+```bash
+mvn -B -ntp -DskipTests validate
+mvn -B -ntp -pl application/core -Dtest=TaskMgrTest,DownloadTaskTest,XMLUserConfigTest test
+mvn -B -ntp -pl application/trayView -DskipTests compile
+```
+
+**Related PR** · `feat: add batch episode selection and download queue controls` (TBD)
+
+**Notes** — See `docs/batch-episode-downloads.md`. Provider metadata and queue
+pause/resume are follow-up.
 
 ---
 

--- a/fwk/api/src/com/dabi/habitv/api/plugin/dto/EpisodeDTO.java
+++ b/fwk/api/src/com/dabi/habitv/api/plugin/dto/EpisodeDTO.java
@@ -1,6 +1,7 @@
 package com.dabi.habitv.api.plugin.dto;
 
 import java.io.Serializable;
+import java.util.Date;
 
 import com.dabi.habitv.api.plugin.exception.InvalidEpisodeException;
 
@@ -15,6 +16,12 @@ public class EpisodeDTO implements Comparable<EpisodeDTO>, Serializable {
 	private final String id;
 
 	private int num = 0;
+
+	private Date episodeDate;
+
+	private Long durationSeconds;
+
+	private Long sizeBytes;
 
 	public EpisodeDTO(final CategoryDTO category, final String name,
 			final String id) {
@@ -119,6 +126,30 @@ public class EpisodeDTO implements Comparable<EpisodeDTO>, Serializable {
 
 	public void setNum(final int i) {
 		this.num = i;
+	}
+
+	public Date getEpisodeDate() {
+		return episodeDate == null ? null : new Date(episodeDate.getTime());
+	}
+
+	public void setEpisodeDate(final Date episodeDate) {
+		this.episodeDate = episodeDate == null ? null : new Date(episodeDate.getTime());
+	}
+
+	public Long getDurationSeconds() {
+		return durationSeconds;
+	}
+
+	public void setDurationSeconds(final Long durationSeconds) {
+		this.durationSeconds = durationSeconds;
+	}
+
+	public Long getSizeBytes() {
+		return sizeBytes;
+	}
+
+	public void setSizeBytes(final Long sizeBytes) {
+		this.sizeBytes = sizeBytes;
 	}
 
 }

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/CategoryTreeNormalizer.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/CategoryTreeNormalizer.java
@@ -1,0 +1,109 @@
+package com.dabi.habitv.framework.plugin.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+
+/**
+ * Pads shallow provider category trees to a consistent depth below the plugin
+ * node: channel → category → program.
+ *
+ * Only synthetic nodes created by this normalizer are forced to be
+ * non-downloadable. Existing provider nodes keep their original downloadability
+ * semantics because some providers intentionally expose downloadable branches.
+ */
+public final class CategoryTreeNormalizer {
+
+	public static final String DEFAULT_CHANNEL_NAME = "Principal";
+
+	public static final String DEFAULT_CATEGORY_NAME = "Programmes";
+
+	/** Target depth from channel root to downloadable leaf (3 nodes). */
+	private static final int TARGET_DEPTH = 3;
+
+	private CategoryTreeNormalizer() {
+	}
+
+	public static Set<CategoryDTO> normalize(final String pluginName, final Set<CategoryDTO> roots) {
+		if (roots == null || roots.isEmpty()) {
+			return roots;
+		}
+		final Set<CategoryDTO> normalized = new LinkedHashSet<>();
+		final List<CategoryDTO> shallowRoots = new ArrayList<>();
+		for (final CategoryDTO root : roots) {
+			final int depth = structureDepth(root);
+			if (depth >= TARGET_DEPTH) {
+				normalized.add(root);
+			} else if (depth == 2) {
+				insertCategoryLevel(root, DEFAULT_CATEGORY_NAME);
+				normalized.add(root);
+			} else {
+				shallowRoots.add(root);
+			}
+		}
+		if (!shallowRoots.isEmpty()) {
+			normalized.add(wrapRootsInDefaultChannel(pluginName, shallowRoots));
+		}
+		return normalized;
+	}
+
+	private static CategoryDTO wrapRootsInDefaultChannel(final String pluginName, final List<CategoryDTO> roots) {
+		final String channelId = syntheticId(pluginName, "channel");
+		final CategoryDTO channel = new CategoryDTO(pluginName, DEFAULT_CHANNEL_NAME, channelId,
+				resolveExtension(roots));
+		channel.setDownloadable(false);
+		final CategoryDTO category = new CategoryDTO(pluginName, DEFAULT_CATEGORY_NAME,
+				syntheticId(channelId, "programmes"), resolveExtension(roots));
+		category.setDownloadable(false);
+		for (final CategoryDTO root : roots) {
+			category.addSubCategory(root);
+		}
+		channel.addSubCategory(category);
+		return channel;
+	}
+
+	private static void insertCategoryLevel(final CategoryDTO parent, final String categoryName) {
+		final Collection<CategoryDTO> children = parent.getSubCategories();
+		if (children == null || children.isEmpty()) {
+			return;
+		}
+		final CategoryDTO category = new CategoryDTO(parent.getPlugin(), categoryName,
+				syntheticId(parent.getId(), "programmes"), parent.getExtension());
+		category.setDownloadable(false);
+		for (final CategoryDTO child : new ArrayList<>(children)) {
+			category.addSubCategory(child);
+		}
+		parent.getSubCategories().clear();
+		parent.addSubCategory(category);
+	}
+
+	static int structureDepth(final CategoryDTO node) {
+		final Collection<CategoryDTO> subs = node.getSubCategories();
+		final boolean hasSubs = subs != null && !subs.isEmpty();
+		if (!hasSubs) {
+			return node.isDownloadable() ? 1 : 0;
+		}
+		int maxChild = 0;
+		for (final CategoryDTO child : subs) {
+			maxChild = Math.max(maxChild, structureDepth(child));
+		}
+		return maxChild == 0 ? 1 : 1 + maxChild;
+	}
+
+	private static String resolveExtension(final List<CategoryDTO> roots) {
+		for (final CategoryDTO root : roots) {
+			if (root.getExtension() != null) {
+				return root.getExtension();
+			}
+		}
+		return null;
+	}
+
+	private static String syntheticId(final String parentId, final String suffix) {
+		return parentId + "#" + suffix;
+	}
+}

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/CategoryTreeNormalizerTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/CategoryTreeNormalizerTest.java
@@ -1,0 +1,118 @@
+package com.dabi.habitv.framework.plugin.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+
+public class CategoryTreeNormalizerTest {
+
+	@Test
+	public void padsChannelToEmissionWithProgramsLevel() {
+		final CategoryDTO channel = new CategoryDTO("sixplay", "M6", "http://m6", "mp4");
+		final CategoryDTO show = new CategoryDTO("sixplay", "Show", "http://show", "mp4");
+		show.setDownloadable(true);
+		channel.addSubCategory(show);
+
+		final Set<CategoryDTO> normalized = CategoryTreeNormalizer.normalize("sixplay",
+				new LinkedHashSet<>(Arrays.asList(channel)));
+
+		assertEquals(1, normalized.size());
+		final CategoryDTO m6 = normalized.iterator().next();
+		assertEquals("M6", m6.getName());
+		final CategoryDTO programs = m6.getSubCategories().iterator().next();
+		assertEquals(CategoryTreeNormalizer.DEFAULT_CATEGORY_NAME, programs.getName());
+		assertFalse(programs.isDownloadable());
+		final CategoryDTO showNode = programs.getSubCategories().iterator().next();
+		assertEquals("Show", showNode.getName());
+		assertTrue(showNode.isDownloadable());
+		assertEquals(3, CategoryTreeNormalizer.structureDepth(m6));
+	}
+
+	@Test
+	public void leavesThreeLevelTreeUnchanged() {
+		final CategoryDTO channel = new CategoryDTO("francetv", "France 2", "http://f2", "mp4");
+		channel.setDownloadable(false);
+		final CategoryDTO rubrique = new CategoryDTO("francetv", "Info", "http://f2/info", "mp4");
+		rubrique.setDownloadable(false);
+		final CategoryDTO program = new CategoryDTO("francetv", "JT", "http://jt", "mp4");
+		program.setDownloadable(true);
+		rubrique.addSubCategory(program);
+		channel.addSubCategory(rubrique);
+
+		final Set<CategoryDTO> normalized = CategoryTreeNormalizer.normalize("francetv",
+				new LinkedHashSet<>(Arrays.asList(channel)));
+
+		assertEquals(1, normalized.size());
+		assertEquals(3, CategoryTreeNormalizer.structureDepth(normalized.iterator().next()));
+		assertEquals("Info", normalized.iterator().next().getSubCategories().iterator().next().getName());
+	}
+
+	@Test
+	public void preservesDownloadableBranchesInExistingDeepTree() {
+		final CategoryDTO channel = new CategoryDTO("canalPlus", "Parent", "parent", "mp4");
+		channel.setDownloadable(true);
+		final CategoryDTO rubrique = new CategoryDTO("canalPlus", "Rubrique", "rubrique", "mp4");
+		rubrique.setDownloadable(false);
+		final CategoryDTO program = new CategoryDTO("canalPlus", "Program", "program", "mp4");
+		program.setDownloadable(true);
+		rubrique.addSubCategory(program);
+		channel.addSubCategory(rubrique);
+
+		final Set<CategoryDTO> normalized = CategoryTreeNormalizer.normalize("canalPlus",
+				new LinkedHashSet<>(Arrays.asList(channel)));
+
+		final CategoryDTO normalizedChannel = normalized.iterator().next();
+		assertTrue(normalizedChannel.isDownloadable());
+		assertEquals(3, CategoryTreeNormalizer.structureDepth(normalizedChannel));
+	}
+
+	@Test
+	public void normalizesShallowRootEvenWhenAnotherRootIsAlreadyDeep() {
+		final CategoryDTO deepChannel = new CategoryDTO("francetv", "France 2", "http://f2", "mp4");
+		deepChannel.setDownloadable(false);
+		final CategoryDTO section = new CategoryDTO("francetv", "Info", "http://f2/info", "mp4");
+		section.setDownloadable(false);
+		final CategoryDTO program = new CategoryDTO("francetv", "JT", "http://jt", "mp4");
+		program.setDownloadable(true);
+		section.addSubCategory(program);
+		deepChannel.addSubCategory(section);
+
+		final CategoryDTO shallowLeaf = new CategoryDTO("francetv", "Direct", "http://direct", "mp4");
+		shallowLeaf.setDownloadable(true);
+
+		final Set<CategoryDTO> normalized = CategoryTreeNormalizer.normalize("francetv",
+				new LinkedHashSet<>(Arrays.asList(deepChannel, shallowLeaf)));
+
+		assertEquals(2, normalized.size());
+		for (final CategoryDTO root : normalized) {
+			assertEquals(3, CategoryTreeNormalizer.structureDepth(root));
+		}
+	}
+
+	@Test
+	public void wrapsSingleDownloadableRootInPrincipalAndPrograms() {
+		final CategoryDTO leaf = new CategoryDTO("mlssoccer", "Highlights", "http://highlights", "mp4");
+		leaf.setDownloadable(true);
+
+		final Set<CategoryDTO> normalized = CategoryTreeNormalizer.normalize("mlssoccer",
+				new LinkedHashSet<>(Arrays.asList(leaf)));
+
+		assertEquals(1, normalized.size());
+		final CategoryDTO channel = normalized.iterator().next();
+		assertEquals(CategoryTreeNormalizer.DEFAULT_CHANNEL_NAME, channel.getName());
+		final Iterator<CategoryDTO> it = channel.getSubCategories().iterator();
+		final CategoryDTO category = it.next();
+		assertEquals(CategoryTreeNormalizer.DEFAULT_CATEGORY_NAME, category.getName());
+		assertFalse(category.isDownloadable());
+		assertEquals("Highlights", category.getSubCategories().iterator().next().getName());
+	}
+}

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvEpisodeMetadata.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvEpisodeMetadata.java
@@ -1,0 +1,59 @@
+package com.dabi.habitv.provider.francetv;
+
+import java.util.Date;
+import java.util.Map;
+
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+/**
+ * Maps france.tv mobile API content items to {@link EpisodeDTO} optional metadata.
+ */
+final class FranceTvEpisodeMetadata {
+
+	private FranceTvEpisodeMetadata() {
+	}
+
+	static void apply(final Map<String, Object> item, final EpisodeDTO episode) {
+		if (item == null || episode == null) {
+			return;
+		}
+		final Date broadcastDate = parseBroadcastDate(item);
+		if (broadcastDate != null) {
+			episode.setEpisodeDate(broadcastDate);
+		}
+		final Long duration = parseDurationSeconds(item);
+		if (duration != null) {
+			episode.setDurationSeconds(duration);
+		}
+	}
+
+	static Date parseBroadcastDate(final Map<String, Object> item) {
+		final Long seconds = firstEpochSeconds(item, "broadcast_begin_date", "begin_date");
+		if (seconds == null) {
+			return null;
+		}
+		return new Date(seconds.longValue() * 1000L);
+	}
+
+	static Long parseDurationSeconds(final Map<String, Object> item) {
+		final Object raw = item.get("duration");
+		if (raw instanceof Number) {
+			final long value = ((Number) raw).longValue();
+			return value >= 0 ? Long.valueOf(value) : null;
+		}
+		return null;
+	}
+
+	private static Long firstEpochSeconds(final Map<String, Object> item, final String... keys) {
+		for (final String key : keys) {
+			final Object raw = item.get(key);
+			if (raw instanceof Number) {
+				final long value = ((Number) raw).longValue();
+				if (value > 0) {
+					return Long.valueOf(value);
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvPluginManager.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvPluginManager.java
@@ -52,7 +52,9 @@ public class FranceTvPluginManager extends BasePluginWithProxy implements Plugin
 				if (StringUtils.isEmpty(name)) {
 					continue;
 				}
-				episodes.add(new EpisodeDTO(category, name, pageUrl));
+				final EpisodeDTO episode = new EpisodeDTO(category, name, pageUrl);
+				FranceTvEpisodeMetadata.apply(item, episode);
+				episodes.add(episode);
 			}
 		} catch (IOException e) {
 			getLog().error("Failed to fetch france.tv episodes for " + programPath, e);
@@ -75,29 +77,13 @@ public class FranceTvPluginManager extends BasePluginWithProxy implements Plugin
 	}
 
 	private Collection<CategoryDTO> findPrograms(final String channelSlug) {
-		final Set<CategoryDTO> programs = new LinkedHashSet<>();
 		try {
-			final List<Map<String, Object>> items = apiClient.fetchPrograms(channelSlug);
-			for (final Map<String, Object> item : items) {
-				final Object rawPath = item.get("program_path");
-				if (rawPath == null) {
-					continue;
-				}
-				final String programPath = String.valueOf(rawPath);
-				final String programUrl = FranceTvUrls.programPageUrl(programPath);
-				if (StringUtils.isEmpty(programUrl)) {
-					continue;
-				}
-				final String programName = programLabel(item, programPath);
-				final CategoryDTO program = new CategoryDTO(FranceTvConf.NAME, programName, programUrl,
-						FranceTvConf.EXTENSION);
-				program.setDownloadable(true);
-				programs.add(program);
-			}
+			return FranceTvProgramCatalog.groupProgramsBySection(channelSlug,
+					apiClient.fetchPrograms(channelSlug));
 		} catch (IOException e) {
 			getLog().error("Failed to fetch france.tv programs for channel " + channelSlug, e);
+			return new LinkedHashSet<>();
 		}
-		return programs;
 	}
 
 	@Override
@@ -116,16 +102,6 @@ public class FranceTvPluginManager extends BasePluginWithProxy implements Plugin
 			return DownloadableState.SPECIFIC;
 		}
 		return DownloadableState.IMPOSSIBLE;
-	}
-
-	private static String programLabel(final Map<String, Object> item, final String programPath) {
-		final Object label = item.get("label");
-		if (label != null && StringUtils.isNotEmpty(String.valueOf(label))) {
-			return String.valueOf(label).trim();
-		}
-		final int lastUnderscore = programPath.lastIndexOf('_');
-		String segment = lastUnderscore >= 0 ? programPath.substring(lastUnderscore + 1) : programPath;
-		return segment.replace('-', ' ');
 	}
 
 	private static String episodeDisplayName(final Map<String, Object> item) {

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvProgramCatalog.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvProgramCatalog.java
@@ -1,0 +1,134 @@
+package com.dabi.habitv.provider.francetv;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+
+/**
+ * Builds channel → section (Info, Documentaires, …) → program hierarchy from
+ * france.tv mobile API program listings.
+ */
+final class FranceTvProgramCatalog {
+
+	/** Preferred section order (url_complete slugs from france.tv API). */
+	private static final List<String> SECTION_ORDER = Arrays.asList("cinema", "info", "documentaires",
+			"series-et-fictions", "culture", "sport", "divertissement", "societe");
+
+	private FranceTvProgramCatalog() {
+	}
+
+	static Collection<CategoryDTO> groupProgramsBySection(final String channelSlug,
+			final List<Map<String, Object>> items) {
+		if (items == null || items.isEmpty()) {
+			return Collections.emptyList();
+		}
+		final Map<String, CategoryDTO> sectionBySlug = new LinkedHashMap<>();
+		CategoryDTO uncategorized = null;
+		for (final Map<String, Object> item : items) {
+			if (item == null) {
+				continue;
+			}
+			final Object rawPath = item.get("program_path");
+			if (rawPath == null) {
+				continue;
+			}
+			final String programPath = String.valueOf(rawPath);
+			final String programUrl = FranceTvUrls.programPageUrl(programPath);
+			if (StringUtils.isEmpty(programUrl)) {
+				continue;
+			}
+			final String programName = programLabel(item, programPath);
+			final CategoryDTO program = new CategoryDTO(FranceTvConf.NAME, programName, programUrl,
+					FranceTvConf.EXTENSION);
+			program.setDownloadable(true);
+
+			final Map<String, Object> categoryMeta = categoryMeta(item);
+			if (categoryMeta == null) {
+				if (uncategorized == null) {
+					uncategorized = new CategoryDTO(FranceTvConf.NAME, "Autres",
+							FranceTvUrls.sectionPageUrl(channelSlug, null), FranceTvConf.EXTENSION);
+					uncategorized.setDownloadable(false);
+				}
+				uncategorized.addSubCategory(program);
+			} else {
+				sectionForProgram(sectionBySlug, channelSlug, categoryMeta).addSubCategory(program);
+			}
+		}
+		return orderedSections(sectionBySlug, uncategorized);
+	}
+
+	private static Collection<CategoryDTO> orderedSections(final Map<String, CategoryDTO> sectionBySlug,
+			final CategoryDTO uncategorized) {
+		final List<CategoryDTO> ordered = new ArrayList<>();
+		for (final String slug : SECTION_ORDER) {
+			final CategoryDTO section = sectionBySlug.remove(slug);
+			if (section != null) {
+				ordered.add(section);
+			}
+		}
+		ordered.addAll(sectionBySlug.values());
+		if (uncategorized != null && !uncategorized.getSubCategories().isEmpty()) {
+			ordered.add(uncategorized);
+		}
+		return new LinkedHashSet<>(ordered);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> categoryMeta(final Map<String, Object> item) {
+		final Object category = item.get("category");
+		if (category instanceof Map) {
+			return (Map<String, Object>) category;
+		}
+		return null;
+	}
+
+	private static CategoryDTO sectionForProgram(final Map<String, CategoryDTO> sectionBySlug,
+			final String channelSlug, final Map<String, Object> categoryMeta) {
+		final String urlComplete = stringValue(categoryMeta.get("url_complete"));
+		final String key = StringUtils.isEmpty(urlComplete) ? "_default" : urlComplete;
+		CategoryDTO section = sectionBySlug.get(key);
+		if (section != null) {
+			return section;
+		}
+		final String label = sectionLabel(categoryMeta, urlComplete);
+		section = new CategoryDTO(FranceTvConf.NAME, label,
+				FranceTvUrls.sectionPageUrl(channelSlug, urlComplete), FranceTvConf.EXTENSION);
+		section.setDownloadable(false);
+		sectionBySlug.put(key, section);
+		return section;
+	}
+
+	private static String sectionLabel(final Map<String, Object> categoryMeta, final String urlComplete) {
+		final String label = stringValue(categoryMeta.get("label"));
+		if (StringUtils.isNotEmpty(label)) {
+			return label;
+		}
+		if (StringUtils.isNotEmpty(urlComplete)) {
+			return urlComplete.replace('-', ' ');
+		}
+		return "Autres";
+	}
+
+	private static String programLabel(final Map<String, Object> item, final String programPath) {
+		final String label = stringValue(item.get("label"));
+		if (StringUtils.isNotEmpty(label)) {
+			return label;
+		}
+		final int lastUnderscore = programPath.lastIndexOf('_');
+		final String segment = lastUnderscore >= 0 ? programPath.substring(lastUnderscore + 1) : programPath;
+		return segment.replace('-', ' ');
+	}
+
+	private static String stringValue(final Object value) {
+		return value == null ? "" : String.valueOf(value).trim();
+	}
+}

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvUrls.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvUrls.java
@@ -77,6 +77,16 @@ final class FranceTvUrls {
 		return "integrale".equals(type) || "unitaire".equals(type);
 	}
 
+	static String sectionPageUrl(final String channelSlug, final String urlComplete) {
+		if (StringUtils.isEmpty(channelSlug)) {
+			return null;
+		}
+		if (StringUtils.isEmpty(urlComplete)) {
+			return FranceTvConf.HOME_URL + "/" + channelSlug + "/";
+		}
+		return FranceTvConf.HOME_URL + "/" + channelSlug + "/" + urlComplete + "/";
+	}
+
 	static String channelLabel(final String slug) {
 		switch (slug) {
 		case "france-2":

--- a/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvCategoryGroupingTest.java
+++ b/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvCategoryGroupingTest.java
@@ -1,0 +1,65 @@
+package com.dabi.habitv.provider.francetv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+
+public class FranceTvCategoryGroupingTest {
+
+	@Test
+	public void sectionPageUrlBuildsChannelCategoryPath() {
+		assertEquals("https://www.france.tv/france-2/documentaires/",
+				FranceTvUrls.sectionPageUrl("france-2", "documentaires"));
+	}
+
+	@Test
+	public void programsGroupUnderApiCategoryLabels() {
+		final CategoryDTO france2 = new CategoryDTO("francetv", "France 2",
+				"https://www.france.tv/france-2/", "mp4");
+		france2.addSubCategories(FranceTvProgramCatalog.groupProgramsBySection("france-2",
+				Arrays.asList(programItem("france-2_show-a", "Show A", "documentaires", "Documentaires"),
+						programItem("france-2_show-b", "Show B", "info", "Info"),
+						programItem("france-2_show-c", "Show C", "cinema", "Cinéma"))));
+
+		assertEquals(3, france2.getSubCategories().size());
+		final java.util.Iterator<CategoryDTO> sectionIt = france2.getSubCategories().iterator();
+		assertEquals("Cinéma", sectionIt.next().getName());
+		assertEquals("Info", sectionIt.next().getName());
+		assertEquals("Documentaires", sectionIt.next().getName());
+		final CategoryDTO docu = findSub(france2, "Documentaires");
+		assertFalse(docu.isDownloadable());
+		assertEquals("Show A", docu.getSubCategories().iterator().next().getName());
+		assertEquals("Info", findSub(france2, "Info").getName());
+		assertEquals("Cinéma", findSub(france2, "Cinéma").getName());
+	}
+
+	private static CategoryDTO findSub(final CategoryDTO parent, final String name) {
+		for (final CategoryDTO sub : parent.getSubCategories()) {
+			if (name.equals(sub.getName())) {
+				return sub;
+			}
+		}
+		throw new AssertionError("missing subcategory " + name);
+	}
+
+	private static Map<String, Object> programItem(final String programPath, final String label,
+			final String urlComplete, final String categoryLabel) {
+		final Map<String, Object> category = new LinkedHashMap<>();
+		category.put("label", categoryLabel);
+		category.put("url_complete", urlComplete);
+		category.put("type", "categorie");
+
+		final Map<String, Object> item = new LinkedHashMap<>();
+		item.put("program_path", programPath);
+		item.put("label", label);
+		item.put("category", category);
+		return item;
+	}
+}

--- a/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvEpisodeMetadataTest.java
+++ b/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvEpisodeMetadataTest.java
@@ -1,0 +1,58 @@
+package com.dabi.habitv.provider.francetv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+public class FranceTvEpisodeMetadataTest {
+
+	@Test
+	public void parsesBroadcastDateAndDurationFromApiItem() {
+		final Map<String, Object> item = new LinkedHashMap<>();
+		item.put("broadcast_begin_date", Integer.valueOf(1777756706));
+		item.put("duration", Integer.valueOf(157));
+
+		final Date date = FranceTvEpisodeMetadata.parseBroadcastDate(item);
+		assertNotNull(date);
+		assertEquals(1777756706000L, date.getTime());
+
+		assertEquals(Long.valueOf(157), FranceTvEpisodeMetadata.parseDurationSeconds(item));
+	}
+
+	@Test
+	public void applySetsEpisodeFields() {
+		final Map<String, Object> item = new LinkedHashMap<>();
+		item.put("broadcast_begin_date", Long.valueOf(1700000000L));
+		item.put("duration", Long.valueOf(3600));
+
+		final CategoryDTO program = new CategoryDTO("francetv", "JT 20h",
+				"https://www.france.tv/france-2/journal-20-heures/", "mp4");
+		final EpisodeDTO episode = new EpisodeDTO(program, "Episode 1",
+				"https://www.france.tv/france-2/journal-20-heures/1-ep.html");
+
+		FranceTvEpisodeMetadata.apply(item, episode);
+
+		assertNotNull(episode.getEpisodeDate());
+		assertEquals(Long.valueOf(3600), episode.getDurationSeconds());
+		assertNull(episode.getSizeBytes());
+	}
+
+	@Test
+	public void fallsBackToBeginDateWhenBroadcastMissing() {
+		final Map<String, Object> item = new LinkedHashMap<>();
+		item.put("begin_date", Long.valueOf(1600000000L));
+
+		final Date date = FranceTvEpisodeMetadata.parseBroadcastDate(item);
+		assertNotNull(date);
+		assertEquals(1600000000000L, date.getTime());
+	}
+}

--- a/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvUrlsTest.java
+++ b/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvUrlsTest.java
@@ -102,6 +102,14 @@ public class FranceTvUrlsTest {
 	}
 
 	@Test
+	public void sectionPageUrlUsesCategorySlugUnderChannel() {
+		assertEquals("https://www.france.tv/france-3/cinema/",
+				FranceTvUrls.sectionPageUrl("france-3", "cinema"));
+		assertEquals("https://www.france.tv/france-2/",
+				FranceTvUrls.sectionPageUrl("france-2", null));
+	}
+
+	@Test
 	public void channelLabelMapsKnownSlugs() {
 		assertEquals("France 2", FranceTvUrls.channelLabel("france-2"));
 		assertEquals("France 3", FranceTvUrls.channelLabel("france-3"));


### PR DESCRIPTION
## Summary
- Adds multi-episode selection and batch enqueue from the JavaFX episode UI.
- Adds configurable download concurrency through `maxConcurrentDownloads`.
- Adds sortable episode metadata columns where data is available.
- Improves plugin/category/show tree display using existing category hierarchy.

## Scope
- Batch selection and queueing.
- Duplicate-safe enqueue.
- Download concurrency limit.
- Best-effort metadata display.
- Tree display improvements for plugin/category/show navigation.

## Out of scope
- Provider rewrites.
- DRM bypassing.
- Live network scraping tests.
- Replacing youtube-dl/yt-dlp behavior.
- Full metadata extraction for every provider.

## User-visible behavior
- Users can select multiple episodes and enqueue them at once.
- Habitv will not enqueue the same episode twice.
- Users can configure the maximum number of simultaneous downloads.
- Episode lists can be sorted by name.
- Metadata appears when providers expose it; missing metadata is displayed safely.

## Cleanup note
This branch was synchronized with current `develop` and cleaned before merge. Cleanup preserved legacy downloaded-index compatibility, guarded batch enqueue re-entry, normalized numeric config inputs, aligned new tray UI strings with French UI wording, and stabilized queue tests.

## Validation
```
git diff --check
(no issues)

mvn -B -ntp -DskipTests validate
[INFO] BUILD SUCCESS
[INFO] Total time:  0.955 s

mvn -B -ntp -pl application/core -am \
  -Dtest=TaskMgrTest,DownloadTaskTest,XMLUserConfigTest,DownloadedDAOTest,EpisodeDuplicateDetectorTest,EpisodeMetadataFormattingTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 2
[INFO] BUILD SUCCESS
[INFO] Total time:  31.508 s

mvn -B -ntp -pl application/trayView -am -DskipTests compile
[INFO] BUILD SUCCESS
[INFO] Total time:  29.356 s

mvn -B -ntp -pl plugins/francetv -am -Dsurefire.failIfNoSpecifiedTests=false test
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
[INFO] Total time:  27.269 s
```

## Risks
- Some providers may not expose duration, size, or date.
- Existing plugin/category data may not distinguish channel vs show cleanly.
- JavaFX legacy behavior may limit test coverage.

## Follow-up
- Add provider-specific metadata enrichment.
- Add queue pause/resume controls.
- Add persistent queue recovery after restart.
- Add richer provider/channel taxonomy once plugins are modernized.
