### PR TITLE
build: define plugin versioning policy and apply to youtube/arte/francetv

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,6 +53,13 @@ yet stabilized (see `docs/audit-master-baseline.md`).
 - Adding OWASP, SBOM, or static-analysis plugins in this phase.
 - Reformatting files, renaming variables outside a change, or moving
   packages.
+- Bumping a `plugins/*/pom.xml` `<version>` for changes that do not
+  match a `plugin-versioning-policy` trigger (downloader/parser
+  behaviour, user-facing endpoint, user-facing configuration). See
+  the "Plugin versioning" section of `CONTRIBUTING.md`. Inside a
+  bumped plugin, internal reactor deps (`api`, `framework`,
+  `plugin-tester`) MUST use `${project.parent.version}`, never
+  `${project.version}`.
 
 ## Things to encourage
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,6 +47,7 @@
 - [ ] PR keeps linear history
 - [ ] English used for branches, commits, comments, docs, and PR text
 - [ ] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`, risk register, decision log as needed)
+- [ ] If a `plugins/*/pom.xml` `<version>` is bumped, the trigger from `plugin-versioning-policy` is named in Summary/Scope (downloader/parser, user-facing endpoint, or user-facing configuration), and internal deps use `${project.parent.version}`
 - [ ] No secrets, tokens, local paths, or build outputs committed
 
 ## Suggested squash merge commit (optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ Conventional Commits, English, imperative, lowercase, ≤ 72 chars.
 | Diff size | Keep small and focused; reject opportunistic refactors |
 | History | Linear inside feature branches; no merge commits |
 | Doc sync | Update tracker, risk register, decision log on meaningful changes |
+| Plugin version bump | A `plugins/*/pom.xml` `<version>` override must match a `plugin-versioning-policy` trigger (downloader/parser, user-facing endpoint, user-facing configuration). Name the trigger in the PR body. Internal reactor deps in a bumped plugin MUST use `${project.parent.version}`. |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
-| 2026-05-21 | TBD | Define `plugin-versioning-policy` ADR, extend AGENTS.md §4 / Copilot instructions / PR template, and bump `youtube` (`4.1.1-SNAPSHOT`), `arte` (`4.1.1-SNAPSHOT`), `francetv` (`4.1.2-SNAPSHOT`) accordingly |
+| 2026-05-21 | TBD | Define `plugin-versioning-policy` ADR in `docs/decision-log.md`, document the policy in `CONTRIBUTING.md`, extend `AGENTS.md` §4 / `.github/copilot-instructions.md` / `.github/pull_request_template.md`, and bump `youtube` (`4.1.1-SNAPSHOT`), `arte` (`4.1.1-SNAPSHOT`), `francetv` (`4.1.2-SNAPSHOT`) accordingly |
 | 2026-05-17 | `d68f795` | Align JDT compliance with Java 8 (PR [#32](https://github.com/Mika3578/habitv/pull/32)) |
 | 2026-05-17 | `a659383` | Standardize static repository workspace layout (PR [#34](https://github.com/Mika3578/habitv/pull/34)) |
 | 2026-05-17 | `f30773c` | Align own-version plugin internal dependencies (PR [#33](https://github.com/Mika3578/habitv/pull/33)) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
-| 2026-05-21 | TBD | Define `plugin-versioning-policy` ADR and bump `youtube` (`4.1.1-SNAPSHOT`), `arte` (`4.1.1-SNAPSHOT`), `francetv` (`4.1.2-SNAPSHOT`) accordingly |
+| 2026-05-21 | TBD | Define `plugin-versioning-policy` ADR, extend AGENTS.md §4 / Copilot instructions / PR template, and bump `youtube` (`4.1.1-SNAPSHOT`), `arte` (`4.1.1-SNAPSHOT`), `francetv` (`4.1.2-SNAPSHOT`) accordingly |
 | 2026-05-17 | `d68f795` | Align JDT compliance with Java 8 (PR [#32](https://github.com/Mika3578/habitv/pull/32)) |
 | 2026-05-17 | `a659383` | Standardize static repository workspace layout (PR [#34](https://github.com/Mika3578/habitv/pull/34)) |
 | 2026-05-17 | `f30773c` | Align own-version plugin internal dependencies (PR [#33](https://github.com/Mika3578/habitv/pull/33)) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-21 | TBD | Define `plugin-versioning-policy` ADR and bump `youtube` (`4.1.1-SNAPSHOT`), `arte` (`4.1.1-SNAPSHOT`), `francetv` (`4.1.2-SNAPSHOT`) accordingly |
 | 2026-05-17 | `d68f795` | Align JDT compliance with Java 8 (PR [#32](https://github.com/Mika3578/habitv/pull/32)) |
 | 2026-05-17 | `a659383` | Standardize static repository workspace layout (PR [#34](https://github.com/Mika3578/habitv/pull/34)) |
 | 2026-05-17 | `f30773c` | Align own-version plugin internal dependencies (PR [#33](https://github.com/Mika3578/habitv/pull/33)) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ for the full rationale.
   detection, binary swap such as `youtube-dl` → `yt-dlp`).
 - A user-facing endpoint or channel slug changes (e.g. swapping a
   dead provider URL).
-- A user-facing configuration changes (API key resolution, defaults,
+- A user-facing configuration change (API key resolution, defaults,
   credential layout).
 
 **Do NOT bump for:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,44 @@ WIP                   ← do not commit WIP
 
 ---
 
+## 🏷️ Plugin versioning
+
+Each `plugins/*/pom.xml` inherits `<version>` from the root POM by
+default. A plugin **MAY** override the version and publish on its own
+patch line when at least one user-visible trigger applies. See the
+`plugin-versioning-policy` ADR in [`docs/decision-log.md`](docs/decision-log.md)
+for the full rationale.
+
+**Bump the plugin's `<version>` when:**
+
+- The downloader or parser behavior changes (URL handling, format
+  detection, binary swap such as `youtube-dl` → `yt-dlp`).
+- A user-facing endpoint or channel slug changes (e.g. swapping a
+  dead provider URL).
+- A user-facing configuration changes (API key resolution, defaults,
+  credential layout).
+
+**Do NOT bump for:**
+
+- Offline test fixtures.
+- Build, CI, or IDE cleanup.
+- Dependency management or reactor alignment.
+- Internal renames invisible to a configured user.
+- Documentation-only changes.
+
+**Conventions:**
+
+- Keep the `-SNAPSHOT` suffix while `CHANGELOG.md` `[Unreleased]` has
+  not been cut. Dropping `-SNAPSHOT` is gated by `static-repo-publish`.
+- Internal reactor dependencies (`api`, `framework`, `plugin-tester`)
+  inside a bumped plugin MUST use `${project.parent.version}`, never
+  `${project.version}` (cf. `own-version-deps-align`). A bare
+  `${project.version}` in a plugin whose version differs from the
+  parent resolves to a non-existent artifact at compile time.
+- The PR body must name which trigger applies when bumping.
+
+---
+
 ## 🎯 One tracker item per PR
 
 | Rule | Detail |

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -24,6 +24,7 @@ older ones rather than rewriting them in place.
 | `doc-sync-and-rule-lifecycle` | Doc sync protocol & rule lifecycle (meta-rules) | ✅ Accepted |
 | `descriptive-slug-ids` | Switch tracker / risk / ADR identifiers to descriptive slugs | ✅ Accepted |
 | `legacy-dabiboo-svn-removal` | Remove active legacy DabiBoo/SVN wiring from build and runtime paths | ✅ Accepted |
+| `plugin-versioning-policy` | When to bump a plugin `<version>` independently of the parent POM | 🟡 Proposed |
 
 ---
 
@@ -434,6 +435,74 @@ updates by default behind `habitv.update.enabled` with optional
   `index.html` or manifest files on GitHub Pages.
 - ✅ Functional Maven/publication cutover remains a separate
   `static-repo-publish` item.
+
+---
+
+## 🟡 `plugin-versioning-policy` — When to bump a plugin `<version>` independently of the parent POM
+
+| | |
+|---|---|
+| **Status** | 🟡 Proposed |
+| **Date** | 2026-05-21 |
+| **Tracker** | `own-version-deps-align` (related) |
+| **Touches** | `CONTRIBUTING.md`, `plugins/*/pom.xml` |
+
+**Context** — Plugin POMs under `plugins/*/pom.xml` inherit
+`4.1.0-SNAPSHOT` from the root POM, but four already override the
+version: `beinsport`, `footyroom`, `francetv` at `4.1.1-SNAPSHOT`,
+and `ffmpeg` at `4.1.2-SNAPSHOT`. The runtime updater
+(`fwk/framework/.../FindArtifactUtils.java:259-267`) filters
+candidates on `major.minor` (`4.1.`) and accepts any patch, so
+per-plugin patch versions are supported by design. However, no
+written rule defined **when** a plugin should bump. Recent
+functional changes to `youtube` (yt-dlp downloader migration,
+PR #52) and `arte` (EMAC API discovery fix, PR #55) shipped without
+a bump, so the runtime updater cannot advertise them to users.
+Conversely, `francetv` was bumped before its substantial follow-up
+(PR #64) that extended channel slugs, URL acceptance, and
+`MAX_PAGES`.
+
+**Decision** — A plugin's `<version>` MAY override the parent only
+when at least one of the following trigger conditions holds.
+Otherwise the plugin inherits the parent version.
+
+Bump triggers (any of):
+- Downloader or parser behavior change (URL handling, format
+  detection, binary swap such as `youtube-dl` → `yt-dlp`).
+- User-facing endpoint or channel slug change (e.g. swapping a
+  dead provider URL).
+- User-facing configuration change (API key resolution, defaults,
+  credential layout).
+
+Non-triggers (do not bump):
+- Offline test fixtures.
+- Build, CI, or IDE cleanup.
+- Dependency management or reactor alignment.
+- Internal renames invisible to a configured user.
+- Documentation-only changes.
+
+Suffix rule — keep `-SNAPSHOT` while `CHANGELOG.md` `[Unreleased]`
+has not been cut. Dropping `-SNAPSHOT` is gated by the
+`static-repo-publish` tracker item.
+
+Internal dependency rule (carried over from `own-version-deps-align`)
+— shared reactor dependencies (`api`, `framework`, `plugin-tester`)
+in a bumped plugin MUST stay on `${project.parent.version}`, never
+`${project.version}`. A `${project.version}` reference in a plugin
+whose version differs from the parent will resolve to a non-existent
+artifact at compile time.
+
+**Consequences**
+- ✅ The runtime updater can advertise a new version of a single
+  plugin to users without forcing a full reactor release.
+- ✅ Reviewers can challenge an unjustified bump (or the lack of one)
+  against an enumerated trigger list, instead of arguing taste.
+- ⚠️ Plugin authors must keep a one-line note in their PR body
+  identifying which trigger applies; the policy is enforced at
+  review, not by tooling.
+- 🔁 The policy formalises the implicit pattern used by `beinsport`,
+  `footyroom`, `francetv`, `ffmpeg`. Existing overrides are
+  grandfathered; no retroactive renames.
 
 ---
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -451,11 +451,14 @@ updates by default behind `habitv.update.enabled` with optional
 `4.1.0-SNAPSHOT` from the root POM, but four already override the
 version: `beinsport`, `footyroom`, `francetv` at `4.1.1-SNAPSHOT`,
 and `ffmpeg` at `4.1.2-SNAPSHOT`. The runtime updater
-(`fwk/framework/.../FindArtifactUtils.java:259-267`) filters
-candidates on `major.minor` (`4.1.`) and accepts any patch, so
-per-plugin patch versions are supported by design. However, no
-written rule defined **when** a plugin should bump. Recent
-functional changes to `youtube` (yt-dlp downloader migration,
+(`fwk/framework/.../FindArtifactUtils.java:259-267`) computes the
+candidate prefix via `getVersionMaj`, which returns the first two
+dot-separated segments of the configured core version (e.g. `4.1`
+for `4.1.0-SNAPSHOT`), and filters available artifacts with
+`entry.getVersion().startsWith(versionMaj)`. Per-plugin patch
+versions on the same `4.1` line are therefore supported by design.
+However, no written rule defined **when** a plugin should bump.
+Recent functional changes to `youtube` (yt-dlp downloader migration,
 PR #52) and `arte` (EMAC API discovery fix, PR #55) shipped without
 a bump, so the runtime updater cannot advertise them to users.
 Conversely, `francetv` was bumped before its substantial follow-up

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -445,7 +445,7 @@ updates by default behind `habitv.update.enabled` with optional
 | **Status** | 🟡 Proposed |
 | **Date** | 2026-05-21 |
 | **Tracker** | `own-version-deps-align` (related) |
-| **Touches** | `CONTRIBUTING.md`, `plugins/*/pom.xml` |
+| **Touches** | `AGENTS.md` §4, `CONTRIBUTING.md`, `.github/copilot-instructions.md`, `.github/pull_request_template.md`, `plugins/*/pom.xml` |
 
 **Context** — Plugin POMs under `plugins/*/pom.xml` inherit
 `4.1.0-SNAPSHOT` from the root POM, but four already override the

--- a/plugins/arte/pom.xml
+++ b/plugins/arte/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>arte</artifactId>
 	<name>arte</name>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.1-SNAPSHOT</version>
 
 <dependencies>
 		<dependency>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>${project.version}</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/plugins/francetv/pom.xml
+++ b/plugins/francetv/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<artifactId>francetv</artifactId>
 	<name>francetv</name>
-	<version>4.1.1-SNAPSHOT</version>
+	<version>4.1.2-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/plugins/youtube/pom.xml
+++ b/plugins/youtube/pom.xml
@@ -11,14 +11,14 @@
 
 <artifactId>youtube</artifactId>
 	<name>youtube</name>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.1-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>plugin-tester</artifactId>
-			<version>${project.version}</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
-		</dependency>	
+		</dependency>
 		<dependency>
 			<groupId>com.google.apis</groupId>
 			<artifactId>google-api-services-youtube</artifactId>


### PR DESCRIPTION
## Summary

Formalise *when* a `plugins/*/pom.xml` may override the parent
`<version>` (the runtime updater already supports per-plugin patch
lines via `FindArtifactUtils.getVersionMaj`), and apply the new
policy to three plugins whose recent work hit a user-visible trigger.

Related tracker item: `own-version-deps-align` (HBTV-012). New ADR
slug: `plugin-versioning-policy` (🟡 Proposed).

## Changes

**Commit 1 — `docs: define plugin versioning policy`**

- New ADR in `docs/decision-log.md` (`plugin-versioning-policy`) +
  dashboard row.
- New "🏷️ Plugin versioning" section in `CONTRIBUTING.md` between
  *Commit style* and *One tracker item per PR*.

The policy defines bump triggers (downloader/parser behaviour,
user-facing endpoint, user-facing configuration), explicit
non-triggers (offline test fixtures, build/CI/IDE cleanup, dep
alignment, internal renames, docs-only), the `-SNAPSHOT` suffix
rule (kept until `static-repo-publish` cuts a release), and
carries the HBTV-012 internal-dep contract
(`${project.parent.version}`, never `${project.version}`).

**Commit 2 — `build(plugins): bump youtube, arte, francetv per versioning policy`**

| Plugin | Before | After | Trigger |
|---|---|---|---|
| `plugins/youtube/pom.xml` | `4.1.0-SNAPSHOT` | `4.1.1-SNAPSHOT` | Downloader binary swap (yt-dlp, PR #52) + API key resolution change (PR #29) |
| `plugins/arte/pom.xml` | `4.1.0-SNAPSHOT` | `4.1.1-SNAPSHOT` | Endpoint change — EMAC API discovery restored (PR #55) |
| `plugins/francetv/pom.xml` | `4.1.1-SNAPSHOT` | `4.1.2-SNAPSHOT` | Channel slug + URL acceptance extensions on top of the prior pluzz→france.tv rename (PR #64) |

Same commit also fixes the HBTV-012 contract violation on
`plugins/youtube/pom.xml:19` and `plugins/arte/pom.xml:28`
(internal `plugin-tester` dep was using `${project.version}`,
which would resolve to a non-existent `plugin-tester:4.1.1-SNAPSHOT`
once the plugin's own version diverges from the parent).

One CHANGELOG row under `[Unreleased]` → *Build & infrastructure*.

## Out of scope

- No bump for `canalPlus`, `6play`, or 15 other plugins whose recent
  commits are limited to offline test fixtures, build/CI cleanup,
  or IDE diagnostics.
- No change to the parent POM `<version>` or to `fwk/` /
  `application/` modules.
- No publication to GitHub Pages (gated by `static-repo-publish`).
- The remaining 17 plugins still using `${project.version}` for
  internal deps are not touched — safe-by-coincidence while their
  version equals the parent. Cleanup belongs to a dedicated
  `own-version-deps-align` follow-up if/when those plugins bump.

## Test plan

- [x] `mvn -B -ntp -DskipTests validate` → BUILD SUCCESS, 33 modules
- [x] `mvn -B -ntp -DskipTests -pl plugins/youtube,plugins/arte,plugins/francetv -am compile` → BUILD SUCCESS
- [x] `git grep -n '\${project\.version}' plugins/youtube plugins/arte plugins/francetv` → no hits (HBTV-012 contract)
- [ ] Reviewer confirms the trigger justification for each of the three bumps maps to the new ADR
- [ ] Reviewer confirms the ADR text accurately formalises current practice (`beinsport`/`footyroom`/`ffmpeg` grandfathered)

Full-reactor `mvn compile` fails on `application/trayView` for
unrelated JavaFX 2.x reasons (`javafx-modernization`), pre-existing
on `develop` HEAD before this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KrU2QzfbsoEphe67UHqRrd)_