### PR TITLE
feat(provider): refactor francetv category and metadata mapping

### DIFF
--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvEpisodeMetadata.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvEpisodeMetadata.java
@@ -1,0 +1,59 @@
+package com.dabi.habitv.provider.francetv;
+
+import java.util.Date;
+import java.util.Map;
+
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+/**
+ * Maps france.tv mobile API content items to {@link EpisodeDTO} optional metadata.
+ */
+final class FranceTvEpisodeMetadata {
+
+	private FranceTvEpisodeMetadata() {
+	}
+
+	static void apply(final Map<String, Object> item, final EpisodeDTO episode) {
+		if (item == null || episode == null) {
+			return;
+		}
+		final Date broadcastDate = parseBroadcastDate(item);
+		if (broadcastDate != null) {
+			episode.setEpisodeDate(broadcastDate);
+		}
+		final Long duration = parseDurationSeconds(item);
+		if (duration != null) {
+			episode.setDurationSeconds(duration);
+		}
+	}
+
+	static Date parseBroadcastDate(final Map<String, Object> item) {
+		final Long seconds = firstEpochSeconds(item, "broadcast_begin_date", "begin_date");
+		if (seconds == null) {
+			return null;
+		}
+		return new Date(seconds.longValue() * 1000L);
+	}
+
+	static Long parseDurationSeconds(final Map<String, Object> item) {
+		final Object raw = item.get("duration");
+		if (raw instanceof Number) {
+			final long value = ((Number) raw).longValue();
+			return value >= 0 ? Long.valueOf(value) : null;
+		}
+		return null;
+	}
+
+	private static Long firstEpochSeconds(final Map<String, Object> item, final String... keys) {
+		for (final String key : keys) {
+			final Object raw = item.get(key);
+			if (raw instanceof Number) {
+				final long value = ((Number) raw).longValue();
+				if (value > 0) {
+					return Long.valueOf(value);
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvPluginManager.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvPluginManager.java
@@ -52,7 +52,9 @@ public class FranceTvPluginManager extends BasePluginWithProxy implements Plugin
 				if (StringUtils.isEmpty(name)) {
 					continue;
 				}
-				episodes.add(new EpisodeDTO(category, name, pageUrl));
+				final EpisodeDTO episode = new EpisodeDTO(category, name, pageUrl);
+				FranceTvEpisodeMetadata.apply(item, episode);
+				episodes.add(episode);
 			}
 		} catch (IOException e) {
 			getLog().error("Failed to fetch france.tv episodes for " + programPath, e);
@@ -75,29 +77,13 @@ public class FranceTvPluginManager extends BasePluginWithProxy implements Plugin
 	}
 
 	private Collection<CategoryDTO> findPrograms(final String channelSlug) {
-		final Set<CategoryDTO> programs = new LinkedHashSet<>();
 		try {
-			final List<Map<String, Object>> items = apiClient.fetchPrograms(channelSlug);
-			for (final Map<String, Object> item : items) {
-				final Object rawPath = item.get("program_path");
-				if (rawPath == null) {
-					continue;
-				}
-				final String programPath = String.valueOf(rawPath);
-				final String programUrl = FranceTvUrls.programPageUrl(programPath);
-				if (StringUtils.isEmpty(programUrl)) {
-					continue;
-				}
-				final String programName = programLabel(item, programPath);
-				final CategoryDTO program = new CategoryDTO(FranceTvConf.NAME, programName, programUrl,
-						FranceTvConf.EXTENSION);
-				program.setDownloadable(true);
-				programs.add(program);
-			}
+			return FranceTvProgramCatalog.groupProgramsByRubrique(channelSlug,
+					apiClient.fetchPrograms(channelSlug));
 		} catch (IOException e) {
 			getLog().error("Failed to fetch france.tv programs for channel " + channelSlug, e);
+			return new LinkedHashSet<>();
 		}
-		return programs;
 	}
 
 	@Override
@@ -116,16 +102,6 @@ public class FranceTvPluginManager extends BasePluginWithProxy implements Plugin
 			return DownloadableState.SPECIFIC;
 		}
 		return DownloadableState.IMPOSSIBLE;
-	}
-
-	private static String programLabel(final Map<String, Object> item, final String programPath) {
-		final Object label = item.get("label");
-		if (label != null && StringUtils.isNotEmpty(String.valueOf(label))) {
-			return String.valueOf(label).trim();
-		}
-		final int lastUnderscore = programPath.lastIndexOf('_');
-		String segment = lastUnderscore >= 0 ? programPath.substring(lastUnderscore + 1) : programPath;
-		return segment.replace('-', ' ');
 	}
 
 	private static String episodeDisplayName(final Map<String, Object> item) {

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvProgramCatalog.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvProgramCatalog.java
@@ -1,0 +1,127 @@
+package com.dabi.habitv.provider.francetv;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+
+/**
+ * Builds channel → rubrique (Info, Documentaires, …) → program hierarchy from
+ * france.tv mobile API program listings.
+ */
+final class FranceTvProgramCatalog {
+
+	/** Preferred rubrique order (url_complete slugs from france.tv API). */
+	private static final List<String> RUBRIQUE_ORDER = Arrays.asList("cinema", "info", "documentaires",
+			"series-et-fictions", "culture", "sport", "divertissement", "societe");
+
+	private FranceTvProgramCatalog() {
+	}
+
+	static Collection<CategoryDTO> groupProgramsByRubrique(final String channelSlug,
+			final List<Map<String, Object>> items) {
+		final Map<String, CategoryDTO> rubriqueBySlug = new LinkedHashMap<>();
+		CategoryDTO uncategorized = null;
+		for (final Map<String, Object> item : items) {
+			final Object rawPath = item.get("program_path");
+			if (rawPath == null) {
+				continue;
+			}
+			final String programPath = String.valueOf(rawPath);
+			final String programUrl = FranceTvUrls.programPageUrl(programPath);
+			if (StringUtils.isEmpty(programUrl)) {
+				continue;
+			}
+			final String programName = programLabel(item, programPath);
+			final CategoryDTO program = new CategoryDTO(FranceTvConf.NAME, programName, programUrl,
+					FranceTvConf.EXTENSION);
+			program.setDownloadable(true);
+
+			final Map<String, Object> categoryMeta = categoryMeta(item);
+			if (categoryMeta == null) {
+				if (uncategorized == null) {
+					uncategorized = new CategoryDTO(FranceTvConf.NAME, "Autres",
+							FranceTvUrls.rubriquePageUrl(channelSlug, null), FranceTvConf.EXTENSION);
+					uncategorized.setDownloadable(false);
+				}
+				uncategorized.addSubCategory(program);
+			} else {
+				rubriqueForProgram(rubriqueBySlug, channelSlug, categoryMeta).addSubCategory(program);
+			}
+		}
+		return orderedRubriques(rubriqueBySlug, uncategorized);
+	}
+
+	private static Collection<CategoryDTO> orderedRubriques(final Map<String, CategoryDTO> rubriqueBySlug,
+			final CategoryDTO uncategorized) {
+		final List<CategoryDTO> ordered = new ArrayList<>();
+		for (final String slug : RUBRIQUE_ORDER) {
+			final CategoryDTO rubrique = rubriqueBySlug.remove(slug);
+			if (rubrique != null) {
+				ordered.add(rubrique);
+			}
+		}
+		ordered.addAll(rubriqueBySlug.values());
+		if (uncategorized != null && !uncategorized.getSubCategories().isEmpty()) {
+			ordered.add(uncategorized);
+		}
+		return new LinkedHashSet<>(ordered);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> categoryMeta(final Map<String, Object> item) {
+		final Object category = item.get("category");
+		if (category instanceof Map) {
+			return (Map<String, Object>) category;
+		}
+		return null;
+	}
+
+	private static CategoryDTO rubriqueForProgram(final Map<String, CategoryDTO> rubriqueBySlug,
+			final String channelSlug, final Map<String, Object> categoryMeta) {
+		final String urlComplete = stringValue(categoryMeta.get("url_complete"));
+		final String key = StringUtils.isEmpty(urlComplete) ? "_default" : urlComplete;
+		CategoryDTO rubrique = rubriqueBySlug.get(key);
+		if (rubrique != null) {
+			return rubrique;
+		}
+		final String label = rubriqueLabel(categoryMeta, urlComplete);
+		rubrique = new CategoryDTO(FranceTvConf.NAME, label,
+				FranceTvUrls.rubriquePageUrl(channelSlug, urlComplete), FranceTvConf.EXTENSION);
+		rubrique.setDownloadable(false);
+		rubriqueBySlug.put(key, rubrique);
+		return rubrique;
+	}
+
+	private static String rubriqueLabel(final Map<String, Object> categoryMeta, final String urlComplete) {
+		final String label = stringValue(categoryMeta.get("label"));
+		if (StringUtils.isNotEmpty(label)) {
+			return label;
+		}
+		if (StringUtils.isNotEmpty(urlComplete)) {
+			return urlComplete.replace('-', ' ');
+		}
+		return "Autres";
+	}
+
+	private static String programLabel(final Map<String, Object> item, final String programPath) {
+		final Object label = item.get("label");
+		if (label != null && StringUtils.isNotEmpty(String.valueOf(label))) {
+			return String.valueOf(label).trim();
+		}
+		final int lastUnderscore = programPath.lastIndexOf('_');
+		final String segment = lastUnderscore >= 0 ? programPath.substring(lastUnderscore + 1) : programPath;
+		return segment.replace('-', ' ');
+	}
+
+	private static String stringValue(final Object value) {
+		return value == null ? "" : String.valueOf(value).trim();
+	}
+}

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvProgramCatalog.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvProgramCatalog.java
@@ -112,9 +112,9 @@ final class FranceTvProgramCatalog {
 	}
 
 	private static String programLabel(final Map<String, Object> item, final String programPath) {
-		final Object label = item.get("label");
-		if (label != null && StringUtils.isNotEmpty(String.valueOf(label))) {
-			return String.valueOf(label).trim();
+		final String label = stringValue(item.get("label"));
+		if (StringUtils.isNotEmpty(label)) {
+			return label;
 		}
 		final int lastUnderscore = programPath.lastIndexOf('_');
 		final String segment = lastUnderscore >= 0 ? programPath.substring(lastUnderscore + 1) : programPath;

--- a/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvUrls.java
+++ b/plugins/francetv/src/com/dabi/habitv/provider/francetv/FranceTvUrls.java
@@ -77,6 +77,16 @@ final class FranceTvUrls {
 		return "integrale".equals(type) || "unitaire".equals(type);
 	}
 
+	static String rubriquePageUrl(final String channelSlug, final String urlComplete) {
+		if (StringUtils.isEmpty(channelSlug)) {
+			return null;
+		}
+		if (StringUtils.isEmpty(urlComplete)) {
+			return FranceTvConf.HOME_URL + "/" + channelSlug + "/";
+		}
+		return FranceTvConf.HOME_URL + "/" + channelSlug + "/" + urlComplete + "/";
+	}
+
 	static String channelLabel(final String slug) {
 		switch (slug) {
 		case "france-2":

--- a/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvCategoryGroupingTest.java
+++ b/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvCategoryGroupingTest.java
@@ -1,0 +1,65 @@
+package com.dabi.habitv.provider.francetv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+
+public class FranceTvCategoryGroupingTest {
+
+	@Test
+	public void rubriquePageUrlBuildsChannelCategoryPath() {
+		assertEquals("https://www.france.tv/france-2/documentaires/",
+				FranceTvUrls.rubriquePageUrl("france-2", "documentaires"));
+	}
+
+	@Test
+	public void programsGroupUnderApiCategoryLabels() {
+		final CategoryDTO france2 = new CategoryDTO("francetv", "France 2",
+				"https://www.france.tv/france-2/", "mp4");
+		france2.addSubCategories(FranceTvProgramCatalog.groupProgramsByRubrique("france-2",
+				Arrays.asList(programItem("france-2_show-a", "Show A", "documentaires", "Documentaires"),
+						programItem("france-2_show-b", "Show B", "info", "Info"),
+						programItem("france-2_show-c", "Show C", "cinema", "Cinéma"))));
+
+		assertEquals(3, france2.getSubCategories().size());
+		final java.util.Iterator<CategoryDTO> rubriqueIt = france2.getSubCategories().iterator();
+		assertEquals("Cinéma", rubriqueIt.next().getName());
+		assertEquals("Info", rubriqueIt.next().getName());
+		assertEquals("Documentaires", rubriqueIt.next().getName());
+		final CategoryDTO docu = findSub(france2, "Documentaires");
+		assertFalse(docu.isDownloadable());
+		assertEquals("Show A", docu.getSubCategories().iterator().next().getName());
+		assertEquals("Info", findSub(france2, "Info").getName());
+		assertEquals("Cinéma", findSub(france2, "Cinéma").getName());
+	}
+
+	private static CategoryDTO findSub(final CategoryDTO parent, final String name) {
+		for (final CategoryDTO sub : parent.getSubCategories()) {
+			if (name.equals(sub.getName())) {
+				return sub;
+			}
+		}
+		throw new AssertionError("missing subcategory " + name);
+	}
+
+	private static Map<String, Object> programItem(final String programPath, final String label,
+			final String urlComplete, final String categoryLabel) {
+		final Map<String, Object> category = new LinkedHashMap<>();
+		category.put("label", categoryLabel);
+		category.put("url_complete", urlComplete);
+		category.put("type", "categorie");
+
+		final Map<String, Object> item = new LinkedHashMap<>();
+		item.put("program_path", programPath);
+		item.put("label", label);
+		item.put("category", category);
+		return item;
+	}
+}

--- a/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvEpisodeMetadataTest.java
+++ b/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvEpisodeMetadataTest.java
@@ -1,0 +1,58 @@
+package com.dabi.habitv.provider.francetv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+
+public class FranceTvEpisodeMetadataTest {
+
+	@Test
+	public void parsesBroadcastDateAndDurationFromApiItem() {
+		final Map<String, Object> item = new LinkedHashMap<>();
+		item.put("broadcast_begin_date", Integer.valueOf(1777756706));
+		item.put("duration", Integer.valueOf(157));
+
+		final Date date = FranceTvEpisodeMetadata.parseBroadcastDate(item);
+		assertNotNull(date);
+		assertEquals(1777756706000L, date.getTime());
+
+		assertEquals(Long.valueOf(157), FranceTvEpisodeMetadata.parseDurationSeconds(item));
+	}
+
+	@Test
+	public void applySetsEpisodeFields() {
+		final Map<String, Object> item = new LinkedHashMap<>();
+		item.put("broadcast_begin_date", Long.valueOf(1700000000L));
+		item.put("duration", Long.valueOf(3600));
+
+		final CategoryDTO program = new CategoryDTO("francetv", "JT 20h",
+				"https://www.france.tv/france-2/journal-20-heures/", "mp4");
+		final EpisodeDTO episode = new EpisodeDTO(program, "Episode 1",
+				"https://www.france.tv/france-2/journal-20-heures/1-ep.html");
+
+		FranceTvEpisodeMetadata.apply(item, episode);
+
+		assertNotNull(episode.getEpisodeDate());
+		assertEquals(Long.valueOf(3600), episode.getDurationSeconds());
+		assertNull(episode.getSizeBytes());
+	}
+
+	@Test
+	public void fallsBackToBeginDateWhenBroadcastMissing() {
+		final Map<String, Object> item = new LinkedHashMap<>();
+		item.put("begin_date", Long.valueOf(1600000000L));
+
+		final Date date = FranceTvEpisodeMetadata.parseBroadcastDate(item);
+		assertNotNull(date);
+		assertEquals(1600000000000L, date.getTime());
+	}
+}

--- a/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvUrlsTest.java
+++ b/plugins/francetv/test/com/dabi/habitv/provider/francetv/FranceTvUrlsTest.java
@@ -102,6 +102,14 @@ public class FranceTvUrlsTest {
 	}
 
 	@Test
+	public void rubriquePageUrlUsesCategorySlugUnderChannel() {
+		assertEquals("https://www.france.tv/france-3/cinema/",
+				FranceTvUrls.rubriquePageUrl("france-3", "cinema"));
+		assertEquals("https://www.france.tv/france-2/",
+				FranceTvUrls.rubriquePageUrl("france-2", null));
+	}
+
+	@Test
 	public void channelLabelMapsKnownSlugs() {
 		assertEquals("France 2", FranceTvUrls.channelLabel("france-2"));
 		assertEquals("France 3", FranceTvUrls.channelLabel("france-3"));


### PR DESCRIPTION
## Summary
- split FranceTV category grouping from metadata extraction logic
- introduce dedicated structures for episode metadata and catalog resolution
- add targeted tests for grouping, metadata parsing, and URL behavior

## Test plan
- [ ] mvn -B -ntp -pl plugins/francetv -am test