### PR TITLE
build: enable mvn install/package on JDK 9+ via OpenJFX provided deps

### DIFF
--- a/application/habiTv/pom.xml
+++ b/application/habiTv/pom.xml
@@ -29,6 +29,39 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<!--
+		  On JDK 9+, JavaFX 2.x is no longer bundled with the JDK. The
+		  launcher references trayView whose ancestor extends
+		  javafx.application.Application, so javac needs the JavaFX API
+		  available even though HabitvLauncher itself does not import it.
+		  Match trayView/pom.xml's javafx-openjfx-compile profile.
+		-->
+		<profile>
+			<id>javafx-openjfx-compile</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<javafx.platform>linux</javafx.platform>
+				<openjfx.version>17.0.13</openjfx.version>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-base</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-graphics</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 	<build>
 <plugins>
       <plugin>

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -26,6 +26,52 @@
 			<artifactId>reload4j</artifactId>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<!--
+		  On JDK 9+, JavaFX 2.x is no longer bundled with the JDK. Supply the
+		  JavaFX classes as compile-only ("provided") dependencies so the
+		  reactor compiles end-to-end. At runtime, JavaFX is still expected
+		  to come from the JDK (Liberica/Zulu JDK 8 + JavaFX) or from an
+		  external OpenJFX module path, matching the existing launcher
+		  bootstrap. See AGENTS.md hard rules §2 ("javafx-modernization").
+		-->
+		<profile>
+			<id>javafx-openjfx-compile</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<javafx.platform>linux</javafx.platform>
+				<openjfx.version>17.0.13</openjfx.version>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-base</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-graphics</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-controls</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-fxml</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 	<build>
 		<resources>
 			<resource>


### PR DESCRIPTION
Superseded by PR #100, which uses the correctly named branch `fix/javafx-openjfx-compile-profile` with the same clean JavaFX compile-profile diff.

Do not merge this PR.