### PR TITLE
fix(youtube): relax yt-dlp preflight timeout

### DIFF
--- a/plugins/youtube/pom.xml
+++ b/plugins/youtube/pom.xml
@@ -11,7 +11,7 @@
 
 <artifactId>youtube</artifactId>
 	<name>youtube</name>
-	<version>4.1.1-SNAPSHOT</version>
+	<version>4.1.2-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnostics.java
@@ -20,6 +20,9 @@ public final class YtDlpRuntimeDiagnostics {
 	private static final Logger LOG = Logger.getLogger(YtDlpRuntimeDiagnostics.class);
 
 	static final String USER_MESSAGE_PREFIX = "yt-dlp failed before the download started";
+	private static final int YT_DLP_PREFLIGHT_TIMEOUT_SECONDS = 10;
+	private static final long YT_DLP_PREFLIGHT_TIMEOUT_MILLIS = YT_DLP_PREFLIGHT_TIMEOUT_SECONDS * 1000L;
+	private static final int OUTPUT_SNIPPET_MAX_LENGTH = 300;
 
 	private static final String[] PYINSTALLER_SIGNATURES = { "[PYI-", "Failed to extract", "Cryptodome", "_MEI" };
 
@@ -108,11 +111,12 @@ public final class YtDlpRuntimeDiagnostics {
 		}
 		logExecutableDiagnostics(executablePath, binDir);
 		final String versionCmd = executablePath + " --version";
+		LOG.info("yt-dlp preflight command: " + versionCmd);
 		final Map<String, String> env = buildYtDlpEnvironment(binDir);
-		final CmdExecutor versionExecutor = new CmdExecutor(cmdProcessor, versionCmd, 1000) {
+		final CmdExecutor versionExecutor = new CmdExecutor(cmdProcessor, versionCmd, YT_DLP_PREFLIGHT_TIMEOUT_MILLIS) {
 			@Override
 			protected long getHungProcessTime() {
-				return 1000;
+				return YT_DLP_PREFLIGHT_TIMEOUT_MILLIS;
 			}
 
 			@Override
@@ -125,12 +129,15 @@ public final class YtDlpRuntimeDiagnostics {
 				return true;
 			}
 		};
+		final long startedAt = System.currentTimeMillis();
 		try {
 			versionExecutor.start();
 		} catch (final ExecutorFailedException e) {
+			logPreflightOutcome(startedAt, e.getFullOuput());
 			throw asBootstrapFailureIfNeeded(versionCmd, e.getFullOuput(), executablePath, e);
 		}
 		final String fullOutput = versionExecutor.getFullOutput();
+		logPreflightOutcome(startedAt, fullOutput);
 		if (isBootstrapExtractionFailure(fullOutput)) {
 			throw new ExecutorFailedException(versionCmd, fullOutput,
 					buildBootstrapFailureUserMessage(executablePath), null);
@@ -146,5 +153,28 @@ public final class YtDlpRuntimeDiagnostics {
 			return new ExecutorFailedException(cmd, fullOutput, buildBootstrapFailureUserMessage(executablePath), cause);
 		}
 		return cause;
+	}
+
+	private static void logPreflightOutcome(final long startedAt, final String fullOutput) {
+		final long elapsedMs = System.currentTimeMillis() - startedAt;
+		LOG.info("yt-dlp preflight elapsed ms: " + elapsedMs);
+		final String snippet = buildOutputSnippet(fullOutput);
+		if (snippet != null) {
+			LOG.info("yt-dlp preflight output snippet: " + snippet);
+		}
+	}
+
+	private static String buildOutputSnippet(final String fullOutput) {
+		if (fullOutput == null) {
+			return null;
+		}
+		final String compact = fullOutput.replace('\r', ' ').replace('\n', ' ').trim();
+		if (compact.isEmpty()) {
+			return null;
+		}
+		if (compact.length() <= OUTPUT_SNIPPET_MAX_LENGTH) {
+			return compact;
+		}
+		return compact.substring(0, OUTPUT_SNIPPET_MAX_LENGTH) + "...";
 	}
 }

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
@@ -97,7 +97,9 @@ public class YtDlpRuntimeDiagnosticsTest {
 		final String javaExecName = System.getProperty("os.name").toLowerCase().contains("win") ? "java.exe" : "java";
 		final String javaExec = new File(javaHome, "bin" + File.separator + javaExecName).getAbsolutePath();
 		final String classPath = System.getProperty("java.class.path");
-		final String executablePath = javaExec + " -cp " + classPath + " "
+		final String quotedJavaExec = "\"" + javaExec + "\"";
+		final String quotedClassPath = "\"" + classPath + "\"";
+		final String executablePath = quotedJavaExec + " -cp " + quotedClassPath + " "
 				+ SlowVersionMain.class.getName();
 
 		final long startedAt = System.currentTimeMillis();

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
@@ -94,7 +94,9 @@ public class YtDlpRuntimeDiagnosticsTest {
 				"habitv-test-" + UUID.randomUUID());
 		final File binDir = new File(parent, "bin");
 		final File javaHome = new File(System.getProperty("java.home"));
-		final String javaExecName = System.getProperty("os.name").toLowerCase().contains("win") ? "java.exe" : "java";
+		final boolean windows = System.getProperty("os.name").toLowerCase().contains("win");
+		final String javaExecName = windows ? "java.exe" : "java";
+		final String cmdProcessor = windows ? "cmd.exe /c #CMD#" : "/bin/sh -c #CMD#";
 		final String javaExec = new File(javaHome, "bin" + File.separator + javaExecName).getAbsolutePath();
 		final String classPath = System.getProperty("java.class.path");
 		final String quotedJavaExec = "\"" + javaExec + "\"";
@@ -104,7 +106,7 @@ public class YtDlpRuntimeDiagnosticsTest {
 
 		try {
 			final long startedAt = System.currentTimeMillis();
-			YtDlpRuntimeDiagnostics.runPreflight("", executablePath, binDir.getAbsolutePath());
+			YtDlpRuntimeDiagnostics.runPreflight(cmdProcessor, executablePath, binDir.getAbsolutePath());
 			final long elapsedMs = System.currentTimeMillis() - startedAt;
 
 			assertTrue("preflight should allow command startup longer than one second, elapsed ms=" + elapsedMs,

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
@@ -102,12 +102,31 @@ public class YtDlpRuntimeDiagnosticsTest {
 		final String executablePath = quotedJavaExec + " -cp " + quotedClassPath + " "
 				+ SlowVersionMain.class.getName();
 
-		final long startedAt = System.currentTimeMillis();
-		YtDlpRuntimeDiagnostics.runPreflight("", executablePath, binDir.getAbsolutePath());
-		final long elapsedMs = System.currentTimeMillis() - startedAt;
+		try {
+			final long startedAt = System.currentTimeMillis();
+			YtDlpRuntimeDiagnostics.runPreflight("", executablePath, binDir.getAbsolutePath());
+			final long elapsedMs = System.currentTimeMillis() - startedAt;
 
-		assertTrue("preflight should allow command startup longer than one second, elapsed ms=" + elapsedMs,
-				elapsedMs >= 1200L);
+			assertTrue("preflight should allow command startup longer than one second, elapsed ms=" + elapsedMs,
+					elapsedMs >= 1200L);
+		} finally {
+			deleteRecursively(parent);
+		}
+	}
+
+	private static void deleteRecursively(final File file) {
+		if (file == null || !file.exists()) {
+			return;
+		}
+		if (file.isDirectory()) {
+			final File[] children = file.listFiles();
+			if (children != null) {
+				for (final File child : children) {
+					deleteRecursively(child);
+				}
+			}
+		}
+		file.delete();
 	}
 
 	public static class SlowVersionMain {

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YtDlpRuntimeDiagnosticsTest.java
@@ -88,4 +88,32 @@ public class YtDlpRuntimeDiagnosticsTest {
 		assertFalse("disabled preflight must not create the parent directory", parent.exists());
 	}
 
+	@Test
+	public void runPreflightAllowsStartupLongerThanOneSecond() {
+		final File parent = new File(System.getProperty("java.io.tmpdir"),
+				"habitv-test-" + UUID.randomUUID());
+		final File binDir = new File(parent, "bin");
+		final File javaHome = new File(System.getProperty("java.home"));
+		final String javaExecName = System.getProperty("os.name").toLowerCase().contains("win") ? "java.exe" : "java";
+		final String javaExec = new File(javaHome, "bin" + File.separator + javaExecName).getAbsolutePath();
+		final String classPath = System.getProperty("java.class.path");
+		final String executablePath = javaExec + " -cp " + classPath + " "
+				+ SlowVersionMain.class.getName();
+
+		final long startedAt = System.currentTimeMillis();
+		YtDlpRuntimeDiagnostics.runPreflight("", executablePath, binDir.getAbsolutePath());
+		final long elapsedMs = System.currentTimeMillis() - startedAt;
+
+		assertTrue("preflight should allow command startup longer than one second, elapsed ms=" + elapsedMs,
+				elapsedMs >= 1200L);
+	}
+
+	public static class SlowVersionMain {
+
+		public static void main(final String[] args) throws InterruptedException {
+			Thread.sleep(1500L);
+			System.out.println("2026.05.21");
+		}
+	}
+
 }


### PR DESCRIPTION
## Related issue
N/A

## Scope
youtube-ytdlp-preflight-timeout

## Summary
`yt-dlp --version` can take longer than 1 second on Windows before producing output, which caused the preflight process to be falsely classified as hung and blocked downloads before they started.

## Changes
- plugin-versioning-policy: downloader/parser
- Replaced the hardcoded 1s yt-dlp preflight hung timeout with a named 10s timeout (`YT_DLP_PREFLIGHT_TIMEOUT_SECONDS`).
- Added regression coverage proving preflight allows startup longer than one second.
- Kept the change scoped to yt-dlp preflight diagnostics.
- Added preflight diagnostics logs for command, elapsed time, and output snippet while keeping existing executable and TEMP/TMP diagnostics.

## Validation
- `git status --short`
  - no output (clean working tree)
- `mvn -B -ntp -pl plugins/youtube -am test`
  - BUILD SUCCESS
  - youtube tests: `Tests run: 23, Failures: 0, Errors: 0, Skipped: 0`
- `mvn -B -ntp -DskipTests validate`
  - BUILD SUCCESS

## Risk / rollback
Low risk: only preflight timeout/diagnostics path changed in youtube plugin runtime checks. Rollback by reverting commit `b468429f`.

## Notes
Manual follow-up: after the PR build passes, run one RSS/YouTube-backed download in Habitv to confirm end-to-end recovery.