### PR TITLE
docs(agents): align AI rules policy

### DIFF
--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -39,7 +39,7 @@ They exist to keep modernization safe, incremental, and reviewable.
 - Follow `AGENTS.md` as the source of truth for PR target policy,
   branch naming, duplicate branch/PR prevention, commit style, PR
   structure, validation, and linear history.
-- Use small PRs scoped to a single tracker item.
+- Use small PRs scoped to a single descriptive scope (see `docs/dev-tracker.md`).
 - Use English for branches, commits, comments, docs, and PR text.
 
 ## Documentation discipline

--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -36,9 +36,9 @@ They exist to keep modernization safe, incremental, and reviewable.
 
 ## Branching and PRs
 
-- Follow `AGENTS.md` as the source of truth for branch naming, duplicate
-  branch/PR prevention, commit style, PR structure, validation, and
-  linear history.
+- Follow `AGENTS.md` as the source of truth for PR target policy,
+  branch naming, duplicate branch/PR prevention, commit style, PR
+  structure, validation, and linear history.
 - Use small PRs scoped to a single tracker item.
 - Use English for branches, commits, comments, docs, and PR text.
 

--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -36,11 +36,11 @@ They exist to keep modernization safe, incremental, and reviewable.
 
 ## Branching and PRs
 
+- Follow `AGENTS.md` as the source of truth for branch naming, duplicate
+  branch/PR prevention, commit style, PR structure, validation, and
+  linear history.
 - Use small PRs scoped to a single tracker item.
 - Use English for branches, commits, comments, docs, and PR text.
-- Keep linear history (no merge commits in feature branches).
-- Branch naming: `chore/...`, `build/...`, `ci/...`, `docs/...`,
-  `test/...`, `runtime/...`, `provider/...`, `fix/...`, `feature/...`.
 
 ## Documentation discipline
 

--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -10,8 +10,8 @@ They exist to keep modernization safe, incremental, and reviewable.
 
 ## Java baseline
 
-- Always keep Java 8 compatibility unless an explicit tracker item
-  (e.g. HBTV-002 successor) says otherwise and is referenced in the PR.
+- Always keep Java 8 compatibility unless an explicit tracked migration
+  item says otherwise and is referenced in the PR.
 - Do not introduce Java 9+ language features or JDK 11/17/21-only APIs.
 - Any Java baseline migration must happen in a dedicated migration PR
   with an ADR in `docs/decision-log.md`.

--- a/.cursor/rules/pr-style.mdc
+++ b/.cursor/rules/pr-style.mdc
@@ -16,7 +16,7 @@ validation, and linear history.
 ## Pull requests
 
 - Use English for PR titles, bodies, review comments, and merge metadata.
-- Keep PRs scoped to one tracker item when applicable.
+- Keep PRs scoped to one descriptive scope item when applicable.
 - Document validation commands actually run; default safe command is
   `mvn -B -ntp -DskipTests validate`.
 - Fill every required (non-optional) section of

--- a/.cursor/rules/pr-style.mdc
+++ b/.cursor/rules/pr-style.mdc
@@ -9,6 +9,10 @@ globs:
 
 # Habitv PR and squash merge style
 
+Follow `AGENTS.md` as the source of truth for branch naming, duplicate
+branch/PR prevention, commit style, PR structure, validation, and
+linear history.
+
 ## Pull requests
 
 - Use English for PR titles, bodies, review comments, and merge metadata.

--- a/.cursor/rules/pr-style.mdc
+++ b/.cursor/rules/pr-style.mdc
@@ -9,9 +9,9 @@ globs:
 
 # Habitv PR and squash merge style
 
-Follow `AGENTS.md` as the source of truth for branch naming, duplicate
-branch/PR prevention, commit style, PR structure, validation, and
-linear history.
+Follow `AGENTS.md` as the source of truth for PR target policy, branch
+naming, duplicate branch/PR prevention, commit style, PR structure,
+validation, and linear history.
 
 ## Pull requests
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Development tracker
     url: https://github.com/Mika3578/habitv/blob/develop/docs/dev-tracker.md
-    about: Review active modernization items (HBTV-XXX) before opening a feature request
+    about: Review active modernization items and descriptive scope slugs before opening a feature request
   - name: Security policy
     url: https://github.com/Mika3578/habitv/blob/develop/SECURITY.md
     about: Report vulnerabilities privately per SECURITY.md

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Large architectural changes need a tracker item (HBTV-XXX) and often an ADR.
+        Large architectural changes need a scoped work item and often an ADR.
         See `docs/dev-tracker.md`.
 
   - type: textarea
@@ -33,8 +33,8 @@ body:
   - type: input
     id: tracker
     attributes:
-      label: Tracker item (if any)
-      placeholder: HBTV-XXX
+      label: Related issue or scope (optional)
+      placeholder: "#123 or provider-youtube-ytdlp"
 
   - type: checkboxes
     id: scope

--- a/.github/ISSUE_TEMPLATE/modernization.md
+++ b/.github/ISSUE_TEMPLATE/modernization.md
@@ -1,15 +1,15 @@
 ---
 name: Modernization task
 about: Tracked modernization or governance change for Habitv
-title: "HBTV-XXX: <short summary>"
+title: "<descriptive-scope>: <short summary>"
 labels: ["modernization", "tracker"]
 assignees: []
 ---
 
-## Tracker ID
+## Scope slug
 
-<!-- Must match an entry in docs/dev-tracker.md and docs/dev-tracker.json -->
-HBTV-
+<!-- Use a descriptive kebab-case scope, e.g. provider-youtube-ytdlp -->
+scope-
 
 ## Scope
 

--- a/.github/ISSUE_TEMPLATE/modernization.md
+++ b/.github/ISSUE_TEMPLATE/modernization.md
@@ -9,7 +9,7 @@ assignees: []
 ## Scope slug
 
 <!-- Use a descriptive kebab-case scope, e.g. provider-youtube-ytdlp -->
-scope-
+provider-youtube-ytdlp
 
 ## Scope
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,7 @@ narrowly-scoped suggestions over rewrites.
 ## Workflow policy source of truth
 
 Follow `AGENTS.md` as the source of truth for:
+- PR target policy
 - branch naming
 - duplicate branch and PR prevention
 - commit style

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,8 +29,8 @@ Follow `AGENTS.md` as the source of truth for:
   reactor restructures, parent POM rewrites, or aggregator merges
   unless an explicit tracker item is referenced in the prompt.
 - Do not propose provider rewrites (e.g. canalPlus, arte, pluzz,
-  6play, youtube). Provider changes go through dedicated tracker
-  items HBTV-006 / HBTV-007 / future.
+  6play, youtube). Provider changes go through dedicated scoped work
+  tracked in repository docs.
 
 ## Key modules
 
@@ -59,8 +59,9 @@ yet stabilized (see `docs/audit-master-baseline.md`).
 ## Things to avoid suggesting
 
 - Replacing `javax.xml.bind` with `jakarta.xml.bind`.
-- Replacing `youtube-dl` with `yt-dlp` (tracked under HBTV-007).
-- Upgrading or replacing JavaFX dependencies (tracked under HBTV-008).
+- Replacing `youtube-dl` with `yt-dlp` (tracked under `ytdlp-migration`).
+- Upgrading or replacing JavaFX dependencies (tracked under
+  `javafx-modernization`).
 - Adding network-dependent tests to the default lifecycle.
 - Adding OWASP, SBOM, or static-analysis plugins in this phase.
 - Reformatting files, renaming variables outside a change, or moving

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,17 @@ is staged through tracker items in `docs/dev-tracker.md`.
 Treat the codebase as production legacy: prefer conservative,
 narrowly-scoped suggestions over rewrites.
 
