### PR TITLE
build: enable mvn install/package on JDK 11+ via OpenJFX provided deps

### DIFF
--- a/application/habiTv/pom.xml
+++ b/application/habiTv/pom.xml
@@ -43,7 +43,6 @@
 				<jdk>[9,)</jdk>
 			</activation>
 			<properties>
-				<javafx.platform>linux</javafx.platform>
 				<openjfx.version>17.0.13</openjfx.version>
 			</properties>
 			<dependencies>

--- a/application/habiTv/pom.xml
+++ b/application/habiTv/pom.xml
@@ -31,7 +31,7 @@
 	</dependencies>
 	<profiles>
 		<!--
-		  On JDK 9+, JavaFX 2.x is no longer bundled with the JDK. The
+		  On JDK 11+, JavaFX 2.x is no longer bundled with the JDK. The
 		  launcher references trayView whose ancestor extends
 		  javafx.application.Application, so javac needs the JavaFX API
 		  available even though HabitvLauncher itself does not import it.
@@ -40,7 +40,7 @@
 		<profile>
 			<id>javafx-openjfx-compile</id>
 			<activation>
-				<jdk>[9,)</jdk>
+				<jdk>[11,)</jdk>
 			</activation>
 			<properties>
 				<openjfx.version>17.0.13</openjfx.version>

--- a/application/habiTv/pom.xml
+++ b/application/habiTv/pom.xml
@@ -29,6 +29,39 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<!--
+		  On JDK 9+, JavaFX 2.x is no longer bundled with the JDK. The
+		  launcher references trayView whose ancestor extends
+		  javafx.application.Application, so javac needs the JavaFX API
+		  available even though HabitvLauncher itself does not import it.
+		  Match trayView/pom.xml's javafx-openjfx-compile profile.
+		-->
+		<profile>
+			<id>javafx-openjfx-compile</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<javafx.platform>linux</javafx.platform>
+				<openjfx.version>17.0.13</openjfx.version>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-base</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-graphics</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 	<build>
 <plugins>
       <plugin>

--- a/application/habiTv/pom.xml
+++ b/application/habiTv/pom.xml
@@ -6,7 +6,7 @@
 		<version>4.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
-	
+
 	<artifactId>habiTv</artifactId>
 	<packaging>jar</packaging>
 	<name>habiTv</name>
@@ -15,7 +15,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
-		</dependency>		
+		</dependency>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>
 			<artifactId>trayView</artifactId>
@@ -31,11 +31,13 @@
 	</dependencies>
 	<profiles>
 		<!--
-		  On JDK 11+, JavaFX 2.x is no longer bundled with the JDK. The
-		  launcher references trayView whose ancestor extends
-		  javafx.application.Application, so javac needs the JavaFX API
-		  available even though HabitvLauncher itself does not import it.
-		  Match trayView/pom.xml's javafx-openjfx-compile profile.
+		  On JDK 11+, JavaFX is no longer bundled with the JDK. Supply the
+		  JavaFX API as compile-only ("provided") dependencies so this module
+		  compiles on JDK 11+ build hosts. HabitvLauncher does not import
+		  JavaFX directly, but trayView does; match trayView's
+		  javafx-openjfx-compile profile. Not a runtime migration: Java 8
+		  remains the baseline and runtime still uses jfxrt.jar classpath
+		  bootstrapping via HabitvLauncher.
 		-->
 		<profile>
 			<id>javafx-openjfx-compile</id>
@@ -83,6 +85,6 @@
           </execution>
         </executions>
       </plugin>
-    </plugins>		
+    </plugins>
 	</build>
 </project>

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -101,7 +101,7 @@
 					<archive>
 						<manifestEntries>
 							<JavaFX-Version>2.2+</JavaFX-Version>
-							<Main-Class>com.dabi.habitv.tray.HabiTvSplashScreen	</Main-Class>
+							<Main-Class>com.dabi.habitv.tray.HabiTvSplashScreen</Main-Class>
 							<implementation-version>2.2</implementation-version>
 							<JavaFX-Application-Class>com.dabi.habitv.tray.HabiTvSplashScreen</JavaFX-Application-Class>
 							<!-- The artifactId (name) of the jfxrt.jar ... see dependency system 

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -28,12 +28,13 @@
 	</dependencies>
 	<profiles>
 		<!--
-		  On JDK 11+, JavaFX 2.x is no longer bundled with the JDK. Supply the
-		  JavaFX classes as compile-only ("provided") dependencies so the
-		  reactor compiles end-to-end. At runtime, JavaFX is still expected
-		  to come from the JDK (Liberica/Zulu JDK 8 + JavaFX) or from an
-		  external OpenJFX module path, matching the existing launcher
-		  bootstrap. See AGENTS.md hard rules §2 ("javafx-modernization").
+		  On JDK 11+, JavaFX is no longer bundled with the JDK. Supply the
+		  JavaFX API as compile-only ("provided") dependencies so the reactor
+		  compiles on JDK 11+ build hosts. This is not a runtime migration:
+		  Java 8 remains the baseline. At runtime, HabitvLauncher still adds
+		  jfxrt.jar (or -Dhabitv.jfxrt.path) to the classpath, not JPMS
+		  module-path bootstrapping. See AGENTS.md hard rules
+		  ("javafx-modernization").
 		-->
 		<profile>
 			<id>javafx-openjfx-compile</id>

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -41,7 +41,6 @@
 				<jdk>[9,)</jdk>
 			</activation>
 			<properties>
