### PR TITLE
docs: clarify Java runtime policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,9 @@ Do not, without a dedicated tracker item and an accepted ADR:
 
 - Restructure the Maven reactor or aggregator topology.
 - Migrate the Java baseline beyond Java 8.
-- Migrate JavaFX (JDK-bundled `jfxrt`) to OpenJFX.
+- Migrate JavaFX (`jfxrt.jar` on Java 8 runtime) to shipped OpenJFX runtime
+  packaging (compile bridge on JDK 11+ is not sufficient — see
+  `docs/java-runtime-policy.md`).
 - Regenerate JAXB-bound classes or move to `jakarta.*`.
 - Replace `youtube-dl` with `yt-dlp` (see `ytdlp-migration`).
 - Change runtime updater URLs or layout (see `static-repo-publish`).

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ reactor.
 | Topic | Current state |
 |-------|----------------|
 | Integration branch | [`develop`](https://github.com/Mika3578/habitv/tree/develop) |
-| Java baseline | **Java 8** — CI uses Zulu 8 for legacy validate, Liberica 8 `jdk+fx` for Maven CI Java 8 jobs, and Temurin 8 in the `master`-only legacy build |
-| Root `mvn validate` / `mvn compile` | Works on `develop` |
-| Full `mvn package` (GUI) | Works with a JDK 8 that includes JavaFX; platform packaging modules use separate `jdk.home` setup |
+| Java baseline | **Java 8** runtime and `source`/`target` **1.8** — see [`docs/java-runtime-policy.md`](docs/java-runtime-policy.md) |
+| Root `mvn validate` / `mvn compile` | Works on `develop` (Java 8 required CI; JDK 11+ diagnostic) |
+| Full `mvn package` (GUI) | On **Java 8**, use a JDK 8 distribution **with JavaFX** (e.g. Liberica Full JDK 8, Zulu 8 with FX); do not assume every Java 8 package includes FX. JDK 11+ build hosts use a **compile-only** OpenJFX profile ([PR #100](https://github.com/Mika3578/habitv/pull/100)) — not a Java 11+ **runtime** yet |
 | Artifact / plugin updates | HTTPS static repo ([`habitv-repo`](https://github.com/Mika3578/habitv-repo)) — legacy `dabiboo.free.fr` removed |
 | Provider plugins | Mixed: some work offline; many replay sites changed — see [provider inventory](docs/provider-inventory.md) |
 
@@ -32,7 +32,11 @@ reactor.
 
 ## Quick start (developers)
 
-**Prerequisites:** JDK 8, Maven 3.6+, Git.
+**Prerequisites:** JDK 8 for runtime-aligned work, Maven 3.6+, Git. GUI
+packaging on Java 8 needs a **JavaFX-capable** JDK 8 (see
+[`docs/java-runtime-policy.md`](docs/java-runtime-policy.md)). Building on
+JDK 11+ is supported for CI parity but does not change the Java 8 runtime
+baseline.
 
 ```bash
 git clone https://github.com/Mika3578/habitv.git
@@ -68,8 +72,8 @@ Runtime layout and manual download: [`docs/runtime-quickstart.md`](docs/runtime-
 | Command | Status on `develop` | Notes |
 |---------|---------------------|--------|
 | `mvn -B -ntp -DskipTests validate` | Safe, default | 33 reactor modules |
-| `mvn -B -ntp -DskipTests compile` | Safe | Java 8 only |
-| `mvn -B -ntp -DskipTests package` | Java 8 + JavaFX | Requires a JDK 8 with JavaFX for GUI modules; use scoped builds for console-only validation |
+| `mvn -B -ntp -DskipTests compile` | Safe | Bytecode **1.8**; required CI on Java 8 |
+| `mvn -B -ntp -DskipTests package` | Java 8 + JavaFX (GUI) | GUI modules need JavaFX on the **build** JDK (Java 8 FX-capable distro, or JDK 11+ with provided OpenJFX at compile — see runtime policy). Console-only scoped build avoids GUI/JavaFX |
 | `mvn -B -ntp test` | Partial | Live `*PluginManagerTest` excluded by default |
 | `mvn -B -ntp test -Plive-provider-tests` | Opt-in | Hits real broadcaster networks |
 | `mvn -B -ntp verify` | Not safe yet | Full lifecycle still gated |
@@ -78,13 +82,17 @@ CI parity: [`docs/ci.md`](docs/ci.md).
 
 ### Known build constraints
 
-- **Java 8 only** for this phase — no Java 9+ language features or APIs.
+- **Java 8** is the supported **runtime** baseline; compiler stays at
+  **1.8**. No Java 9+ language features or APIs in application code.
+- **JDK 11+** may be used on build hosts (provided OpenJFX profile per
+  [PR #100](https://github.com/Mika3578/habitv/pull/100)); that is not
+  Java 11/17/21 **runtime** migration.
 - **JAXB**: configuration/grabconfig types are generated under
   `target/generated-sources/jaxb` in `application/core` (see tracker
   `jaxb-launcher-recovery`).
-- **JavaFX**: `application/habiTv`, `trayView`, and out-of-reactor
-  `habiTv-linux` / `habiTv-windows` expect JDK 8 with `jfxrt.jar` (tracker
-  `javafx-modernization`).
+- **JavaFX**: GUI modules use JavaFX 2.x / `jfxrt.jar` on **Java 8
+  runtime**; use a **JavaFX-capable** JDK 8 for local GUI builds. JDK 11+
+  does not bundle JavaFX. Tracker: `javafx-modernization`.
 - **Legacy HTTP repo** (`dabiboo.free.fr`, FTP deploy, SVN SCM): removed from
   active POMs; history in [`docs/audit-master-baseline.md`](docs/audit-master-baseline.md).
 
@@ -140,6 +148,7 @@ Details: [`CONTRIBUTING.md`](CONTRIBUTING.md), [`AGENTS.md`](AGENTS.md),
 
 | Document | Purpose |
 |----------|---------|
+| [`docs/java-runtime-policy.md`](docs/java-runtime-policy.md) | Java 8 baseline, JavaFX, JDK 11+ build bridge, migration roadmap |
 | [`docs/dev-plan.md`](docs/dev-plan.md) | Phased modernization roadmap |
 | [`docs/dev-tracker.md`](docs/dev-tracker.md) | Work items (mirror: `dev-tracker.json`) |
 | [`docs/automatic-category-download.md`](docs/automatic-category-download.md) | Category watch, index, deduplication limits |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,9 +2,13 @@
 
 ## Baseline and intent
 
-- **Java 8** is the required compile and merge baseline for `develop`.
-- Java 11, 17, 21, and 25 jobs are **diagnostic only** (may fail until JAXB and
-  JavaFX migration completes).
+- **Java 8** is the required compile and merge baseline for `develop`
+  (`source`/`target` **1.8**; supported **runtime** baseline).
+- Java 11, 17, 21, and 25 jobs are **diagnostic only** (build-host checks;
+  not proof of Java 11/17/21 **runtime** support). JDK 11+ may compile GUI
+  modules using the provided OpenJFX profile ([PR #100](https://github.com/Mika3578/habitv/pull/100));
+  end-user runtime migration is tracked under `javafx-modernization`. See
+  [`java-runtime-policy.md`](java-runtime-policy.md).
 - No deployment, credential publishing, or auto-merge from bots.
 
 ## Workflows

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -153,8 +153,9 @@ Remaining: live fixture validation, `habitv-repo` `yt-dlp` tool zip publication.
 
 🔵 **Proposed** · `█░░░░░░░░░░░░░░░░░░░` 5%
 
-- Migrate JavaFX 2.x (JDK-bundled `jfxrt`) to OpenJFX with a modern
-  build (`jpackage`, `jlink`, or equivalent).
+- Migrate JavaFX 2.x (`jfxrt.jar` on Java 8; optional provided OpenJFX at
+  compile on JDK 11+ per PR #100) to **shipped** OpenJFX runtime packaging
+  (`jpackage`, `jlink`, or equivalent).
 - Re-evaluate `application/habiTv-linux` and `habiTv-windows`
   packaging.
 - Modernize the runtime updater (HTTPS, signed metadata) once the

--- a/docs/java-runtime-policy.md
+++ b/docs/java-runtime-policy.md
@@ -1,0 +1,187 @@
+# Java and JavaFX runtime policy
+
+This document is the canonical description of Habitv's **supported Java
+baseline**, **JavaFX expectations**, and **planned runtime migration**. It
+supersedes informal README wording where they conflict.
+
+**Related:** [`keep-java8-baseline`](decision-log.md) (ADR),
+[`javafx-modernization`](dev-tracker.md), risk [`javafx-jdk8`](risk-register.md).
+
+---
+
+## Current status
+
+| Aspect | Policy |
+|--------|--------|
+| **Supported runtime baseline** | **Java 8** only |
+| **Compiler `source` / `target`** | **1.8** across the in-reactor modules |
+| **End-user GUI runtime** | JDK/JRE 8 with a **JavaFX-capable** distribution (see below) |
+| **JDK 11+ on developer/CI machines** | Allowed for **build** (`validate`, `compile`, and scoped `package`) via the `javafx-openjfx-compile` Maven profile; **not** a supported end-user runtime yet |
+| **Runtime migration to Java 11/17/21** | **Not complete** — documentation and CI diagnostics only where noted |
+
+---
+
+## Java 8 baseline
+
+Habitv remains a **Java 8 application** for this modernization phase:
+
+- No Java 9+ language features or JDK-only APIs in production code without
+  an explicit baseline migration ADR.
+- CI **required** jobs use Java 8 (Liberica 8 `jdk+fx` for Maven CI package
+  work, Zulu 8 for legacy validate, Temurin 8 on `master`-only legacy build).
+- Contributors should treat **Java 8** as the compatibility contract for
+  behavior, bytecode, and dependency choices.
+
+Building or packaging on a newer JDK does **not** change the runtime
+contract until a dedicated migration item, ADR, and launcher/packaging work
+land.
+
+---
+
+## JavaFX on Java 8
+
+The tray/GUI modules (`application/trayView`, `application/habiTv`, and
+out-of-reactor `habiTv-linux` / `habiTv-windows`) use **JavaFX 2.x** APIs
+and, on Java 8, expect **`jfxrt.jar`** on the classpath (resolved by
+`HabitvLauncher` or `${jdk.home}` in legacy packaging POMs).
+
+### Do not assume every Java 8 JDK includes JavaFX
+
+Some **historical** Oracle JDK 8 and vendor builds shipped JavaFX inside
+the JDK. Many **modern** Java 8 packages (plain Temurin 8, Zulu 8 without
+the FX bundle, etc.) **do not** include JavaFX.
+
+For **Java 8 GUI runtime**, use a distribution that explicitly ships
+JavaFX, for example:
+
+- [BellSoft Liberica Full JDK 8](https://bell-sw.com/pages/downloads/) (`jdk+fx`)
+- [Azul Zulu 8](https://www.azul.com/downloads/) builds that include the JavaFX bundle
+
+The **console** fat-jar path (`application/consoleView`) does not require
+JavaFX for day-to-day download/export workflows.
+
+### JDK 11 and later do not bundle JavaFX
+
+From JDK 11 onward, JavaFX is **not** part of the JDK. OpenJFX is a
+separate library set; shipping it to end users requires explicit packaging
+(jlink, jpackage, shaded runtime, etc.) — tracked under
+`javafx-modernization`, not finished in this policy phase.
+
+---
+
+## What PR #100 changed
+
+[PR #100](https://github.com/Mika3578/habitv/pull/100) (`fix/javafx-openjfx-compile-profile`,
+merged to `develop`) added a **`javafx-openjfx-compile`** Maven profile on
+`application/trayView` and `application/habiTv`:
+
+- Activates automatically when the build runs on **JDK 11+**.
+- Adds **provided-scope** `org.openjfx` dependencies so JavaFX **APIs** are
+  available at **compile** (and scoped **package** on modern build hosts).
+- Aligns GUI modules with CI **diagnostic** JDK 11+ package jobs that exclude
+  full JavaFX runtime packaging assumptions.
+
+This is a **build-host bridge**, not a runtime migration.
+
+---
+
+## What PR #100 did not change
+
+PR #100 did **not**:
+
+- Raise the supported **end-user runtime** to Java 11, 17, or 21.
+- Change `maven-compiler-plugin` **source/target** (still **1.8**).
+- Replace `HabitvLauncher` **jfxrt.jar** classpath bootstrapping on Java 8.
+- Bundle OpenJFX into release artifacts for users.
+- Complete `javafx-modernization`, platform installers, or `${jdk.home}`
+  legacy packaging modules.
+- Retire risk `javafx-jdk8` or ADR `keep-java8-baseline`.
+
+Habitv is **not** a Java 11/17/21 **runtime** application yet.
+
+---
+
+## Migration targets (why 17, then 21, not 25 now)
+
+### Why Java 17 is the first runtime migration milestone
+
+- **Long-term support (LTS)** with broad tooling, CI image, and library
+  support already used in diagnostic jobs.
+- Natural step after Java 11; many ecosystems treat 17 as the first
+  "modern baseline" for enterprise desktop and server-side Java.
+- Aligns with the **OpenJFX** versions used in the compile bridge profile
+  (17.x line) while runtime packaging work is designed.
+- Keeps scope bounded: one LTS jump from 8, with JAXB and JavaFX packaging
+  addressed deliberately rather than in a single leap.
+
+### Why Java 21 is the future stable target
+
+- Current **LTS** cadence target for new deployments once 17 migration is
+  proven in CI and release artifacts.
+- Longer support window for a desktop app that may stay installed for years.
+- Planned **after** 17 compatibility is demonstrated, not in parallel with
+  the first migration.
+
+### Why Java 25 is not the immediate target
+
+- Newer, shorter track record in CI matrices and third-party plugins.
+- Habitv still carries **legacy Maven plugins**, JAXB generation, and
+  JavaFX 2.x assumptions; jumping to the newest JDK adds noise without
+  reducing the real blockers below.
+- JDK 25 may remain an **experimental diagnostic** JDK in CI; it is not the
+  next supported runtime.
+
+---
+
+## Known blockers before real runtime migration
+
+Real **runtime** migration (users run Habitv on JDK 17/21) is blocked until
+at least:
+
+| Blocker | Tracker / risk | Notes |
+|---------|----------------|-------|
+| **JavaFX runtime packaging** | `javafx-modernization`, `javafx-jdk8` | Move from `jfxrt.jar` / `${jdk.home}` to shipped OpenJFX or jpackage/jlink layout |
+| **JAXB externalization** | `jaxb-mismatch`, `jaxb-launcher-recovery` | `javax.xml.bind` on modular JDKs; module-path vs classpath |
+| **Old Maven plugins** | `java8-baseline`, audit baseline | Shade, Ant tasks, zenjava `javafx-maven-plugin`, compiler assumptions |
+| **Launcher / runtime scripts** | `javafx-modernization` | `HabitvLauncher`, install scripts, `-Dhabitv.jfxrt.path` contract |
+| **Plugin compatibility** | `provider-inventory` | Third-party JARs and native tools must stay Java 8 bytecode until coordinated bump |
+| **CI matrix hardening** | `branch-protection`, [`required-checks-roadmap.md`](required-checks-roadmap.md) | Required gates only when stable; JDK 11+ package is diagnostic today |
+
+---
+
+## Migration roadmap
+
+High-level steps (documentation-only sequencing; tracker items own delivery):
+
+| Step | Goal | Status (approx.) |
+|------|------|-------------------|
+| **1** | Keep **Java 8** baseline stable (`validate` / `compile` / required CI on 8) | In progress — baseline done; maintenance ongoing |
+| **2** | Make **build** compatible with **JDK 11+** hosts (compile/package bridge) | **Partial** — PR #100 (`javafx-openjfx-compile` profile) |
+| **3** | Prepare **Java 17** runtime compatibility (JAXB, OpenJFX packaging, launcher) | Not started for runtime |
+| **4** | Prepare **Java 21** runtime target (LTS stable deployment) | Future |
+| **5** | Evaluate **Java 25** later (experimental CI only until blockers clear) | Diagnostic only |
+
+Step 2 does **not** imply Step 3 is complete. Steps 3–4 require ADR
+superseding `keep-java8-baseline`, green required CI on the target JDK, and
+updated user-facing install docs.
+
+---
+
+## Build vs run (quick reference)
+
+| JDK used for… | Java 8 | JDK 11+ |
+|---------------|--------|---------|
+| Official runtime for users | **Yes** | **No** (yet) |
+| `mvn validate` / `compile` (reactor) | **Yes** (required CI) | Diagnostic CI |
+| GUI `package` with JavaFX APIs | Liberica/Zulu **8 with FX** | **Provided** OpenJFX at compile via profile; not full runtime packaging |
+| Console-only `package` | **Yes** | Often works; still Java 8 bytecode |
+
+**Local parity (Java 8 baseline):**
+
+```bash
+mvn -B -ntp -DskipTests validate
+mvn -B -ntp -DskipTests compile
+mvn -B -ntp -DskipTests -pl '!application/trayView,!application/habiTv' package
+```
+
+See also [`docs/ci.md`](ci.md) and [`docs/runtime-quickstart.md`](runtime-quickstart.md).

--- a/docs/java-runtime-policy.md
+++ b/docs/java-runtime-policy.md
@@ -41,7 +41,8 @@ land.
 ## JavaFX on Java 8
 
 The tray/GUI modules (`application/trayView`, `application/habiTv`, and
-out-of-reactor `habiTv-linux` / `habiTv-windows`) use **JavaFX 2.x** APIs
+out-of-reactor `application/habiTv-linux` / `application/habiTv-windows`)
+use **JavaFX 2.x** APIs
 and, on Java 8, expect **`jfxrt.jar`** on the classpath (resolved by
 `HabitvLauncher` or `${jdk.home}` in legacy packaging POMs).
 

--- a/docs/required-checks-roadmap.md
+++ b/docs/required-checks-roadmap.md
@@ -25,8 +25,9 @@ Do **not** add a check to branch protection when it:
 
 - Depends on live provider websites, replay endpoints, or other external
   network behavior that the project does not control.
-- Fails for reasons contributors cannot fix in the PR (for example missing
-  OpenJFX on Java 11+ before migration work lands).
+- Fails for reasons contributors cannot fix in the PR (for example a JDK 11+
+  build host without the `javafx-openjfx-compile` profile resolving, or
+  missing end-user OpenJFX **runtime** packaging before migration lands).
 - Produces noisy security alerts without a documented remediation path.
 
 Non-blocking jobs must remain visible (no `continue-on-error` used to hide
@@ -38,7 +39,8 @@ are explicitly **not** required).
 ## Phase 0 — Current required baseline
 
 **Goal:** Keep merge-blocking checks limited to the Java 8 baseline that
-already works in CI (Liberica JDK 8 with bundled JavaFX).
+already works in CI (Liberica JDK 8 `jdk+fx` — JavaFX included in that
+distribution, not assumed for all Java 8 packages).
 
 ### Required (target for `develop` ruleset)
 
@@ -100,9 +102,9 @@ Name these checks clearly as **validation**, not package compatibility. Do
 not mark Java 11/17/21/25 package jobs as required while OpenJFX migration is
 incomplete.
 
-**Prerequisites:** JAXB/module-path issues tracked under `jaxb-mismatch` must
-not cause chronic false failures on `validate` for the modules in the default
-reactor.
+**Prerequisites:** JAXB and modular-JDK classpath issues tracked under
+`jaxb-mismatch` must not cause chronic false failures on `validate` for the
+modules in the default reactor.
 
 ---
 
@@ -116,9 +118,13 @@ assumptions.
 
 **Engineering milestones (follow-up PRs, not this roadmap PR):**
 
-1. Add OpenJFX dependencies or JDK-version profiles for Java 11+.
-2. Ensure `application/trayView` compiles and `mvn -DskipTests package`
-   succeeds on the target LTS (prefer **Java 17** or **Java 21**).
+1. ✅ **Partial (PR #100):** `javafx-openjfx-compile` profile — provided-scope
+   OpenJFX on JDK 11+ **build** hosts for compile/package bridge. **Remaining:**
+   ship OpenJFX (or jlink/jpackage layout) for **end-user runtime** on modern
+   JDKs.
+2. Ensure `application/trayView` **runtime** packaging and `mvn -DskipTests
+   package` succeed on the target LTS (first milestone **Java 17**, stable
+   target **Java 21**) — not only compile on JDK 11+.
 3. Keep Java 8 compatibility until a separate ADR retires it.
 4. Leave `application/habiTv-linux` and `application/habiTv-windows` out of
    required gates until explicitly brought into the reactor or replaced.

--- a/docs/runtime-quickstart.md
+++ b/docs/runtime-quickstart.md
@@ -2,7 +2,9 @@
 
 This guide walks through running Habitv with a working YouTube download
 provider on a Linux machine. It assumes a clean checkout of **`develop`**
-and **JDK 8** on the PATH (Java 11+ is not supported for the full GUI yet).
+and **JDK 8** on the PATH for runtime-aligned workflows. End-user **GUI
+runtime** remains Java 8; JDK 11+ is not a supported Habitv runtime (see
+[`java-runtime-policy.md`](java-runtime-policy.md)).
 
 For automatic category watch behavior (index baseline, deduplication limits),
 see [`automatic-category-download.md`](automatic-category-download.md).
@@ -21,9 +23,11 @@ see [`automatic-category-download.md`](automatic-category-download.md).
 mvn -B -ntp -DskipTests -pl '!application/trayView,!application/habiTv' package
 ```
 
-The JavaFX-based GUI modules (`trayView`, `habiTv`) are excluded for
-now because they depend on the JDK-bundled JavaFX runtime, which is
-not part of OpenJDK 11+. The CLI launcher (`consoleView`) is fully
+The JavaFX-based GUI modules (`trayView`, `habiTv`) are excluded from
+this quickstart because they need a **JavaFX-capable JDK 8** at runtime
+(`jfxrt.jar` / launcher classpath). Plain JDK 8 builds without JavaFX,
+and JDK 11+ runtimes, are not supported for the full GUI yet. The CLI
+launcher (`consoleView`) is fully
 functional and ships everything needed for download/export pipelines.
 
 Produces:


### PR DESCRIPTION
## Summary

- Documents the current Java and JavaFX runtime policy.
- Clarifies that Java 8 remains the supported baseline.
- Explains that the JDK 11+ OpenJFX profile is compile/package support only.
- Adds a migration roadmap toward Java 17 and Java 21.

## Scope

java-runtime-policy

## Related issue

- N/A

## Changes

- Add `docs/java-runtime-policy.md` (baseline, JavaFX on 8, PR #100 scope, blockers, five-step roadmap).
- Update `README.md` Java/JavaFX tables and prerequisites.
- Align `docs/ci.md`, `docs/runtime-quickstart.md`, `docs/required-checks-roadmap.md`, `docs/dev-plan.md`, and `CONTRIBUTING.md` to avoid misleading bundled/compatible wording.

## Validation

- `git diff --check` — pass
- `mvn -B -ntp -DskipTests validate` — **BUILD SUCCESS** (33 modules, 2026-05-26)

## Risk / rollback

- Risk: None (documentation only).
- Rollback: Revert PR.

## Notes

This PR does not complete Java 11/17/21 runtime migration. It only documents the current support policy and the intended migration path.

- No Java source changes.
- No Maven dependency or compiler baseline changes.
- No runtime bootstrap changes.

## Checklist

- [x] Branch was created from `develop`
- [x] Duplicate-prevention checks completed before branch creation (see `AGENTS.md`)
- [x] No open PR already covered the same scope before opening this PR
- [x] No unrelated source changes
- [x] `git diff --check` passed
- [x] `mvn -B -ntp -DskipTests validate` passed
- [x] PR keeps linear history
- [x] English used for branches, commits, comments, docs, and PR text
- [x] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`, risk register, decision log as needed) — N/A (policy doc only; no tracker status change)
- [x] No secrets, tokens, local paths, or build outputs committed