+## Workflow policy source of truth
+
+Follow `AGENTS.md` as the source of truth for:
+- branch naming
+- duplicate branch and PR prevention
+- commit style
+- PR structure
+- validation commands
+- linear Git history
+- documentation sync requirements
+
 ## Compatibility constraints
 
 - Target Java 8 only. Do not suggest Java 9+ language features

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,7 +48,7 @@
 - [ ] PR keeps linear history
 - [ ] English used for branches, commits, comments, docs, and PR text
 - [ ] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`, risk register, decision log as needed)
-- [ ] If a `plugins/*/pom.xml` `<version>` is bumped, the trigger from `plugin-versioning-policy` is named in Summary/Scope (downloader/parser, user-facing endpoint, or user-facing configuration), and internal deps use `${project.parent.version}`
+- [ ] If a `plugins/*/pom.xml` `<version>` is bumped, the trigger from `plugin-versioning-policy` is named in Changes/Scope (downloader/parser, user-facing endpoint, or user-facing configuration), and internal deps use `${project.parent.version}`
 - [ ] No secrets, tokens, local paths, or build outputs committed
 
 ## Suggested squash merge commit (optional)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,14 +4,19 @@
 
 <!-- One or two sentences describing what this PR delivers and why. -->
 
+## Scope
+
+<!-- Short descriptive scope, e.g. provider-youtube-ytdlp. -->
+-
+
+## Related issue
+
+<!-- Optional: include a real GitHub issue number, e.g. #123. -->
+- N/A
+
 ## Changes
 
 <!-- Bullet list of what this PR changes. -->
--
-
-## Notes
-
-<!-- Bullet list of intentional non-changes to avoid scope creep. -->
 -
 
 ## Validation
@@ -27,14 +32,9 @@
 - Risk:
 - Rollback:
 
-## Related issue
+## Notes
 
-<!-- Optional: include a real GitHub issue number, e.g. #123. -->
-- N/A
-
-## Scope
-
-<!-- Short descriptive scope, e.g. provider-youtube-ytdlp. -->
+<!-- Bullet list of intentional non-changes to avoid scope creep. -->
 -
 
 ## Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,11 +27,15 @@
 - Risk:
 - Rollback:
 
-## Linked tracker item
+## Related issue
 
-<!-- Descriptive slug from docs/dev-tracker.md; add (HBTV-XXX) when the entry
-     has a legacy code. Use N/A when no tracker item applies. -->
-- `tracker-slug` (HBTV-XXX)
+<!-- Optional: include a real GitHub issue number, e.g. #123. -->
+- N/A
+
+## Scope
+
+<!-- Short descriptive scope, e.g. provider-youtube-ytdlp. -->
+-
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@
 <!-- Commands actually run locally and their honest outcome. -->
 - `git status --short`
 - `git diff --check`
-- `mvn -B -ntp -DskipTests validate`
+- `mvn -B -ntp -DskipTests validate` (required for code changes; optional for docs-only unless build files changed)
 
 ## Risk / rollback
 
@@ -44,11 +44,11 @@
 - [ ] No open PR already covered the same scope before opening this PR
 - [ ] No unrelated source changes
 - [ ] `git diff --check` passed
-- [ ] `mvn -B -ntp -DskipTests validate` passed or baseline failure documented
+- [ ] `mvn -B -ntp -DskipTests validate` passed (or was N/A for docs-only PRs with no build file changes)
 - [ ] PR keeps linear history
 - [ ] English used for branches, commits, comments, docs, and PR text
 - [ ] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`, risk register, decision log as needed)
-- [ ] If a `plugins/*/pom.xml` `<version>` is bumped, the trigger from `plugin-versioning-policy` is named in Changes/Scope (downloader/parser, user-facing endpoint, or user-facing configuration), and internal deps use `${project.parent.version}`
+- [ ] If a `plugins/*/pom.xml` `<version>` is bumped, the trigger from `plugin-versioning-policy` is named in Summary/Changes (downloader/parser, user-facing endpoint, or user-facing configuration), and internal deps use `${project.parent.version}`
 - [ ] No secrets, tokens, local paths, or build outputs committed
 
 ## Suggested squash merge commit (optional)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,12 +4,12 @@
 
 <!-- One or two sentences describing what this PR delivers and why. -->
 
-## Scope
+## Changes
 
 <!-- Bullet list of what this PR changes. -->
 -
 
-## Out of scope
+## Notes
 
 <!-- Bullet list of intentional non-changes to avoid scope creep. -->
 -
@@ -17,20 +17,15 @@
 ## Validation
 
 <!-- Commands actually run locally and their honest outcome. -->
+- `git status --short`
 - `git diff --check`
 - `mvn -B -ntp -DskipTests validate`
 
-## Risk
+## Risk / rollback
 
-<!-- Reference docs/risk-register.md IDs (R-00X) impacted or introduced. -->
-- Affected risks:
-- New risks:
-- Mitigation:
-
-## Rollback
-
-<!-- How to revert this PR safely if it breaks develop. -->
-- Revert commit(s) via `git revert <sha>` and re-run validation.
+<!-- Reference docs/risk-register.md IDs impacted/introduced and describe rollback. -->
+- Risk:
+- Rollback:
 
 ## Linked tracker item
 
@@ -41,6 +36,8 @@
 ## Checklist
 
 - [ ] Branch was created from `develop`
+- [ ] Duplicate-prevention checks completed before branch creation (see `AGENTS.md`)
+- [ ] No open PR already covered the same scope before opening this PR
 - [ ] No unrelated source changes
 - [ ] `git diff --check` passed
 - [ ] `mvn -B -ntp -DskipTests validate` passed or baseline failure documented

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 # Conservative baseline CI for the restart from master.
 # Intentionally validate-only (no compile, no tests) to avoid masking the
 # legacy reactor/plugin issues documented in docs/audit-master-baseline.md.
-# Subsequent PRs (HBTV-001, HBTV-002) will widen this workflow.
+# Subsequent PRs (`maven-reactor`, `java8-baseline`) will widen this workflow.
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ coding agent working on the Habitv repository. These instructions
 complement, but do not replace, the human review process.
 
 **Source of truth policy** — `AGENTS.md` is the single source of truth
