### PR TITLE
feat(youtube): add opt-in embedded subtitles setting

### DIFF
--- a/application/core/src/com/dabi/habitv/core/config/UserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/UserConfig.java
@@ -39,6 +39,8 @@ public interface UserConfig {
 
 	String getYoutubeApiKey();
 
+	boolean getEmbedSubtitles();
+
 	void setMaxAttempts(int parseInt);
 
 	void setUpdateOnStartup(boolean updateOnStartup);
@@ -48,5 +50,7 @@ public interface UserConfig {
 	void setDemonCheckTime(int demonCheckTime);
 
 	void setYoutubeApiKey(String youtubeApiKey);
+
+	void setEmbedSubtitles(boolean embedSubtitles);
 
 }

--- a/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
@@ -48,6 +48,7 @@ import com.dabi.habitv.utils.XMLUtils;
 
 public class XMLUserConfig implements UserConfig {
 	private static final String YOUTUBE_API_KEY = "youtubeApiKey";
+	private static final String EMBED_SUBTITLES = "embedSubtitles";
 
 	private static final int DEFAULT_MAX_ATTEMPTS = 5;
 
@@ -494,6 +495,22 @@ public class XMLUserConfig implements UserConfig {
 	}
 
 	@Override
+	public boolean getEmbedSubtitles() {
+		Downloaders downloaders = config.getDownloadConfig() == null ? null
+				: config.getDownloadConfig().getDownloaders();
+		if (downloaders == null) {
+			return false;
+		}
+		for (Object downloader : downloaders.getAny()) {
+			if (EMBED_SUBTITLES.equals(XMLUtils.getTagName(downloader))) {
+				return Boolean.parseBoolean(normalizeValue(XMLUtils
+						.getTagValue(downloader)));
+			}
+		}
+		return false;
+	}
+
+	@Override
 	public void setMaxAttempts(int maxAttemps) {
 		DownloadConfig downloadConfig = loadDownloadConfig();
 		downloadConfig.setMaxAttempts(maxAttemps);
@@ -554,6 +571,28 @@ public class XMLUserConfig implements UserConfig {
 		if (normalizedValue != null) {
 			downloaders.getAny().add(
 					XMLUtils.buildAnyElement(YOUTUBE_API_KEY, normalizedValue));
+		}
+	}
+
+	@Override
+	public void setEmbedSubtitles(boolean embedSubtitles) {
+		Downloaders downloaders = loadDownloaders();
+		Iterator<Object> iterator = downloaders.getAny().iterator();
+		while (iterator.hasNext()) {
+			Object downloader = iterator.next();
+			if (EMBED_SUBTITLES.equals(XMLUtils.getTagName(downloader))) {
+				if (!embedSubtitles) {
+					iterator.remove();
+				} else {
+					XMLUtils.setTagValue(downloader, Boolean.TRUE.toString());
+				}
+				return;
+			}
+		}
+		if (embedSubtitles) {
+			downloaders.getAny().add(
+					XMLUtils.buildAnyElement(EMBED_SUBTITLES, Boolean.TRUE
+							.toString()));
 		}
 	}
 

--- a/application/core/src/com/dabi/habitv/core/mgr/PluginManager.java
+++ b/application/core/src/com/dabi/habitv/core/mgr/PluginManager.java
@@ -45,7 +45,8 @@ public class PluginManager {
 				config.getCmdProcessor(),
 				pluginFactory.loadPlugins(PluginDownloaderInterface.class),
 				config.getDownloader(), config.getDownloadOuput(),
-				config.getIndexDir(), config.getBinDir(), config.getPluginDir());
+				config.getIndexDir(), config.getBinDir(), config.getPluginDir(),
+				config.getEmbedSubtitles());
 		providersHolder = new ProviderPluginHolder(
 				pluginFactory.loadPlugins(PluginProviderInterface.class));
 		exportersHolder = new ExporterPluginHolder(

--- a/application/core/src/com/dabi/habitv/core/task/DownloadTask.java
+++ b/application/core/src/com/dabi/habitv/core/task/DownloadTask.java
@@ -20,6 +20,7 @@ import com.dabi.habitv.core.dao.DownloadedDAO;
 import com.dabi.habitv.core.event.EpisodeStateEnum;
 import com.dabi.habitv.core.event.RetreiveEvent;
 import com.dabi.habitv.core.token.TokenReplacer;
+import com.dabi.habitv.framework.FrameworkConf;
 import com.dabi.habitv.framework.plugin.utils.DownloadUtils;
 
 public class DownloadTask extends AbstractEpisodeTask {
@@ -163,6 +164,10 @@ public class DownloadTask extends AbstractEpisodeTask {
 				getEpisode().getId(), outputTmpFileName,
 				category.getExtension());
 		downloadParam.getParams().putAll(category.getParameters());
+		if (downloaders.isEmbedSubtitlesEnabled()) {
+			downloadParam.addParam(FrameworkConf.PARAMETER_EMBED_SUBTITLES,
+					Boolean.TRUE.toString());
+		}
 		return downloadParam;
 	}
 

--- a/application/core/test/com/dabi/habitv/core/config/XMLUserConfigTest.java
+++ b/application/core/test/com/dabi/habitv/core/config/XMLUserConfigTest.java
@@ -1,15 +1,20 @@
 package com.dabi.habitv.core.config;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import com.dabi.habitv.configuration.entities.Configuration;
 
 public class XMLUserConfigTest {
 
@@ -19,6 +24,24 @@ public class XMLUserConfigTest {
 
 	@After
 	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void embedSubtitlesDefaultsToFalseForNewConfig() throws Exception {
+		final XMLUserConfig userConfig = newConfigInstance();
+		assertFalse(userConfig.getEmbedSubtitles());
+	}
+
+	private static XMLUserConfig newConfigInstance() throws Exception {
+		final Method buildDefaultConfig = XMLUserConfig.class.getDeclaredMethod(
+				"buildDefaultConfig");
+		buildDefaultConfig.setAccessible(true);
+		final Configuration configuration = (Configuration) buildDefaultConfig
+				.invoke(null);
+		final Constructor<XMLUserConfig> constructor = XMLUserConfig.class
+				.getDeclaredConstructor(Configuration.class);
+		constructor.setAccessible(true);
+		return constructor.newInstance(configuration);
 	}
 
 	@Test

--- a/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
@@ -24,15 +24,18 @@ public class ConfigController extends BaseController {
 
 	private TextField youtubeApiKey;
 
+	private CheckBox embedSubtitles;
+
 	public ConfigController(TextField downloadOuput, TextField nbrMaxAttempts,
 			TextField daemonCheckTimeSec, CheckBox autoUpdate,
-			TextField youtubeApiKey) {
+			TextField youtubeApiKey, CheckBox embedSubtitles) {
 		super();
 		this.downloadOuput = downloadOuput;
 		this.nbrMaxAttempts = nbrMaxAttempts;
 		this.daemonCheckTimeSec = daemonCheckTimeSec;
 		this.autoUpdate = autoUpdate;
 		this.youtubeApiKey = youtubeApiKey;
+		this.embedSubtitles = embedSubtitles;
 	}
 
 	public void init() {
@@ -62,6 +65,8 @@ public class ConfigController extends BaseController {
 				"si coché habiTv se mettra à jour automatiquement."));
 		youtubeApiKey.setTooltip(new Tooltip(
 				"Clé API YouTube Data v3. Laissez vide pour utiliser la variable d'environnement ou l'option Java."));
+		embedSubtitles.setTooltip(new Tooltip(
+				"Embed subtitles in the downloaded video when available."));
 	}
 
 	private void loadConfig() {
@@ -72,6 +77,7 @@ public class ConfigController extends BaseController {
 				.getDemonCheckTime()));
 		autoUpdate.setSelected(userConfig.updateOnStartup());
 		youtubeApiKey.setText(userConfig.getYoutubeApiKey());
+		embedSubtitles.setSelected(userConfig.getEmbedSubtitles());
 	}
 
 	private void addButtonActions() {
@@ -143,6 +149,16 @@ public class ConfigController extends BaseController {
 			public void handle(ActionEvent arg0) {
 				UserConfig userConfig = getController().loadUserConfig();
 				userConfig.setUpdateOnStartup(autoUpdate.isSelected());
+				saveConfig(userConfig);
+			}
+		});
+
+		embedSubtitles.setOnAction(new EventHandler<ActionEvent>() {
+
+			@Override
+			public void handle(ActionEvent arg0) {
+				UserConfig userConfig = getController().loadUserConfig();
+				userConfig.setEmbedSubtitles(embedSubtitles.isSelected());
 				saveConfig(userConfig);
 			}
 		});

--- a/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
@@ -66,7 +66,7 @@ public class ConfigController extends BaseController {
 		youtubeApiKey.setTooltip(new Tooltip(
 				"Clé API YouTube Data v3. Laissez vide pour utiliser la variable d'environnement ou l'option Java."));
 		embedSubtitles.setTooltip(new Tooltip(
-				"Embed subtitles in the downloaded video when available."));
+				"Intègre les sous-titres dans la vidéo téléchargée lorsqu'ils sont disponibles. Nécessite ffmpeg via le post-traitement yt-dlp."));
 	}
 
 	private void loadConfig() {

--- a/application/trayView/src/com/dabi/habitv/tray/controller/WindowController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/WindowController.java
@@ -138,6 +138,9 @@ public class WindowController {
 	@FXML
 	private TextField youtubeApiKey;
 
+	@FXML
+	private CheckBox embedSubtitles;
+
 	private boolean trayMode = false;
 
 	public WindowController() {
@@ -199,7 +202,8 @@ public class WindowController {
 			manager.attach(toDlController);
 
 			new ConfigController(downloadOuput, nbrMaxAttempts,
-					daemonCheckTimeSec, autoUpdate, youtubeApiKey).init(controller, manager,
+					daemonCheckTimeSec, autoUpdate, youtubeApiKey,
+					embedSubtitles).init(controller, manager,
 					primaryStage);
 
 			controller.startDownloadCheckDemon();

--- a/application/trayView/src/com/dabi/habitv/tray/habitv.fxml
+++ b/application/trayView/src/com/dabi/habitv/tray/habitv.fxml
@@ -239,6 +239,8 @@
 											vgrow="SOMETIMES" />
 										<RowConstraints minHeight="10.0" prefHeight="30.0"
 											vgrow="SOMETIMES" />
+										<RowConstraints minHeight="10.0" prefHeight="30.0"
+											vgrow="SOMETIMES" />
 									</rowConstraints>
 									<children>
 										<Label text="Destination des téléchargements : "
@@ -266,6 +268,11 @@
 										<TextField fx:id="youtubeApiKey"
 											BorderPane.alignment="CENTER" GridPane.columnIndex="1"
 											GridPane.rowIndex="4" />
+										<Label text="Embed subtitles when available"
+											GridPane.columnIndex="0" GridPane.rowIndex="5" />
+										<CheckBox fx:id="embedSubtitles"
+											mnemonicParsing="false" GridPane.columnIndex="1"
+											GridPane.rowIndex="5" />
 									</children>
 									<padding>
 										<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/application/trayView/src/com/dabi/habitv/tray/habitv.fxml
+++ b/application/trayView/src/com/dabi/habitv/tray/habitv.fxml
@@ -268,7 +268,7 @@
 										<TextField fx:id="youtubeApiKey"
 											BorderPane.alignment="CENTER" GridPane.columnIndex="1"
 											GridPane.rowIndex="4" />
-										<Label text="Embed subtitles when available"
+										<Label text="Intégrer les sous-titres lorsqu'ils sont disponibles :"
 											GridPane.columnIndex="0" GridPane.rowIndex="5" />
 										<CheckBox fx:id="embedSubtitles"
 											mnemonicParsing="false" GridPane.columnIndex="1"

--- a/fwk/api/src/com/dabi/habitv/api/plugin/holder/DownloaderPluginHolder.java
+++ b/fwk/api/src/com/dabi/habitv/api/plugin/holder/DownloaderPluginHolder.java
@@ -18,8 +18,17 @@ public final class DownloaderPluginHolder extends AbstractPluginHolder<PluginDow
 
 	private final String pluginDir;
 
+	private final boolean embedSubtitles;
+
 	public DownloaderPluginHolder(final String cmdProcessor, final Map<String, PluginDownloaderInterface> downloaderName2downloader,
 			final Map<String, String> downloaderName2BinPath, final String downloadOutputDir, final String indexDir, final String binDir, final String pluginDir) {
+		this(cmdProcessor, downloaderName2downloader, downloaderName2BinPath,
+				downloadOutputDir, indexDir, binDir, pluginDir, false);
+	}
+
+	public DownloaderPluginHolder(final String cmdProcessor, final Map<String, PluginDownloaderInterface> downloaderName2downloader,
+			final Map<String, String> downloaderName2BinPath, final String downloadOutputDir, final String indexDir, final String binDir, final String pluginDir,
+			final boolean embedSubtitles) {
 		super(downloaderName2downloader);
 		this.cmdProcessor = cmdProcessor;
 		this.downloaderName2BinPath = downloaderName2BinPath;
@@ -27,6 +36,7 @@ public final class DownloaderPluginHolder extends AbstractPluginHolder<PluginDow
 		this.indexDir = indexDir;
 		this.binDir = binDir;
 		this.pluginDir = pluginDir;
+		this.embedSubtitles = embedSubtitles;
 	}
 
 	public String getBinPath(final String downloaderName) {
@@ -51,6 +61,10 @@ public final class DownloaderPluginHolder extends AbstractPluginHolder<PluginDow
 
 	public String getPluginDir() {
 		return pluginDir;
+	}
+
+	public boolean isEmbedSubtitlesEnabled() {
+		return embedSubtitles;
 	}
 
 }

--- a/fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java
@@ -10,6 +10,8 @@ public interface FrameworkConf {
 
 	String PARAMETER_ARGS = "ARGUMENTS";
 
+	String PARAMETER_EMBED_SUBTITLES = "EMBED_SUBTITLES";
+
 	String DOWNLOADER_PARAM = "downloader";
 
 	long TIME_BETWEEN_LOG = 2000L;

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
@@ -17,6 +17,7 @@ public final class YoutubeConf {
 	 * {@link com.dabi.habitv.framework.FrameworkConf#DOWNLOAD_DESTINATION} are resolved at runtime.
 	 */
 	public static final String DUMP_CMD = " \"#VIDEO_URL#\" -o \"#FILE_DEST#\" -f \"bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b\" --merge-output-format mp4 --no-check-certificate";
+	public static final String DUMP_CMD_EMBED_SUBS = " --embed-subs --sub-langs \"fr.*,fr,en.*,en,-live_chat\" --sub-format \"srt/vtt/best\"";
 	/**
 	 * Default MP3 extraction flags for yt-dlp ({@code --extract-audio} / {@code --audio-format}).
 	 */

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
@@ -30,7 +30,13 @@ public class YoutubePluginDownloader extends BaseUpdatablePlugin implements Plug
 			// For video downloads, audio quality is controlled by yt-dlp format selection.
 			// --audio-quality is intentionally not used here because it only applies to
 			// audio extraction/conversion with -x.
+			// Subtitle embedding is opt-in because default downloads should stay video/audio only and must not leave subtitle sidecar files.
+			// Auto-generated subtitles are intentionally not enabled here; they should be added later as a separate advanced option.
+			// TODO: Add a separate advanced option to include auto-generated subtitles when official subtitles are unavailable.
 			cmd += YoutubeConf.DUMP_CMD;
+			if (isEmbedSubtitlesEnabled(downloadParam)) {
+				cmd += YoutubeConf.DUMP_CMD_EMBED_SUBS;
+			}
 		} else {
 			cmd += cmdParam;
 		}
@@ -86,6 +92,11 @@ public class YoutubePluginDownloader extends BaseUpdatablePlugin implements Plug
 		} else {
 			return DownloadableState.IMPOSSIBLE;
 		}
+	}
+
+	private boolean isEmbedSubtitlesEnabled(final DownloadParamDTO downloadParam) {
+		return Boolean.parseBoolean(downloadParam
+				.getParam(FrameworkConf.PARAMETER_EMBED_SUBTITLES));
 	}
 
 }

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginDownloader.java
@@ -32,7 +32,6 @@ public class YoutubePluginDownloader extends BaseUpdatablePlugin implements Plug
 			// audio extraction/conversion with -x.
 			// Subtitle embedding is opt-in because default downloads should stay video/audio only and must not leave subtitle sidecar files.
 			// Auto-generated subtitles are intentionally not enabled here; they should be added later as a separate advanced option.
-			// TODO: Add a separate advanced option to include auto-generated subtitles when official subtitles are unavailable.
 			cmd += YoutubeConf.DUMP_CMD;
 			if (isEmbedSubtitlesEnabled(downloadParam)) {
 				cmd += YoutubeConf.DUMP_CMD_EMBED_SUBS;

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
@@ -34,6 +34,7 @@ public class YoutubeConfTest {
 		assertFalse(YoutubeConf.DUMP_CMD.contains("--write-subs"));
 		assertFalse(YoutubeConf.DUMP_CMD.contains("--write-auto-sub"));
 		assertFalse(YoutubeConf.DUMP_CMD.contains("--write-auto-subs"));
+		assertFalse(YoutubeConf.DUMP_CMD.contains("--all-subs"));
 		assertFalse(YoutubeConf.DUMP_CMD.contains("--embed-subs"));
 	}
 

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
@@ -171,6 +171,32 @@ public class YoutubePluginDownloaderCmdTest {
 	}
 
 	@Test
+	public void customParameterArgsDoNotAppendEmbedSubtitlesFlags() throws Exception {
+		final HashMap<String, String> downloaderName2Bin = new HashMap<>();
+		downloaderName2Bin.put(YoutubeConf.NAME, "/usr/bin/yt-dlp");
+		final DownloaderPluginHolder downloaders = new DownloaderPluginHolder(
+				"/bin/sh -c #CMD#",
+				Collections.<String, PluginDownloaderInterface>emptyMap(),
+				downloaderName2Bin, "/tmp/out", "/tmp/idx", "/tmp/bin",
+				"/tmp/plugins");
+
+		final DownloadParamDTO param = new DownloadParamDTO(
+				"https://www.youtube.com/watch?v=jNQXAC9IVRw",
+				"/tmp/out/test.mp4", "mp4");
+		param.addParam(FrameworkConf.PARAMETER_ARGS,
+				" \"#VIDEO_URL#\" -o \"#FILE_DEST#\" --no-check-certificate");
+		param.addParam(FrameworkConf.PARAMETER_EMBED_SUBTITLES, "true");
+
+		final ProcessHolder holder = new YoutubePluginDownloader()
+				.download(param, downloaders);
+		final String cmd = readCmd(holder);
+		assertTrue(cmd.contains("--no-check-certificate"));
+		assertFalse(cmd.contains("--embed-subs"));
+		assertFalse(cmd.contains("--sub-langs"));
+		assertFalse(cmd.contains("--sub-format"));
+	}
+
+	@Test
 	public void downloadWithMp3ArgsIncludesExtractAudioFlags() throws Exception {
 		final HashMap<String, String> downloaderName2Bin = new HashMap<>();
 		downloaderName2Bin.put(YoutubeConf.NAME, "/usr/bin/yt-dlp");

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginDownloaderCmdTest.java
@@ -19,6 +19,7 @@ import com.dabi.habitv.api.plugin.api.PluginDownloaderInterface.DownloadableStat
 import com.dabi.habitv.api.plugin.dto.DownloadParamDTO;
 import com.dabi.habitv.api.plugin.holder.DownloaderPluginHolder;
 import com.dabi.habitv.api.plugin.holder.ProcessHolder;
+import com.dabi.habitv.framework.FrameworkConf;
 import com.dabi.habitv.framework.plugin.utils.CmdExecutor;
 
 public class YoutubePluginDownloaderCmdTest {
@@ -79,11 +80,42 @@ public class YoutubePluginDownloaderCmdTest {
 		assertFalse(cmd.contains("--extract-audio"));
 		assertFalse(cmd.contains("-x"));
 		assertFalse(cmd.contains("--audio-format"));
+		assertFalse(cmd.contains("--embed-subs"));
+		assertFalse(cmd.contains("--sub-langs"));
+		assertFalse(cmd.contains("--sub-format"));
 		assertFalse(cmd.contains("--write-sub"));
 		assertFalse(cmd.contains("--write-subs"));
 		assertFalse(cmd.contains("--write-auto-sub"));
 		assertFalse(cmd.contains("--write-auto-subs"));
-		assertFalse(cmd.contains("--embed-subs"));
+		assertFalse(cmd.contains("--all-subs"));
+	}
+
+	@Test
+	public void embedSubtitlesOptionAppendsEmbedAndLanguageFlags() throws Exception {
+		final HashMap<String, String> downloaderName2Bin = new HashMap<>();
+		downloaderName2Bin.put(YoutubeConf.NAME, "/usr/bin/yt-dlp");
+		final DownloaderPluginHolder downloaders = new DownloaderPluginHolder(
+				"/bin/sh -c #CMD#",
+				Collections.<String, PluginDownloaderInterface>emptyMap(),
+				downloaderName2Bin, "/tmp/out", "/tmp/idx", "/tmp/bin",
+				"/tmp/plugins");
+
+		final DownloadParamDTO param = new DownloadParamDTO(
+				"https://www.youtube.com/watch?v=jNQXAC9IVRw",
+				"/tmp/out/test.mp4", "mp4");
+		param.addParam(FrameworkConf.PARAMETER_EMBED_SUBTITLES, "true");
+
+		final ProcessHolder holder = new YoutubePluginDownloader()
+				.download(param, downloaders);
+		final String cmd = readCmd(holder);
+		assertTrue(cmd.contains("-f \"bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b\""));
+		assertTrue(cmd.contains("--merge-output-format mp4"));
+		assertTrue(cmd.contains("--embed-subs"));
+		assertTrue(cmd.contains("--sub-langs \"fr.*,fr,en.*,en,-live_chat\""));
+		assertTrue(cmd.contains("--sub-format \"srt/vtt/best\""));
+		assertFalse(cmd.contains("--write-auto-subs"));
+		assertFalse(cmd.contains("--write-auto-sub"));
+		assertFalse(cmd.contains("--all-subs"));
 	}
 
 	@Test
@@ -105,8 +137,37 @@ public class YoutubePluginDownloaderCmdTest {
 		final String cmd = readCmd(holder);
 		assertTrue(cmd.contains("-f \"bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b\""));
 		assertTrue(cmd.contains("--merge-output-format mp4"));
+		assertFalse(cmd.contains("--embed-subs"));
 		assertFalse(cmd.contains("--write-subs"));
 		assertFalse(cmd.contains("--write-auto-subs"));
+	}
+
+	@Test
+	public void dailymotionUrlUsesSameEmbedSubtitlesOptionBehavior() throws Exception {
+		final HashMap<String, String> downloaderName2Bin = new HashMap<>();
+		downloaderName2Bin.put(YoutubeConf.NAME, "/usr/bin/yt-dlp");
+		final DownloaderPluginHolder downloaders = new DownloaderPluginHolder(
+				"/bin/sh -c #CMD#",
+				Collections.<String, PluginDownloaderInterface>emptyMap(),
+				downloaderName2Bin, "/tmp/out", "/tmp/idx", "/tmp/bin",
+				"/tmp/plugins");
+
+		final DownloadParamDTO param = new DownloadParamDTO(
+				"https://www.dailymotion.com/video/x9example",
+				"/tmp/out/dm-test.mp4", "mp4");
+		param.addParam(FrameworkConf.PARAMETER_EMBED_SUBTITLES, "true");
+
+		final ProcessHolder holder = new YoutubePluginDownloader()
+				.download(param, downloaders);
+		final String cmd = readCmd(holder);
+		assertTrue(cmd.contains("-f \"bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b\""));
+		assertTrue(cmd.contains("--merge-output-format mp4"));
+		assertTrue(cmd.contains("--embed-subs"));
+		assertTrue(cmd.contains("--sub-langs \"fr.*,fr,en.*,en,-live_chat\""));
+		assertTrue(cmd.contains("--sub-format \"srt/vtt/best\""));
+		assertFalse(cmd.contains("--write-auto-subs"));
+		assertFalse(cmd.contains("--write-auto-sub"));
+		assertFalse(cmd.contains("--all-subs"));
 	}
 
 	@Test


### PR DESCRIPTION
## Related issue

Optional follow-up to merged PR #98.

## Scope

youtube-embed-subtitles-ui-option

## Summary

- PR #98 has been merged into `develop`.
- This branch was rebased on latest `develop`.
- The final yt-dlp command preserves MP4/M4A format selection from PR #98 and adds subtitle embedding only when enabled.
- Add a global opt-in setting for embedded subtitles in yt-dlp-backed downloads.
- Keep subtitle embedding disabled by default.
- Append subtitle embedding flags only when the setting is enabled.
- Keep auto-generated subtitles out of scope.

## Changes

- `FrameworkConf.PARAMETER_EMBED_SUBTITLES` and `DownloadTask` wiring.
- `XMLUserConfig` / `UserConfig` persistence (`embedSubtitles` defaults to false).
- Tray UI checkbox with French label and tooltip.
- `YoutubeConf.DUMP_CMD_EMBED_SUBS` appended only when opt-in is enabled and no custom `PARAMETER_ARGS` are set.
- Default `DUMP_CMD` keeps PR #98 format: `-f "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b" --merge-output-format mp4`.

## Validation

```
mvn -B -ntp -pl plugins/youtube -am test
```

```
[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
[INFO] Total time:  20.304 s
```

```
mvn -B -ntp -pl application/core -am "-Dtest=DownloadTaskTest,XMLUserConfigTest" "-Dsurefire.failIfNoSpecifiedTests=false" test
```

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 2
[INFO] BUILD SUCCESS
[INFO] Total time:  8.744 s
```

```
mvn -B -ntp -pl application/trayView -am -DskipTests compile
```

```
[INFO] BUILD SUCCESS
[INFO] Total time:  6.354 s
```

```
mvn -B -ntp -DskipTests validate
```

```
[INFO] BUILD SUCCESS
[INFO] Total time:  0.864 s
```

## Risk / rollback

- Subtitle embedding requires ffmpeg through yt-dlp post-processing when enabled.
- Roll back by disabling the checkbox or reverting this PR; default downloads remain unchanged.

## Notes

- Enabled path appends: `--embed-subs`, `--sub-langs "fr.*,fr,en.*,en,-live_chat"`, `--sub-format "srt/vtt/best"`.
- Does not add `--write-auto-sub`, `--write-auto-subs`, `--write-sub`, `--write-subs`, or `--all-subs`.
- Custom `FrameworkConf.PARAMETER_ARGS` are not modified with subtitle flags.
- Auto-generated subtitle fallback remains a separate future option.
