### PR TITLE
fix(youtube): prefer MP4-compatible audio/video yt-dlp formats

### DIFF
--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
@@ -16,7 +16,7 @@ public final class YoutubeConf {
 	 * Placeholders {@link com.dabi.habitv.framework.FrameworkConf#DOWNLOAD_INPUT} and
 	 * {@link com.dabi.habitv.framework.FrameworkConf#DOWNLOAD_DESTINATION} are resolved at runtime.
 	 */
-	public static final String DUMP_CMD = " \"#VIDEO_URL#\" -o \"#FILE_DEST#\"  --write-sub --write-auto-sub --no-check-certificate";
+	public static final String DUMP_CMD = " \"#VIDEO_URL#\" -o \"#FILE_DEST#\" -f \"bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b\" --merge-output-format mp4 --no-check-certificate";
 	/**
 	 * Default MP3 extraction flags for yt-dlp ({@code --extract-audio} / {@code --audio-format}).
 	 */

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
@@ -27,6 +27,9 @@ public class YoutubePluginDownloader extends BaseUpdatablePlugin implements Plug
 		String cmd = binParam + " ";
 		final String cmdParam = downloadParam.getParam(FrameworkConf.PARAMETER_ARGS);
 		if (cmdParam == null) {
+			// For video downloads, audio quality is controlled by yt-dlp format selection.
+			// --audio-quality is intentionally not used here because it only applies to
+			// audio extraction/conversion with -x.
 			cmd += YoutubeConf.DUMP_CMD;
 		} else {
 			cmd += cmdParam;

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
@@ -1,6 +1,7 @@
 package com.dabi.habitv.plugin.youtube;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -22,9 +23,18 @@ public class YoutubeConfTest {
 	public void defaultVideoCommandIncludesUrlAndOutputPlaceholders() {
 		assertTrue(YoutubeConf.DUMP_CMD.contains("#VIDEO_URL#"));
 		assertTrue(YoutubeConf.DUMP_CMD.contains("#FILE_DEST#"));
-		assertTrue(YoutubeConf.DUMP_CMD.contains("--write-sub"));
-		assertTrue(YoutubeConf.DUMP_CMD.contains("--write-auto-sub"));
+		assertTrue(YoutubeConf.DUMP_CMD.contains("-f \"bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b\""));
+		assertTrue(YoutubeConf.DUMP_CMD.contains("--merge-output-format mp4"));
 		assertTrue(YoutubeConf.DUMP_CMD.contains("--no-check-certificate"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--audio-quality"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--extract-audio"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("-x"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--audio-format"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--write-sub"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--write-subs"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--write-auto-sub"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--write-auto-subs"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--embed-subs"));
 	}
 
 	@Test

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
@@ -2,6 +2,7 @@ package com.dabi.habitv.plugin.youtube;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -71,9 +72,41 @@ public class YoutubePluginDownloaderCmdTest {
 		assertTrue(cmd.startsWith("/usr/bin/yt-dlp "));
 		assertTrue(cmd.contains("https://www.youtube.com/watch?v=jNQXAC9IVRw"));
 		assertTrue(cmd.contains("/tmp/out/test.mp4"));
-		assertTrue(cmd.contains("--write-sub"));
-		assertTrue(cmd.contains("--write-auto-sub"));
+		assertTrue(cmd.contains("-f \"bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b\""));
+		assertTrue(cmd.contains("--merge-output-format mp4"));
 		assertTrue(cmd.contains("--no-check-certificate"));
+		assertFalse(cmd.contains("--audio-quality"));
+		assertFalse(cmd.contains("--extract-audio"));
+		assertFalse(cmd.contains("-x"));
+		assertFalse(cmd.contains("--audio-format"));
+		assertFalse(cmd.contains("--write-sub"));
+		assertFalse(cmd.contains("--write-subs"));
+		assertFalse(cmd.contains("--write-auto-sub"));
+		assertFalse(cmd.contains("--write-auto-subs"));
+		assertFalse(cmd.contains("--embed-subs"));
+	}
+
+	@Test
+	public void downloadDailymotionUrlUsesSameDefaultVideoSelector() throws Exception {
+		final HashMap<String, String> downloaderName2Bin = new HashMap<>();
+		downloaderName2Bin.put(YoutubeConf.NAME, "/usr/bin/yt-dlp");
+		final DownloaderPluginHolder downloaders = new DownloaderPluginHolder(
+				"/bin/sh -c #CMD#",
+				Collections.<String, PluginDownloaderInterface>emptyMap(),
+				downloaderName2Bin, "/tmp/out", "/tmp/idx", "/tmp/bin",
+				"/tmp/plugins");
+
+		final DownloadParamDTO param = new DownloadParamDTO(
+				"https://www.dailymotion.com/video/x9example",
+				"/tmp/out/dm-test.mp4", "mp4");
+
+		final ProcessHolder holder = new YoutubePluginDownloader()
+				.download(param, downloaders);
+		final String cmd = readCmd(holder);
+		assertTrue(cmd.contains("-f \"bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b\""));
+		assertTrue(cmd.contains("--merge-output-format mp4"));
+		assertFalse(cmd.contains("--write-subs"));
+		assertFalse(cmd.contains("--write-auto-subs"));
 	}
 
 	@Test


### PR DESCRIPTION
Summary:
- Prefer MP4 video and M4A audio when available.
- Keep fallback to yt-dlp best audio/video selection for sources without MP4/M4A formats.
- Avoid using audio extraction options for normal video downloads.
- Keep subtitles disabled by default.

Validation:
- mvn -B -ntp -pl plugins/youtube -am test

Notes:
- --audio-quality is intentionally not used for normal video downloads because it only applies to audio extraction/conversion with -x.
- Audio-only download quality should be implemented later as a separate explicit mode.