-for repository-wide AI agent workflow policy (branch naming, duplicate
-prevention, commits, PR structure, validation, linear history, and
-documentation sync).
+for AI-agent workflow policy in this repository. Tool-specific files
+must reference `AGENTS.md` and must not duplicate conflicting workflow
+rules.
 
 > 📚 **Companion files** (read them before acting):
 > - [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch / commit / PR policy
@@ -227,7 +227,21 @@ Do not invent local tracker IDs.
 
 ## 🧪 6. Validation policy
 
-Default validation command for this phase:
+Validation baseline by PR type:
+
+- Docs-only PR:
+  - `git diff --check`
+  - Maven is not required unless build files changed.
+- Default code PR:
+  - `mvn -B -ntp -DskipTests validate`
+- Java/code-impacting PR:
+  - `mvn -B -ntp -DskipTests validate`
+  - Targeted compile/test commands relevant to the touched modules.
+- Full package:
+  - Run only when explicitly scoped and document JavaFX/JDK 8
+    constraints.
+
+Default validation command for non-docs changes:
 
 ```bash
 mvn -B -ntp -DskipTests validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ Instructions for **Codex, Cursor, Claude, Copilot** and any other AI
 coding agent working on the Habitv repository. These instructions
 complement, but do not replace, the human review process.
 
+**Source of truth policy** — `AGENTS.md` is the single source of truth
+for repository-wide AI agent workflow policy (branch naming, duplicate
+prevention, commits, PR structure, validation, linear history, and
+documentation sync).
+
 > 📚 **Companion files** (read them before acting):
 > - [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch / commit / PR policy
 > - [`docs/dev-plan.md`](docs/dev-plan.md) — phased modernization plan
@@ -81,20 +86,80 @@ Conventional Commits, English, imperative, lowercase, ≤ 72 chars.
 
 ---
 
-## 🎯 4. PR policy
+## 🌿 4. Branch naming and duplicate prevention
+
+Allowed work branch prefixes (only):
+- `fix/`
+- `feat/`
+- `chore/`
+- `docs/`
+- `test/`
+- `ci/`
+- `refactor/`
+
+Deprecated prefixes (do not create new branches with these):
+- `feature/` → `feat/`
+- `build/` → `ci/` for CI/build automation, or `chore/` for maintenance
+- `runtime/` → `fix/`, `feat/`, or `refactor/` depending on scope
+- `provider/` → `fix/provider-...`, `feat/provider-...`,
+  `refactor/provider-...`, `docs/provider-...`, or `test/provider-...`
+
+Branch format:
+`<type>/<tracker-or-pr-id>-<short-scope>`
+
+Examples:
+- `fix/hbtv-006-youtube-ytdlp`
+- `fix/pr-91-canalplus-cstar`
+- `chore/hbtv-012-remove-obsolete-providers`
+- `test/hbtv-006-provider-offline-fixtures`
+- `ci/hbtv-020-maven-pr-validation`
+- `docs/hbtv-006-provider-inventory`
+
+Before creating any branch, run:
+```bash
+git fetch --all --prune
+git branch -a --list "*<scope>*"
+gh pr list --state open --search "<scope>"
+git check-ref-format --branch "<branch-name>"
+```
+
+If an existing branch or open PR already covers the same scope, do not
+create a duplicate. Reuse the existing branch/PR, or create a clearly
+scoped follow-up branch.
+
+Keep history linear on work branches (no merge commits).
+
+---
+
+## 🎯 5. PR policy
 
 | Rule | Detail |
 |------|--------|
 | Tracker reference | Reference one work-item slug (e.g. `legacy-url-migration`) in the PR body |
 | Template | Fill every section of `.github/pull_request_template.md` |
 | Diff size | Keep small and focused; reject opportunistic refactors |
-| History | Linear inside feature branches; no merge commits |
+| History | Linear inside work branches; no merge commits |
 | Doc sync | Update tracker, risk register, decision log on meaningful changes |
 | Plugin version bump | A `plugins/*/pom.xml` `<version>` override must match a `plugin-versioning-policy` trigger (downloader/parser, user-facing endpoint, user-facing configuration). Name the trigger in the PR body. Internal reactor deps in a bumped plugin MUST use `${project.parent.version}`. |
 
+Required PR body sections:
+1. `Summary`
+2. `Changes`
+3. `Validation`
+4. `Risk / rollback`
+5. `Notes`
+
+Before opening a PR:
+1. Verify no open PR already covers the same scope.
+2. Verify the branch is based on the latest `develop`.
+3. Run:
+   - `git status --short`
+   - `mvn -B -ntp -DskipTests validate`
+4. Include exact validation results in the PR body.
+
 ---
 
-## 🧪 5. Validation policy
+## 🧪 6. Validation policy
 
 Default validation command for this phase:
 
@@ -116,7 +181,7 @@ command + output** in the PR body.
 
 ---
 
-## 🛠️ 6. How to maintain trackers
+## 🛠️ 7. How to maintain trackers
 
 `docs/dev-tracker.md` and `docs/dev-tracker.json` are **mirrors**.
 Always update both in the same commit. Fields per item:
@@ -137,7 +202,7 @@ or `ADR-00XX` reference. Append-only; supersede rather than rewrite.
 
 ---
 
-## 🧯 7. How to handle failures
+## 🧯 8. How to handle failures
 
 ### Test failure
 1. Read the failing assertion **and** the test before editing code.
@@ -162,7 +227,7 @@ You **must**:
 
 ---
 
-## 🔐 8. Security awareness
+## 🔐 9. Security awareness
 
 - ❌ Never introduce hardcoded API keys, passwords, or tokens.
 - ❌ Never extend the existing hardcoded credentials (Gmail tests,
@@ -174,7 +239,7 @@ You **must**:
 
 ---
 
-## 🗣️ 9. Communication conventions
+## 🗣️ 10. Communication conventions
 
 - Always reply in **English** in code, commits, comments, docs, and PR
   text — regardless of the user's prompt language.
@@ -185,7 +250,7 @@ You **must**:
 
 ---
 
-## 📅 10. Update cadence
+## 📅 11. Update cadence
 
 This file is reviewed:
 - On every phase transition in `docs/dev-plan.md`.
@@ -197,14 +262,14 @@ Last refresh: see the latest commit touching this file.
 
 ---
 
-## 🔄 11. Doc sync protocol (after every step)
+## 🔄 12. Doc sync protocol (after every step)
 
 **Rule** — every commit that changes meaningful state must keep the
 documentation set in lockstep. A "meaningful state change" is any
 commit that creates, advances, completes, mitigates, supersedes, or
 contradicts an item that is already documented.
 
-### 11.1 What to update, by commit type
+### 12.1 What to update, by commit type
 
 | Type | `CHANGELOG.md` | `dev-tracker.{md,json}` | `risk-register.md` | `decision-log.md` |
 |------|:---:|:---:|:---:|:---:|
@@ -224,7 +289,7 @@ contradicts an item that is already documented.
 **if** the commit's content matches the condition next to the icon ·
 `❌` = leave alone.
 
-### 11.2 What to update, by milestone
+### 12.2 What to update, by milestone
 
 | Milestone | Required updates |
 |---|---|
@@ -235,7 +300,7 @@ contradicts an item that is already documented.
 | **Risk mitigated** | Move the risk to the 🟢 Mitigated bucket. Annotate the mitigating PR in its `Status update` line. |
 | **New decision** | Append an ADR in `decision-log.md` and update its dashboard table. Reference the ADR id from any item it constrains. |
 
-### 11.3 How to verify before a PR
+### 12.3 How to verify before a PR
 
 The agent MUST run this checklist before requesting review:
 
@@ -271,34 +336,34 @@ EOF
 grep -F "$(git rev-parse --short HEAD)" CHANGELOG.md || true
 ```
 
-A PR that flunks 11.1, 11.2, or 11.3 must be amended before merge.
+A PR that flunks 12.1, 12.2, or 12.3 must be amended before merge.
 
 ---
 
-## 🧬 12. Rule lifecycle — meta-rules
+## 🧬 13. Rule lifecycle — meta-rules
 
 This section is the rulebook **about** the rulebook. It governs how
 rules in `AGENTS.md` can be created, modified, or deleted, including
 the rules in this very section.
 
-### 12.1 Rule identification
+### 13.1 Rule identification
 
 Every rule is uniquely identified by its **section heading + index**:
 
 - `2.5` — "Replace `youtube-dl` plugin behavior with `yt-dlp`"
   (a hard rule from Section 2's table)
 - `3` — "Conventional Commits …" (a process rule from Section 3)
-- `12.3` — "Modify a rule" (a meta-rule, this section)
+- `13.3` — "Modify a rule" (a meta-rule, this section)
 
 Rule classes and their breakage consequence:
 
 | Class | Found in | Breakage consequence |
 |------|---------|----------------------|
 | 🔴 **Hard rule** | Section 2 | PR reverted; incident logged |
-| 🟠 **Process rule** | Sections 3–11 | PR amended; warning logged |
-| 🟣 **Meta-rule** | Section 12 | PR blocked at review; cannot proceed without compliance |
+| 🟠 **Process rule** | Sections 3–12 | PR amended; warning logged |
+| 🟣 **Meta-rule** | Section 13 | PR blocked at review; cannot proceed without compliance |
 
-### 12.2 Create a rule
+### 13.2 Create a rule
 
 To **add** a new rule:
 
@@ -315,7 +380,7 @@ To **add** a new rule:
 4. On merge, the ADR transitions from `🟡 Proposed` to
    `✅ Accepted`.
 
-### 12.3 Modify a rule
+### 13.3 Modify a rule
 
 To **change** an existing rule's wording, scope, or strictness:
 
@@ -328,7 +393,7 @@ To **change** an existing rule's wording, scope, or strictness:
    identify the residual risk and link the risk slug that now
    carries it.
 
-### 12.4 Delete a rule
+### 13.4 Delete a rule
 
 To **remove** a rule entirely:
 
@@ -342,7 +407,7 @@ To **remove** a rule entirely:
 3. If the deleted rule was a 🔴 hard rule, the PR requires explicit
    owner approval and cannot be self-approved by an AI agent.
 
-### 12.5 Conflict-of-interest safeguards
+### 13.5 Conflict-of-interest safeguards
 
 These hold for AI agents in particular:
 
@@ -350,7 +415,7 @@ These hold for AI agents in particular:
   PR that benefits from doing so. Split into two PRs: first the
   rulebook change, then the work it enables.
 - 🚫 An agent **may not** silently amend a rule. Every change goes
-  through 12.2 / 12.3 / 12.4 with an ADR.
+  through 13.2 / 13.3 / 13.4 with an ADR.
 - 🚫 An agent **may not** create a rule that exempts itself, a
   specific tool, a specific branch, or a specific user from the
   meta-rules.
@@ -358,12 +423,12 @@ These hold for AI agents in particular:
   the moment it observes one, even if it does not have authority
   to resolve it.
 
-### 12.6 Self-modification of meta-rules
+### 13.6 Self-modification of meta-rules
 
-The meta-rules in Section 12 themselves can be changed — but with
+The meta-rules in Section 13 themselves can be changed — but with
 extra care:
 
-- The ADR proposing a change to Section 12 must remain in
+- The ADR proposing a change to Section 13 must remain in
   `🟡 Proposed` for **at least 7 days** before it can be merged.
 - The cooling-off period prevents an agent from instantly weakening
   its own constraints inside a single working session.
@@ -371,7 +436,7 @@ extra care:
   formatting, or clarifications that demonstrably do not change the
   rules' force.
 
-### 12.7 Audit trail
+### 13.7 Audit trail
 
 Any change to `AGENTS.md` must leave traceable evidence:
 
@@ -379,7 +444,7 @@ Any change to `AGENTS.md` must leave traceable evidence:
   superseding the change (e.g.
   `docs(agents): ... (doc-sync-and-rule-lifecycle)`).
 - The ADR references the section/rule it touches (e.g.
-  `Touches: AGENTS.md §11, §12`).
+  `Touches: AGENTS.md §12, §13`).
 - The dashboard tables in `decision-log.md` and `dev-tracker.md`
   are refreshed in the same PR.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,33 @@ Keep history linear on work branches (no merge commits).
 | Doc sync | Update tracker, risk register, decision log on meaningful changes |
 | Plugin version bump | A `plugins/*/pom.xml` `<version>` override must match a `plugin-versioning-policy` trigger (downloader/parser, user-facing endpoint, user-facing configuration). Name the trigger in the PR body. Internal reactor deps in a bumped plugin MUST use `${project.parent.version}`. |
 
+AI-agent PR target policy:
+- Agent-created PRs must always target `Mika3578/habitv`.
+- Agents must never open PRs directly against `ikfon10/habitv`.
+- `ikfon10/habitv` may be used as an upstream/reference repository only.
+- PRs from `Mika3578/habitv` to `ikfon10/habitv` are maintainer-controlled
+  and must not be automated by Cursor, Claude, Codex, or Copilot unless
+  explicitly requested as a separate task.
+
+Safe GitHub CLI examples:
+
+Correct:
+```bash
+git push -u origin docs/align-ai-rules-policy
+
+gh pr create \
+  --repo Mika3578/habitv \
+  --base develop \
+  --head docs/align-ai-rules-policy \
+  --title "docs(agents): align AI rules policy" \
+  --body-file /tmp/habitv-ai-rules-pr-body.md
+```
+
+Wrong:
+```bash
+gh pr create --repo ikfon10/habitv ...
+```
+
 Required PR body sections:
 1. `Summary`
 2. `Changes`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,8 @@ Before opening a PR:
 2. Verify the branch is based on the latest `develop`.
 3. Run:
    - `git status --short`
-   - `mvn -B -ntp -DskipTests validate`
+   - docs-only PR: `git diff --check`
+   - non-docs PR: `mvn -B -ntp -DskipTests validate`
 4. Include exact validation results in the PR body.
 
 If tracking is needed, use GitHub-native tracking:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,21 +105,40 @@ Deprecated prefixes (do not create new branches with these):
   `refactor/provider-...`, `docs/provider-...`, or `test/provider-...`
 
 Branch format:
-`<type>/<tracker-or-pr-id>-<short-scope>`
+`<type>/<short-scope>`
 
 Examples:
-- `fix/hbtv-006-youtube-ytdlp`
-- `fix/pr-91-canalplus-cstar`
-- `chore/hbtv-012-remove-obsolete-providers`
-- `test/hbtv-006-provider-offline-fixtures`
-- `ci/hbtv-020-maven-pr-validation`
-- `docs/hbtv-006-provider-inventory`
+- `fix/provider-youtube-ytdlp`
+- `feat/provider-francetv-metadata`
+- `docs/provider-inventory-update`
+- `test/provider-offline-fixtures`
+- `ci/maven-pr-validation`
+- `refactor/provider-canalplus-cleanup`
+
+HBTV-style tracker IDs are deprecated.
+
+Do not use tracker IDs such as `hbtv-006`, `HBTV-015`, `hbtv-***`, or
+`HBTV***` in:
+- branch names
+- PR titles
+- commit subjects
+- active documentation headings
+- AI workflow rules
+- PR templates
+
+Use descriptive Conventional Commit scopes instead.
+
+Examples:
+- `fix(provider-youtube): switch downloader to yt-dlp`
+- `docs(agents): align AI rules policy`
+- `test(providers): add offline fixtures`
+- `ci(maven): harden PR validation`
 
 Before creating any branch, run:
 ```bash
 git fetch --all --prune
-git branch -a --list "*<scope>*"
-gh pr list --state open --search "<scope>"
+git branch -a --list "*<short-scope>*"
+gh pr list --repo Mika3578/habitv --state open --search "<short-scope>"
 git check-ref-format --branch "<branch-name>"
 ```
 
@@ -135,7 +154,7 @@ Keep history linear on work branches (no merge commits).
 
 | Rule | Detail |
 |------|--------|
-| Tracker reference | Reference one work-item slug (e.g. `legacy-url-migration`) in the PR body |
+| Related issue / scope | Optionally reference a real GitHub issue (e.g. `#123`) and include a clear descriptive scope |
 | Template | Fill every section of `.github/pull_request_template.md` |
 | Diff size | Keep small and focused; reject opportunistic refactors |
 | History | Linear inside work branches; no merge commits |
@@ -144,7 +163,8 @@ Keep history linear on work branches (no merge commits).
 
 AI-agent PR target policy:
 - Agent-created PRs must always target `Mika3578/habitv`.
-- Agents must never open PRs directly against `ikfon10/habitv`.
+- Agents must never create, update, close, or comment on PRs in
+  `ikfon10/habitv`.
 - `ikfon10/habitv` may be used as an upstream/reference repository only.
 - PRs from `Mika3578/habitv` to `ikfon10/habitv` are maintainer-controlled
   and must not be automated by Cursor, Claude, Codex, or Copilot unless
@@ -169,12 +189,23 @@ Wrong:
 gh pr create --repo ikfon10/habitv ...
 ```
 
+PR title policy:
+- PR titles must use Conventional Commits.
+- Good: `docs(agents): align AI rules policy`
+- Good: `fix(provider-youtube): switch downloader to yt-dlp`
+- Good: `ci(maven): harden PR validation`
+- Bad: `HBTV-006 fix youtube provider`
+- Bad: `docs(HBTV-015): update agent rules`
+- Bad: `fix/hbtv-006-youtube-ytdlp`
+
 Required PR body sections:
-1. `Summary`
-2. `Changes`
-3. `Validation`
-4. `Risk / rollback`
-5. `Notes`
+1. `Related issue` (optional `#<issue-number>`)
+2. `Scope` (short descriptive scope, e.g. `provider-youtube-ytdlp`)
+3. `Summary`
+4. `Changes`
+5. `Validation`
+6. `Risk / rollback`
+7. `Notes`
 
 Before opening a PR:
 1. Verify no open PR already covers the same scope.
@@ -183,6 +214,14 @@ Before opening a PR:
    - `git status --short`
    - `mvn -B -ntp -DskipTests validate`
 4. Include exact validation results in the PR body.
+
+If tracking is needed, use GitHub-native tracking:
+- a real GitHub issue number (e.g. `#123`)
+- labels
+- project fields
+- milestones
+
+Do not invent local tracker IDs.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 AGENTS.md is the single source of truth for repository-wide AI agent workflow policy.
 
 Before making changes, read and follow AGENTS.md for:
+- PR target policy
 - branch naming
 - commit style
 - pull request structure
@@ -45,3 +46,6 @@ Use English for:
 - AI rule files
 
 Keep Git history linear.
+
+For this workflow, agent-created PRs must target `Mika3578/habitv`
+and must not be opened directly against `ikfon10/habitv`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,13 @@
 # Claude Code instructions for Habitv
 
-AGENTS.md is the single source of truth for repository-wide AI agent workflow policy.
+`AGENTS.md` is the single source of truth for repository-wide AI agent
+workflow policy.
 
-Before making changes, read and follow AGENTS.md for:
-- PR target policy
-- branch naming
-- commit style
-- pull request structure
-- validation commands
-- duplicate branch and PR prevention
-- linear Git history
-- documentation sync requirements
+Before making changes, read and follow `AGENTS.md` for branch naming,
+duplicate branch/PR prevention, commit style, PR structure, validation,
+PR target policy, and documentation sync.
 
-Do not use random Claude-generated branch names.
+If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
 
-Allowed branch prefixes only:
-- fix/
-- feat/
-- chore/
-- docs/
-- test/
-- ci/
-- refactor/
-
-Deprecated branch prefixes:
-- feature/
-- build/
-- runtime/
-- provider/
-
-Before creating any branch, run:
-git fetch --all --prune
-git branch -a --list "*<short-scope>*"
-gh pr list --repo Mika3578/habitv --state open --search "<short-scope>"
-git check-ref-format --branch "<branch-name>"
-
-If an existing branch or PR already covers the same scope, do not create a duplicate. Reuse or update the existing branch/PR instead.
-
-Use English for:
-- branch names
-- commit messages
-- PR titles
-- PR bodies
-- code comments
-- AI rule files
-
-Keep Git history linear.
-
-For this workflow, agent-created PRs must target `Mika3578/habitv`
-and must not be opened directly against `ikfon10/habitv`.
-
-Do not use local tracker IDs (e.g. `hbtv-*` / `HBTV-*`) in new branch
-names, PR titles, commit subjects, or active workflow documentation.
+Use English for code comments, commit messages, PR text, and
+documentation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# Claude Code instructions for Habitv
+
+AGENTS.md is the single source of truth for repository-wide AI agent workflow policy.
+
+Before making changes, read and follow AGENTS.md for:
+- branch naming
+- commit style
+- pull request structure
+- validation commands
+- duplicate branch and PR prevention
+- linear Git history
+- documentation sync requirements
+
+Do not use random Claude-generated branch names.
+
+Allowed branch prefixes only:
+- fix/
+- feat/
+- chore/
+- docs/
+- test/
+- ci/
+- refactor/
+
+Deprecated branch prefixes:
+- feature/
+- build/
+- runtime/
+- provider/
+
+Before creating any branch, run:
+git fetch --all --prune
+git branch -a --list "*[scope]*"
+gh pr list --state open --search "[scope]"
+git check-ref-format --branch "[branch-name]"
+
+If an existing branch or PR already covers the same scope, do not create a duplicate. Reuse or update the existing branch/PR instead.
+
+Use English for:
+- branch names
+- commit messages
+- PR titles
+- PR bodies
+- code comments
+- AI rule files
+
+Keep Git history linear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,9 @@ Deprecated branch prefixes:
 
 Before creating any branch, run:
 git fetch --all --prune
-git branch -a --list "*[short-scope]*"
-gh pr list --repo Mika3578/habitv --state open --search "[short-scope]"
-git check-ref-format --branch "[branch-name]"
+git branch -a --list "*<short-scope>*"
+gh pr list --repo Mika3578/habitv --state open --search "<short-scope>"
+git check-ref-format --branch "<branch-name>"
 
 If an existing branch or PR already covers the same scope, do not create a duplicate. Reuse or update the existing branch/PR instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ Deprecated branch prefixes:
 
 Before creating any branch, run:
 git fetch --all --prune
-git branch -a --list "*[scope]*"
-gh pr list --state open --search "[scope]"
+git branch -a --list "*[short-scope]*"
+gh pr list --repo Mika3578/habitv --state open --search "[short-scope]"
 git check-ref-format --branch "[branch-name]"
 
 If an existing branch or PR already covers the same scope, do not create a duplicate. Reuse or update the existing branch/PR instead.
@@ -49,3 +49,6 @@ Keep Git history linear.
 
 For this workflow, agent-created PRs must target `Mika3578/habitv`
 and must not be opened directly against `ikfon10/habitv`.
+
+Do not use local tracker IDs (e.g. `hbtv-*` / `HBTV-*`) in new branch
+names, PR titles, commit subjects, or active workflow documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,9 @@ Before creating a new branch, follow the duplicate-prevention checks
 defined in `AGENTS.md` (`git fetch --all --prune`, matching branch/PR
 search, and `git check-ref-format --branch`).
 
+For AI-agent workflow, PR target policy is defined in `AGENTS.md`:
+agent-created PRs target `Mika3578/habitv` (not `ikfon10/habitv`).
+
 ---
 
 ## 📝 Commit style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,18 +105,20 @@ for the full rationale.
 
 ---
 
-## 🎯 One tracker item per PR
+## 🎯 One scope per PR
 
 | Rule | Detail |
 |------|--------|
-| Tracker ID | Reference one work-item slug (e.g. `legacy-url-migration`) from `docs/dev-tracker.md` in the PR body |
+| Related issue | Optional: reference a real GitHub issue (e.g. `#123`) when one exists |
+| Scope | Use one clear descriptive scope in branch name and PR body (e.g. `provider-youtube-ytdlp`) |
 | Scope discipline | One logical change. No opportunistic refactors or formatting passes |
-| Linear history | No merge commits inside feature branches; squash or rebase only |
+| Linear history | No merge commits inside work branches; squash or rebase only |
 | Doc sync | Update `docs/dev-tracker.{md,json}`, `docs/risk-register.md`, `docs/decision-log.md` when behavior or scope changes |
 | English only | Branches, commits, code comments, docs, PR text |
 
-If your change does not fit any tracker item, open one first via the
-`modernization` issue template before coding.
+Do not use local tracker IDs (e.g. `hbtv-*` / `HBTV-*`) for new branch
+names, PR titles, or commit subjects. Use descriptive scopes and
+GitHub-native tracking (issues, labels, projects, milestones).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,15 @@ contributions follow a stricter-than-usual workflow.
 |--------|------|-------------|
 | `master` | Stable baseline | 🔒 Protected |
 | `develop` | Integration line for modernization | 🔒 Protected |
-| `feature/*`, `fix/*`, `chore/*`, `build/*`, `ci/*`, `docs/*`, `test/*` | Short-lived branches | ✅ Allowed |
+| `fix/*`, `feat/*`, `chore/*`, `docs/*`, `test/*`, `ci/*`, `refactor/*` | Short-lived branches | ✅ Allowed |
 | `legacy` | Historical reference | 🔒 Frozen |
 
 All modernization branches must target **`develop`**.
 The restart bootstrap PR targets `master`. Everything else targets `develop`.
+
+Before creating a new branch, follow the duplicate-prevention checks
+defined in `AGENTS.md` (`git fetch --all --prune`, matching branch/PR
+search, and `git check-ref-format --branch`).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,8 @@ GitHub-native tracking (issues, labels, projects, milestones).
 
 The current safe validation level is **`validate`**.
 Stronger goals are only safe for explicitly scoped modules.
+For docs-only PRs, run `git diff --check`; Maven commands are optional
+unless build files changed.
 
 | Goal | Status in current phase | When to use |
 |------|------------------------|-------------|

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Full table, fixture policy, and follow-up queue:
    - docs-only PR: `git diff --check`
    - code PR: `mvn -B -ntp -DskipTests validate`
    Paste **exact command output** in the PR body.
-5. Keep PRs small; linear history (no merge commits on feature branches).
+5. Keep PRs small; linear history (no merge commits on work branches).
 
 Details: [`CONTRIBUTING.md`](CONTRIBUTING.md), [`AGENTS.md`](AGENTS.md),
 [`docs/pull-request-style-guide.md`](docs/pull-request-style-guide.md).

--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ CI parity: [`docs/ci.md`](docs/ci.md).
 - Plugin JARs and tool binaries are published to
   **`https://mika3578.github.io/habitv-repo/repository/`** (see
   [`docs/static-repository-deploy.md`](docs/static-repository-deploy.md)).
-- Updates are **on by default** at startup; disable with
-  `-Dhabitv.update.enabled=false` or configuration.
+- Runtime update behavior must follow current code/runtime configuration.
+  On current `develop`, updates are enabled at startup and can be
+  disabled with `-Dhabitv.update.enabled=false` or configuration.
 - **SNAPSHOT / timestamped** plugin artifacts: default runtime config allows
   snapshot resolution; see [`docs/runtime-quickstart.md`](docs/runtime-quickstart.md).
 - Telemetry to legacy hosts is **opt-in** (`habitv.stat.enabled`).
@@ -122,9 +123,12 @@ Full table, fixture policy, and follow-up queue:
 ## Contributing
 
 1. Branch from latest **`develop`** (`docs/…`, `fix/…`, `feat/…`, etc.).
-2. One tracker item per PR — see [`docs/dev-tracker.md`](docs/dev-tracker.md).
+2. One descriptive scope per PR — see [`docs/dev-tracker.md`](docs/dev-tracker.md).
 3. [Conventional Commits](https://www.conventionalcommits.org/) in English.
-4. Run validation; paste **exact command output** in the PR body.
+4. Validation:
+   - docs-only PR: `git diff --check`
+   - code PR: `mvn -B -ntp -DskipTests validate`
+   Paste **exact command output** in the PR body.
 5. Keep PRs small; linear history (no merge commits on feature branches).
 
 Details: [`CONTRIBUTING.md`](CONTRIBUTING.md), [`AGENTS.md`](AGENTS.md),
@@ -161,7 +165,9 @@ Details: [`CONTRIBUTING.md`](CONTRIBUTING.md), [`AGENTS.md`](AGENTS.md),
   [`docs/automatic-category-download.md`](docs/automatic-category-download.md)).
 - GUI packaging (`habiTv`, platform installers) is not yet aligned with the
   modernized reactor baseline.
-- `youtube-dl` is deprecated in favor of **yt-dlp** (`ytdlp-migration` tracker).
+- `youtube-dl` is deprecated in favor of **yt-dlp**. Do not make
+  opportunistic yt-dlp changes outside `ytdlp-migration`; follow
+  [`docs/ytdlp-cli-compatibility.md`](docs/ytdlp-cli-compatibility.md).
 
 ---
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -63,7 +63,14 @@ Details: [`repository-maintenance.md`](repository-maintenance.md).
 
 ## Local command parity
 
-Run the same Java 8 commands locally before opening a PR:
+Before opening a PR:
+
+- Docs-only PR: run `git diff --check`.
+- Default code PR: run `mvn -B -ntp -DskipTests validate`.
+- Stronger local commands are scoped and optional unless the PR
+  explicitly targets CI/build behavior.
+
+Scoped Java 8 command set (when needed):
 
 ```bash
 mvn -B -ntp -DskipTests validate

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -24,7 +24,7 @@ older ones rather than rewriting them in place.
 | `doc-sync-and-rule-lifecycle` | Doc sync protocol & rule lifecycle (meta-rules) | ✅ Accepted |
 | `descriptive-slug-ids` | Switch tracker / risk / ADR identifiers to descriptive slugs | ✅ Accepted |
 | `legacy-dabiboo-svn-removal` | Remove active legacy DabiBoo/SVN wiring from build and runtime paths | ✅ Accepted |
-| `ai-policy-source-of-truth` | Align AI workflow policy around AGENTS.md source of truth | 🟡 Proposed |
+| `ai-policy-source-of-truth` | Align AI workflow policy around AGENTS.md source of truth | ✅ Accepted |
 | `plugin-versioning-policy` | When to bump a plugin `<version>` independently of the parent POM | 🟡 Proposed |
 
 ---
@@ -510,11 +510,11 @@ artifact at compile time.
 
 ---
 
-## 🟡 `ai-policy-source-of-truth` — Align AI workflow policy around AGENTS.md source of truth
+## ✅ `ai-policy-source-of-truth` — Align AI workflow policy around AGENTS.md source of truth
 
 | | |
 |---|---|
-| **Status** | 🟡 Proposed |
+| **Status** | ✅ Accepted |
 | **Date** | 2026-05-23 |
 | **Tracker** | `gov-bootstrap` (follow-up) |
 | **Touches** | `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/habitv-master.mdc`, `.cursor/rules/pr-style.mdc`, `.github/copilot-instructions.md`, `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/*`, `.github/workflows/build.yml`, `CONTRIBUTING.md`, `README.md`, `docs/ci.md`, `docs/dev-plan.md`, `docs/dev-tracker.md`, `docs/dev-tracker.json`, `docs/github-repository-settings.md`, `docs/provider-inventory.md`, `docs/pull-request-style-guide.md`, `docs/repository-governance.md`, `docs/repository-maintenance.md`, `docs/security-critical-cve-investigation.md`, `docs/security-dependency-audit.md` |

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -535,6 +535,9 @@ and make enforcement unclear.
   `chore/`, `docs/`, `test/`, `ci/`, and `refactor/`.
 - Deprecated prefixes are `feature/`, `build/`, `runtime/`, and
   `provider/`, with explicit replacement mapping in `AGENTS.md`.
+- Agent-created PRs must target `Mika3578/habitv`. Agents do not open
+  PRs directly against `ikfon10/habitv`; that upstream flow remains
+  maintainer-controlled unless explicitly requested.
 - Before creating a branch, run duplicate/collision checks:
   `git fetch --all --prune`, branch scope search, open PR scope search,
   and `git check-ref-format --branch`.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -517,7 +517,7 @@ artifact at compile time.
 | **Status** | 🟡 Proposed |
 | **Date** | 2026-05-23 |
 | **Tracker** | `gov-bootstrap` (follow-up) |
-| **Touches** | `AGENTS.md`, `.cursor/rules/habitv-master.mdc`, `.cursor/rules/pr-style.mdc`, `.github/copilot-instructions.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md`, `CLAUDE.md` |
+| **Touches** | `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/habitv-master.mdc`, `.cursor/rules/pr-style.mdc`, `.github/copilot-instructions.md`, `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/*`, `.github/workflows/build.yml`, `CONTRIBUTING.md`, `README.md`, `docs/ci.md`, `docs/dev-plan.md`, `docs/dev-tracker.md`, `docs/dev-tracker.json`, `docs/github-repository-settings.md`, `docs/provider-inventory.md`, `docs/pull-request-style-guide.md`, `docs/repository-governance.md`, `docs/repository-maintenance.md`, `docs/security-critical-cve-investigation.md`, `docs/security-dependency-audit.md` |
 | **Legacy code** | ADR-0010 |
 
 **Context** — Workflow guidance drifted across AI and contributor

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -24,6 +24,7 @@ older ones rather than rewriting them in place.
 | `doc-sync-and-rule-lifecycle` | Doc sync protocol & rule lifecycle (meta-rules) | ✅ Accepted |
 | `descriptive-slug-ids` | Switch tracker / risk / ADR identifiers to descriptive slugs | ✅ Accepted |
 | `legacy-dabiboo-svn-removal` | Remove active legacy DabiBoo/SVN wiring from build and runtime paths | ✅ Accepted |
+| `ai-policy-source-of-truth` | Align AI workflow policy around AGENTS.md source of truth | 🟡 Proposed |
 | `plugin-versioning-policy` | When to bump a plugin `<version>` independently of the parent POM | 🟡 Proposed |
 
 ---
@@ -509,6 +510,44 @@ artifact at compile time.
 
 ---
 
+## 🟡 `ai-policy-source-of-truth` — Align AI workflow policy around AGENTS.md source of truth
+
+| | |
+|---|---|
+| **Status** | 🟡 Proposed |
+| **Date** | 2026-05-23 |
+| **Tracker** | `gov-bootstrap` (follow-up) |
+| **Touches** | `AGENTS.md`, `.cursor/rules/habitv-master.mdc`, `.cursor/rules/pr-style.mdc`, `.github/copilot-instructions.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md`, `CLAUDE.md` |
+| **Legacy code** | ADR-0010 |
+
+**Context** — Workflow guidance drifted across AI and contributor
+instruction files, especially around branch prefixes and duplicate
+work prevention. Inconsistent rules increase duplicate branches/PRs
+and make enforcement unclear.
+
+**Decision**
+- `AGENTS.md` is the single source of truth for repository-wide AI
+  agent workflow policy.
+- Tool-specific rule files should stay short and reference
+  `AGENTS.md` for branch naming, commit style, PR structure,
+  validation, duplicate prevention, linear history, and doc sync.
+- Allowed work-branch prefixes are restricted to `fix/`, `feat/`,
+  `chore/`, `docs/`, `test/`, `ci/`, and `refactor/`.
+- Deprecated prefixes are `feature/`, `build/`, `runtime/`, and
+  `provider/`, with explicit replacement mapping in `AGENTS.md`.
+- Before creating a branch, run duplicate/collision checks:
+  `git fetch --all --prune`, branch scope search, open PR scope search,
+  and `git check-ref-format --branch`.
+
+**Consequences**
+- ✅ Branch naming and duplicate-prevention workflow are consistent for
+  AI tools and human contributors.
+- ✅ Tool-specific files remain concise and less likely to diverge.
+- ⚠️ Follow-up edits that change workflow policy must continue using
+  ADR-backed updates per the AGENTS rule lifecycle.
+
+---
+
 ## 📝 How to add a new ADR
 
 1. Pick a descriptive kebab-case slug (e.g. `enable-spotbugs`).
@@ -583,3 +622,4 @@ current slugs. Source of truth is the per-entry `Legacy code` field.
 | ADR-0007 | `doc-sync-and-rule-lifecycle` |
 | ADR-0008 | `descriptive-slug-ids` |
 | ADR-0009 | `legacy-dabiboo-svn-removal` |
+| ADR-0010 | `ai-policy-source-of-truth` |

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -551,6 +551,22 @@ and make enforcement unclear.
 
 ---
 
+## 2026-05-23 - Remove HBTV-style tracker IDs from workflow naming
+
+`AGENTS.md` remains the source of truth for AI agent workflow policy.
+
+HBTV-style tracker IDs such as `hbtv-006` and `HBTV-015` are deprecated
+for new branch names, PR titles, commit subjects, and workflow
+documentation.
+
+Future work should use descriptive Conventional Commit scopes and
+GitHub-native tracking through issues, labels, projects, and milestones.
+
+Existing historical tracker references may remain only when needed to
+preserve context.
+
+---
+
 ## 📝 How to add a new ADR
 
 1. Pick a descriptive kebab-case slug (e.g. `enable-spotbugs`).

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -16,7 +16,7 @@ later phase.
 ## 🎯 Phase progress
 
 ```
-███████████████░░░░░  77%   (5 / 7 phases done, 1 in progress)
+███████████████▋░░░░  79%   (tracker-aligned overall progress)
 ```
 
 | Phase | Title | Status | Progress | Tracker items |

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR).",
-  "lastRefresh": "2026-05-20",
+  "lastRefresh": "2026-05-23",
   "statusValues": [
     "proposed",
     "in-progress",
@@ -46,7 +46,7 @@
         "git log --oneline -5 -> bootstrap commits present"
       ],
       "pr": "chore: bootstrap restart workflow from master (#21)",
-      "notes": "Documentation/workflow only. GitHub UI-level settings application moved to branch-protection."
+      "notes": "Documentation/workflow only. GitHub UI-level settings application moved to branch-protection. Follow-up policy alignment makes AGENTS.md the source of truth for AI workflow rules and aligns tool-specific instruction files by reference."
     },
     {
       "id": "maven-reactor",

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
-  "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR).",
+  "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR). Legacy HBTV codes are historical-only and not for new workflow naming.",
   "lastRefresh": "2026-05-23",
   "statusValues": [
     "proposed",

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -46,7 +46,7 @@
         "git log --oneline -5 -> bootstrap commits present"
       ],
       "pr": "chore: bootstrap restart workflow from master (#21)",
-      "notes": "Documentation/workflow only. GitHub UI-level settings application moved to branch-protection. Follow-up policy alignment makes AGENTS.md the source of truth for AI workflow rules and aligns tool-specific instruction files by reference."
+      "notes": "Documentation/workflow only. GitHub UI-level settings application moved to branch-protection. Follow-up policy alignment makes AGENTS.md the source of truth for AI workflow rules and aligns tool-specific instruction files by reference, including agent PR target policy (Mika3578/habitv first, upstream PR flow maintainer-controlled)."
     },
     {
       "id": "maven-reactor",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -109,10 +109,11 @@ git log --oneline -5                 # bootstrap commits present
 
 **Notes** — Documentation/workflow only; no runtime or provider changes.
 GitHub UI-level settings application moved to its own item
-(`branch-protection`). Follow-up policy alignment makes `AGENTS.md`
-the source of truth for AI workflow rules and aligns tool-specific
-instruction files by reference, including agent PR target policy
-(`Mika3578/habitv` first, upstream PR flow maintainer-controlled).
+(`branch-protection`). Follow-up policy alignment captured in ADR
+`ai-policy-source-of-truth` (✅ Accepted): `AGENTS.md` is the source
+of truth for AI workflow rules; tool-specific files reference it by
+reference, including agent PR target policy (`Mika3578/habitv` first,
+upstream PR flow maintainer-controlled).
 
 ---
 

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -109,7 +109,8 @@ git log --oneline -5                 # bootstrap commits present
 GitHub UI-level settings application moved to its own item
 (`branch-protection`). Follow-up policy alignment makes `AGENTS.md`
 the source of truth for AI workflow rules and aligns tool-specific
-instruction files by reference.
+instruction files by reference, including agent PR target policy
+(`Mika3578/habitv` first, upstream PR flow maintainer-controlled).
 
 ---
 

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -11,6 +11,8 @@
 > kebab-case slug. The opaque legacy codes (`HBTV-XXX`) are preserved
 > on each entry for compatibility with existing PRs and commits. See
 > the `descriptive-slug-ids` ADR for the rationale and full mapping.
+> Legacy codes are historical-only and must not be used for new branch
+> names, PR titles, commit subjects, or workflow naming.
 
 **Last refresh:** 2026-05-23 · **Active branch:** `develop`
 

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -12,7 +12,7 @@
 > on each entry for compatibility with existing PRs and commits. See
 > the `descriptive-slug-ids` ADR for the rationale and full mapping.
 
-**Last refresh:** 2026-05-20 · **Active branch:** `develop`
+**Last refresh:** 2026-05-23 · **Active branch:** `develop`
 
 **Documentation entry point:** [`README.md`](../README.md) (overview, build matrix,
 automatic category behavior, provider summary, doc map).
@@ -107,7 +107,9 @@ git log --oneline -5                 # bootstrap commits present
 
 **Notes** — Documentation/workflow only; no runtime or provider changes.
 GitHub UI-level settings application moved to its own item
-(`branch-protection`).
+(`branch-protection`). Follow-up policy alignment makes `AGENTS.md`
+the source of truth for AI workflow rules and aligns tool-specific
+instruction files by reference.
 
 ---
 

--- a/docs/github-repository-settings.md
+++ b/docs/github-repository-settings.md
@@ -10,16 +10,17 @@ apply them manually under **Settings** on
 - `master` — stable / release baseline.
 - `develop` — integration branch for active modernization, created
   from `master` after the bootstrap PR is merged.
-- Feature branches branch from `develop` (after bootstrap) using:
+- Work branches branch from `develop` (after bootstrap) using:
   - `chore/...`
-  - `build/...`
   - `ci/...`
   - `docs/...`
   - `test/...`
-  - `runtime/...`
-  - `provider/...`
   - `fix/...`
-  - `feature/...`
+  - `feat/...`
+  - `refactor/...`
+- Deprecated prefixes (`feature/...`, `build/...`, `runtime/...`,
+  `provider/...`) are not used for new branches. Use the replacement
+  mapping defined in `AGENTS.md`.
 
 ## Recommended default branch
 

--- a/docs/github-repository-settings.md
+++ b/docs/github-repository-settings.md
@@ -83,4 +83,5 @@ there.
    git push -u origin develop`) and apply the same branch
    protection.
 4. Optionally set `develop` as the default branch.
-5. Track this work as HBTV-003 in `docs/dev-tracker.md`.
+5. Track this work under the `branch-protection` item in
+   `docs/dev-tracker.md` (legacy code mapping remains historical only).

--- a/docs/provider-inventory.md
+++ b/docs/provider-inventory.md
@@ -1,6 +1,7 @@
-# 🔌 Provider and plugin inventory (HBTV-006)
+# 🔌 Provider and plugin inventory
 
-**Tracker item**: `provider-inventory` (`HBTV-006`)  
+**Tracker item**: `provider-inventory`  
+**Legacy code**: `HBTV-006` (historical reference only)  
 **Status:** in progress (~55%) — inventory and offline fixtures; rewrites are
 separate PRs per module.
 

--- a/docs/pull-request-style-guide.md
+++ b/docs/pull-request-style-guide.md
@@ -8,9 +8,8 @@ review comments, and squash merge metadata.
 - Use a clear summary in the PR title; Conventional Commit style is preferred
   for the eventual squash merge title.
 - Keep the PR body focused on outcome, scope, validation, and risks.
-- Reference one tracker slug from `docs/dev-tracker.md` when applicable;
-  add the legacy `HBTV-XXX` code in parentheses when the entry defines one
-  (for example `clean-squash-merge-policy` (HBTV-018)).
+- Reference one descriptive scope slug from `docs/dev-tracker.md` when
+  applicable.
 - Fill every required (non-optional) section of
   `.github/pull_request_template.md`.
 

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -13,9 +13,9 @@ security, and automation boundaries for the modernization restart.
 |--------|------|
 | `develop` | Default integration branch. All active work merges here first. |
 | `master` / `main` | Legacy stable baseline when present. Protected from direct pushes. |
-| Short-lived branches | Created from `develop`: `feature/*`, `fix/*`, `chore/*`, `docs/*`, `ci/*`, and other prefixes defined in `AGENTS.md`. |
+| Short-lived branches | Created from `develop`: `fix/*`, `feat/*`, `chore/*`, `docs/*`, `test/*`, `ci/*`, `refactor/*` (see `AGENTS.md`). |
 
-Do not base modernization feature branches on `master` unless a tracker item
+Do not base modernization work branches on `master` unless a tracker item
 explicitly requires it.
 
 ## Merge model
@@ -29,7 +29,7 @@ explicitly requires it.
 
 ## Required local validation before opening a PR
 
-Run from the repository root on the feature branch:
+Run from the repository root on the work branch:
 
 ```bash
 git diff --check

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -81,8 +81,8 @@ manually.
 
 - Java baseline migration beyond Java 8.
 - Plugin or provider modernization.
-- Maven artifact repository migration (HBTV-004).
-- Runtime updater URL or layout changes (HBTV-005).
+- Maven artifact repository migration (`legacy-url-migration`).
+- Runtime updater URL or layout changes (`static-repo-publish`).
 
 Tracker items and ADRs in `docs/dev-tracker.md` and `docs/decision-log.md`
 govern when those areas may change.

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -9,11 +9,12 @@ documentation sync, and automation expectations.
 |--------|------|
 | `develop` | Integration line for modernization — **branch from here** |
 | `master` | Stable baseline snapshot |
-| `feature/*`, `fix/*`, `docs/*`, `build/*`, `ci/*`, … | Short-lived topic branches |
+| `fix/*`, `feat/*`, `chore/*`, `docs/*`, `test/*`, `ci/*`, `refactor/*` | Short-lived topic branches |
 
 Modernization PRs target **`develop`** with linear history (no merge commits on
-the feature branch). Squash merge to `develop` with a cleaned title/body (see
-below).
+work branches). Squash merge to `develop` with a cleaned title/body (see
+below). Follow duplicate-prevention checks before creating any new branch as
+defined in `AGENTS.md`.
 
 ## Contributor workflow
 

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -19,10 +19,12 @@ defined in `AGENTS.md`.
 ## Contributor workflow
 
 1. Sync to latest `develop`.
-2. Pick or add a tracker item in [`dev-tracker.md`](dev-tracker.md).
-3. Keep the PR scoped to **one** logical change / tracker item.
+2. Pick or add a descriptive scope item in [`dev-tracker.md`](dev-tracker.md).
+3. Keep the PR scoped to **one** logical change / scope.
 4. Use [Conventional Commits](https://www.conventionalcommits.org/) in English.
-5. Run validation (default: `mvn -B -ntp -DskipTests validate`).
+5. Run validation:
+   - docs-only PR: `git diff --check`
+   - default code PR: `mvn -B -ntp -DskipTests validate`
 6. Paste exact command output in the PR body.
 7. Update `dev-tracker.md` + `dev-tracker.json` (and risk/decision docs when
    applicable) in the same PR when state changes.
@@ -32,7 +34,7 @@ See [`CONTRIBUTING.md`](../CONTRIBUTING.md) and [`AGENTS.md`](../AGENTS.md).
 ## PR metadata policy
 
 - PR titles and bodies in **English**.
-- Reference one tracker slug (e.g. `provider-inventory`).
+- Reference one descriptive scope slug (e.g. `provider-inventory`).
 - Squash merge title: Conventional Commits + PR number.
 - Squash body: final outcome and validation — not intermediate commit bullets.
 - Remove accidental `Co-authored-by` trailers unless intentional.

--- a/docs/security-critical-cve-investigation.md
+++ b/docs/security-critical-cve-investigation.md
@@ -70,6 +70,6 @@ gh api "repos/Mika3578/habitv/dependabot/alerts?state=open&severity=critical" -q
 | **Fix** | Replace `log4j:log4j:1.2.17` with `ch.qos.reload4j:reload4j:1.2.26` in root `dependencyManagement` and direct module declarations |
 | **Reason** | Minimal Java 8–compatible drop-in; preserves `org.apache.log4j.*` API without Log4j 2 migration |
 | **Validation (2026-05-20)** | `dependency:tree` shows `reload4j:1.2.26` only; `validate` and `compile` BUILD SUCCESS (33 modules) |
-| **Tracker** | `critical-log4j-cve-remediation` (HBTV-019) |
+| **Tracker** | `critical-log4j-cve-remediation` (`HBTV-019`, historical reference only) |
 
 **Follow-up:** Re-run Dependabot after merge; dismiss stale `log4j:log4j` alerts. Broader dependency audit (Guava 20, legacy mail, etc.) stays out of scope.

--- a/docs/security-dependency-audit.md
+++ b/docs/security-dependency-audit.md
@@ -1,6 +1,7 @@
 # Dependency security audit baseline
 
-> **Tracker:** `dependency-security-audit` (HBTV-016)  
+> **Tracker:** `dependency-security-audit`  
+> **Legacy code:** `HBTV-016` (historical reference only)  
 > **Branch:** `security/dependabot-audit-baseline`  
 > **Last refresh:** 2026-05-20
 

--- a/docs/security-dependency-audit.md
+++ b/docs/security-dependency-audit.md
@@ -2,7 +2,7 @@
 
 > **Tracker:** `dependency-security-audit`  
 > **Legacy code:** `HBTV-016` (historical reference only)  
-> **Branch:** `security/dependabot-audit-baseline`  
+> **Branch:** `security/dependabot-audit-baseline` (legacy prefix; historical reference only)  
 > **Last refresh:** 2026-05-20
 
 ## GitHub warning summary


### PR DESCRIPTION
## Summary
Aligns Habitv AI instruction and contributor workflow policy around AGENTS.md as the source of truth, and removes HBTV-style tracker IDs from active workflow naming.

## Changes
- AGENTS.md is the source of truth for AI-agent workflow policy.
- Tool-specific files now point to AGENTS.md instead of duplicating conflicting rules.
- Active HBTV-style tracker IDs are deprecated for new workflow naming.
- AI-agent PRs must target Mika3578/habitv, not ikfon10/habitv.
- Branch prefix policy is restricted to fix/, feat/, chore/, docs/, test/, ci/, and refactor/.
- Documentation validation and PR template expectations are clarified.

## Validation
- git status --short
- git diff --check
- git check-ref-format --branch "$(git branch --show-current)"
- rg -n "\b[Hh][Bb][Tt][Vv][-_]?[0-9*]+\b|\b[Hh][Bb][Tt][Vv]\*+\b" AGENTS.md CLAUDE.md .cursor .github CONTRIBUTING.md README.md docs || true
- rg -n "feature/|build/|runtime/|provider/" AGENTS.md CLAUDE.md .cursor .github CONTRIBUTING.md README.md docs || true
- rg -n "ikfon10/habitv|Mika3578/habitv|gh pr create|gh pr edit|gh pr checkout|--repo|--head|cross-repo|fork|upstream" AGENTS.md CLAUDE.md .cursor .github CONTRIBUTING.md README.md docs || true

## Risk / rollback
Low risk. Documentation and workflow policy only. Rollback by reverting the documentation commit.

## Notes
New work should use descriptive branch scopes and Conventional Commit titles instead of local HBTV tracker IDs.