-				<javafx.platform>linux</javafx.platform>
 				<openjfx.version>17.0.13</openjfx.version>
 			</properties>
 			<dependencies>

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -26,6 +26,52 @@
 			<artifactId>reload4j</artifactId>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<!--
+		  On JDK 9+, JavaFX 2.x is no longer bundled with the JDK. Supply the
+		  JavaFX classes as compile-only ("provided") dependencies so the
+		  reactor compiles end-to-end. At runtime, JavaFX is still expected
+		  to come from the JDK (Liberica/Zulu JDK 8 + JavaFX) or from an
+		  external OpenJFX module path, matching the existing launcher
+		  bootstrap. See AGENTS.md hard rules §2 ("javafx-modernization").
+		-->
+		<profile>
+			<id>javafx-openjfx-compile</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<javafx.platform>linux</javafx.platform>
+				<openjfx.version>17.0.13</openjfx.version>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-base</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-graphics</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-controls</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-fxml</artifactId>
+					<version>${openjfx.version}</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 	<build>
 		<resources>
 			<resource>

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -28,7 +28,7 @@
 	</dependencies>
 	<profiles>
 		<!--
-		  On JDK 9+, JavaFX 2.x is no longer bundled with the JDK. Supply the
+		  On JDK 11+, JavaFX 2.x is no longer bundled with the JDK. Supply the
 		  JavaFX classes as compile-only ("provided") dependencies so the
 		  reactor compiles end-to-end. At runtime, JavaFX is still expected
 		  to come from the JDK (Liberica/Zulu JDK 8 + JavaFX) or from an
@@ -38,7 +38,7 @@
 		<profile>
 			<id>javafx-openjfx-compile</id>
 			<activation>
-				<jdk>[9,)</jdk>
+				<jdk>[11,)</jdk>
 			</activation>
 			<properties>
 				<openjfx.version>17.0.13</openjfx.version>

--- a/application/trayView/pom.xml
+++ b/application/trayView/pom.xml
@@ -104,7 +104,7 @@
 							<Main-Class>com.dabi.habitv.tray.HabiTvSplashScreen</Main-Class>
 							<implementation-version>2.2</implementation-version>
 							<JavaFX-Application-Class>com.dabi.habitv.tray.HabiTvSplashScreen</JavaFX-Application-Class>
-							<!-- The artifactId (name) of the jfxrt.jar ... see dependency system 
+							<!-- The artifactId (name) of the jfxrt.jar ... see dependency system
 								scope -->
 							<Class-Path>javafx-2.2.jar</Class-Path>
 						</manifestEntries>


### PR DESCRIPTION
## Summary

Build-only compatibility fix for compiling and packaging Habitv on JDK 11+ where JavaFX is no longer bundled with the JDK.

This PR adds a `javafx-openjfx-compile` Maven profile to `application/trayView` and `application/habiTv`. The profile activates only on JDK `[11,)` and adds OpenJFX 17.0.13 dependencies with `provided` scope so JavaFX classes are available to the compiler.

## Scope

- `application/trayView/pom.xml`: add provided OpenJFX dependencies for base, graphics, controls, and fxml.
- `application/habiTv/pom.xml`: add provided OpenJFX dependencies for base and graphics.
- No Java source changes.
- No provider changes.
- No runtime bootstrap changes.
- No shaded OpenJFX dependencies.

## Compatibility notes

Java 8 remains the primary runtime and compile baseline. For JavaFX GUI builds and runtime on Java 8, use a Java 8 distribution/package that provides JavaFX in the bundle, such as Liberica Full JDK 8 or a Zulu 8 package that includes JavaFX.

On JDK 8, the OpenJFX profile is inactive.

On JDK 11+, OpenJFX is used only as a compile-time provided dependency. This does not complete Java 11/17/21 runtime migration, and runtime packaging modernization remains future work.

## Validation

Validated by GitHub Actions on the head commit:

- Maven CI passed Java 8 baseline jobs.
- Maven CI passed Java 8 package job.
- Compatibility diagnostic jobs passed on Java 11, Java 17, Java 21, and Java 25.
- Dependency Review passed.
- CI passed.

Recommended local commands:

- `mvn -B -ntp -DskipTests validate`
- `mvn -B -ntp -DskipTests -pl application/trayView,application/habiTv -am compile`
- `mvn -B -ntp -DskipTests package`

## Risk

Low build-time risk. The profile is inactive on JDK 8 and OpenJFX dependencies are provided, so they are not included in the shaded application jar.