### PR TITLE
fix(tray): repair rss category add flow

### DIFF
--- a/application/trayView/src/com/dabi/habitv/tray/controller/todl/ToDownloadController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/todl/ToDownloadController.java
@@ -310,7 +310,8 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 		final CategoryForm categoryForm = new CategoryForm(templateCategory);
 		Double width = categoryForm.getAdvisedWidth();
 		Double height = categoryForm.getAdvisedHeight();
-		new Popin(width, height).show("Ajout d'une catégorie " + templateCategory.getName(), categoryForm).setOkButtonHandler(new ButtonHandler() {
+		final Popin popin = width == null || height == null ? new Popin() : new Popin(width, height);
+		popin.show("Ajout d'une catégorie " + templateCategory.getName(), categoryForm).setOkButtonHandler(new ButtonHandler() {
 
 			@Override
 			public void onAction() {
@@ -344,14 +345,10 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 
 	private CategoryDTO buildCategoryFromTemplateV2(CategoryDTO templateCategory, String text) {
 		String id = templateCategory.getId().split("!!")[0].replace("§ID§", text);
-		CategoryDTO categoryDTO = new CategoryDTO(templateCategory.getPlugin(), findNameById(id), id, FrameworkConf.MP4);
+		CategoryDTO categoryDTO = new CategoryDTO(templateCategory.getPlugin(), findNameById(id, text), id, FrameworkConf.MP4);
 		categoryDTO.setState(StatusEnum.USER);
 		categoryDTO.setDownloadable(true);
 		return categoryDTO;
-	}
-
-	private String findNameById(String id) {
-		return findNameById(id, null);
 	}
 
 	private String findNameById(String id, String defaultName) {
@@ -359,6 +356,9 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 		if (defaultName == null) {
 			if (DownloadUtils.isHttpUrl(id)) {
 				name = RetrieverUtils.getTitleByUrl(id);
+				if (name == null || name.trim().isEmpty()) {
+					name = id;
+				}
 			} else {
 				File file = new File(id);
 				if (file.exists()) {

--- a/application/trayView/src/com/dabi/habitv/tray/controller/todl/ToDownloadController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/todl/ToDownloadController.java
@@ -352,25 +352,18 @@ public class ToDownloadController extends BaseController implements CoreSubscrib
 	}
 
 	private String findNameById(String id, String defaultName) {
-		String name;
-		if (defaultName == null) {
-			if (DownloadUtils.isHttpUrl(id)) {
-				name = RetrieverUtils.getTitleByUrl(id);
-				if (name == null || name.trim().isEmpty()) {
-					name = id;
-				}
-			} else {
-				File file = new File(id);
-				if (file.exists()) {
-					name = file.getName();
-				} else {
-					name = defaultName;
-				}
-			}
-		} else {
-			name = defaultName;
+		if (defaultName != null && !defaultName.trim().isEmpty()) {
+			return defaultName;
 		}
-		return name;
+		if (id == null) {
+			return defaultName;
+		}
+		if (DownloadUtils.isHttpUrl(id)) {
+			String name = RetrieverUtils.getTitleByUrl(id);
+			return name == null || name.trim().isEmpty() ? id : name;
+		}
+		File file = new File(id);
+		return file.exists() ? file.getName() : id;
 	}
 
 	private void fillEpisodeList(final CategoryDTO category) {


### PR DESCRIPTION
## Related issue
None

## Scope
rss-add-category-popup

## Summary
Fix the tray add-category flow for RSS templates when popup dimensions are undefined.
Ensure newly created categories keep a visible name when remote title lookup is empty.

## Changes
Use a default Popin() when advised width or height are null.
Use the user-entered template value as fallback category name for V2 templates.
Guard empty HTTP title resolution with a non-empty fallback.

## Validation
mvn -B -ntp -pl application/trayView -DskipTests compile
Result: BUILD SUCCESS

## Risk / rollback
Low UI-only risk in tray category creation workflow.
Rollback by reverting commit 78033954.

## Notes
No dependency or build topology changes.