### PR TITLE
fix(core): improve episode metadata source formatting

### DIFF
--- a/application/core/src/com/dabi/habitv/core/task/EpisodeMetadataFormatting.java
+++ b/application/core/src/com/dabi/habitv/core/task/EpisodeMetadataFormatting.java
@@ -6,10 +6,13 @@ import java.util.Locale;
 
 import com.dabi.habitv.api.plugin.dto.CategoryDTO;
 import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+import com.dabi.habitv.framework.plugin.utils.DownloadUtils;
 
 public final class EpisodeMetadataFormatting {
 
 	private static final String UNKNOWN = "Inconnu";
+	private static final int MAX_SHORT_URL_LENGTH = 48;
+	private static final String PROGRAM_URL_PARAM = "PROGRAM_URL";
 
 	private EpisodeMetadataFormatting() {
 	}
@@ -56,46 +59,74 @@ public final class EpisodeMetadataFormatting {
 				Double.valueOf(bytes / (1024.0 * 1024.0 * 1024.0)));
 	}
 
+	/**
+	 * Program (emission) page URL from the episode category, when the provider
+	 * stores an HTTP(S) identifier on the downloadable category node or in
+	 * {@link #PROGRAM_URL_PARAM}.
+	 */
+	public static String programPageUrl(final EpisodeDTO episode) {
+		if (episode == null || episode.getCategory() == null) {
+			return null;
+		}
+		final CategoryDTO category = episode.getCategory();
+		final String explicitUrl = trimToHttpUrl(category.getParameter(PROGRAM_URL_PARAM));
+		if (explicitUrl != null) {
+			return explicitUrl;
+		}
+		return trimToHttpUrl(category.getId());
+	}
+
+	public static String formatProgramLinkLabel(final EpisodeDTO episode) {
+		if (episode != null && episode.getCategory() != null
+				&& episode.getCategory().getName() != null) {
+			final String trimmedCategoryName = episode.getCategory().getName().trim();
+			if (!trimmedCategoryName.isEmpty()) {
+				return trimmedCategoryName;
+			}
+		}
+		final String url = programPageUrl(episode);
+		if (url == null) {
+			return UNKNOWN;
+		}
+		return shortenUrl(url);
+	}
+
 	public static String formatSource(final EpisodeDTO episode) {
+		final String programUrl = programPageUrl(episode);
+		if (programUrl != null) {
+			return programUrl;
+		}
 		if (episode == null || episode.getId() == null
 				|| episode.getId().trim().isEmpty()) {
 			return UNKNOWN;
 		}
-		return episode.getId();
+		return episode.getId().trim();
+	}
+
+	private static String shortenUrl(final String url) {
+		if (url.length() <= MAX_SHORT_URL_LENGTH) {
+			return url;
+		}
+		final int ellipsisLength = 3;
+		final int prefixLength = MAX_SHORT_URL_LENGTH - ellipsisLength;
+		return url.substring(0, prefixLength) + "...";
 	}
 
 	public static String formatStatusLabel(final String status) {
 		if (status == null || status.trim().isEmpty()) {
 			return UNKNOWN;
 		}
-		return status;
+		return status.trim();
 	}
 
-	public static String programPageUrl(final EpisodeDTO episode) {
-		if (episode == null) {
+	private static String trimToHttpUrl(final String value) {
+		if (value == null) {
 			return null;
 		}
-		final CategoryDTO category = episode.getCategory();
-		if (category == null) {
+		final String trimmed = value.trim();
+		if (trimmed.isEmpty() || !DownloadUtils.isHttpUrl(trimmed)) {
 			return null;
 		}
-		final String categoryId = category.getId();
-		if (categoryId != null && (categoryId.startsWith("http://")
-				|| categoryId.startsWith("https://"))) {
-			return categoryId;
-		}
-		return null;
-	}
-
-	public static String formatProgramLinkLabel(final EpisodeDTO episode) {
-		if (episode == null) {
-			return UNKNOWN;
-		}
-		final CategoryDTO category = episode.getCategory();
-		if (category == null || category.getName() == null
-				|| category.getName().trim().isEmpty()) {
-			return UNKNOWN;
-		}
-		return category.getName();
+		return trimmed;
 	}
 }

--- a/application/core/src/com/dabi/habitv/core/task/SearchCategoryTask.java
+++ b/application/core/src/com/dabi/habitv/core/task/SearchCategoryTask.java
@@ -4,6 +4,7 @@ import com.dabi.habitv.api.plugin.api.PluginProviderInterface;
 import com.dabi.habitv.api.plugin.pub.Publisher;
 import com.dabi.habitv.core.event.SearchCategoryEvent;
 import com.dabi.habitv.core.event.SearchCategoryStateEnum;
+import com.dabi.habitv.framework.plugin.utils.CategoryTreeNormalizer;
 
 public final class SearchCategoryTask extends
 		AbstractTask<SearchCategoryResult> {
@@ -53,9 +54,10 @@ public final class SearchCategoryTask extends
 	@Override
 	protected SearchCategoryResult doCall() {
 		try {
-			return new SearchCategoryResult(channel, provider.findCategory());
+			return new SearchCategoryResult(channel,
+					CategoryTreeNormalizer.normalize(channel, provider.findCategory()));
 		} catch (Exception e) {
-			LOG.error("", e);
+			LOG.error("Failed to build categories for channel " + channel, e);
 			return new SearchCategoryResult(channel);
 		}
 	}

--- a/application/core/test/com/dabi/habitv/core/task/EpisodeMetadataFormattingTest.java
+++ b/application/core/test/com/dabi/habitv/core/task/EpisodeMetadataFormattingTest.java
@@ -1,6 +1,7 @@
 package com.dabi.habitv.core.task;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -54,5 +55,148 @@ public class EpisodeMetadataFormattingTest {
 		final Calendar calendar = new GregorianCalendar(2024, Calendar.JANUARY, 15);
 		final Date date = calendar.getTime();
 		assertEquals("2024-01-15", EpisodeMetadataFormatting.formatDate(date));
+	}
+
+	@Test
+	public void programPageUrlNullEpisode() {
+		assertNull(EpisodeMetadataFormatting.programPageUrl(null));
+	}
+
+	@Test
+	public void programPageUrlUsesCategoryHttpId() {
+		final CategoryDTO program = new CategoryDTO("francetv", "Journal 20h",
+				"https://www.france.tv/france-2/journal-20-heures/", "mp4");
+		final EpisodeDTO episode = new EpisodeDTO(program, "ep1",
+				"https://www.france.tv/france-2/journal-20-heures/1-ep.html");
+		assertEquals("https://www.france.tv/france-2/journal-20-heures/",
+				EpisodeMetadataFormatting.programPageUrl(episode));
+		assertEquals("Journal 20h", EpisodeMetadataFormatting.formatProgramLinkLabel(episode));
+	}
+
+	@Test
+	public void programPageUrlTrimsCategoryHttpId() {
+		final CategoryDTO program = new CategoryDTO("francetv", "Journal 20h",
+				"  https://www.france.tv/france-2/journal-20-heures/  ", "mp4");
+		final EpisodeDTO episode = new EpisodeDTO(program, "ep1",
+				"https://www.france.tv/france-2/journal-20-heures/1-ep.html");
+		assertEquals("https://www.france.tv/france-2/journal-20-heures/",
+				EpisodeMetadataFormatting.programPageUrl(episode));
+	}
+
+	@Test
+	public void programPageUrlPrefersExplicitParameter() {
+		final CategoryDTO category = new CategoryDTO("plugin", "Cat", "slug-not-a-url", null);
+		category.addParameter("PROGRAM_URL", "https://example.com/program");
+		final EpisodeDTO episode = new EpisodeDTO(category, "ep", "http://video");
+		assertEquals("https://example.com/program",
+				EpisodeMetadataFormatting.programPageUrl(episode));
+	}
+
+	@Test
+	public void programPageUrlFallsBackToHttpIdentifier() {
+		final CategoryDTO category = new CategoryDTO("plugin", "Cat",
+				"https://www.france.tv/france-5/c-dans-l-air/", null);
+		final EpisodeDTO episode = new EpisodeDTO(category, "ep", "http://video");
+		assertEquals("https://www.france.tv/france-5/c-dans-l-air/",
+				EpisodeMetadataFormatting.programPageUrl(episode));
+	}
+
+	@Test
+	public void programPageUrlReturnsNullForNonUrlIdentifier() {
+		final CategoryDTO category = new CategoryDTO("plugin", "Cat", "internal-slug", null);
+		final EpisodeDTO episode = new EpisodeDTO(category, "ep", "http://video");
+		assertNull(EpisodeMetadataFormatting.programPageUrl(episode));
+	}
+
+	@Test
+	public void programPageUrlIgnoresNonHttpExplicitParameter() {
+		final CategoryDTO category = new CategoryDTO("plugin", "Cat",
+				"https://fallback.example/show", null);
+		category.addParameter("PROGRAM_URL", "javascript:alert(1)");
+		final EpisodeDTO episode = new EpisodeDTO(category, "ep", "http://video");
+		assertEquals("https://fallback.example/show",
+				EpisodeMetadataFormatting.programPageUrl(episode));
+	}
+
+	@Test
+	public void formatProgramLinkLabelUsesNameWithoutProgramUrl() {
+		final CategoryDTO program = new CategoryDTO("francetv", "Journal 20h", "journal-20h",
+				"mp4");
+		final EpisodeDTO episode = new EpisodeDTO(program, "ep1",
+				"https://www.france.tv/france-2/journal-20-heures/1-ep.html");
+		assertEquals("Journal 20h", EpisodeMetadataFormatting.formatProgramLinkLabel(episode));
+	}
+
+	@Test
+	public void formatProgramLinkLabelFallsBackToShortenedProgramUrlWhenNameMissing() {
+		final String longUrl = "https://example.com/abcdefghijklmnopqrstuvwxyz0123456789/extra";
+		final EpisodeDTO nullNameEpisode = new EpisodeDTO(
+				new CategoryDTO("plugin", null, longUrl, "mp4"), "ep1", "episode-id");
+		assertEquals("https://example.com/abcdefghijklmnopqrstuvwxy...",
+				EpisodeMetadataFormatting.formatProgramLinkLabel(nullNameEpisode));
+		final EpisodeDTO blankNameEpisode = new EpisodeDTO(
+				new CategoryDTO("plugin", "   ", longUrl, "mp4"), "ep2", "episode-id");
+		assertEquals("https://example.com/abcdefghijklmnopqrstuvwxy...",
+				EpisodeMetadataFormatting.formatProgramLinkLabel(blankNameEpisode));
+	}
+
+	@Test
+	public void formatSourcePrefersTrimmedProgramPageUrlForHttpAndHttpsCategoryIds() {
+		final EpisodeDTO httpEpisode = new EpisodeDTO(
+				new CategoryDTO("plugin", "program", "  http://example.com/program  ", "mp4"), "ep1",
+				"episode-id");
+		assertEquals("http://example.com/program", EpisodeMetadataFormatting.formatSource(httpEpisode));
+		final EpisodeDTO httpsEpisode = new EpisodeDTO(
+				new CategoryDTO("plugin", "program", "  https://example.com/program  ", "mp4"), "ep2",
+				"episode-id");
+		assertEquals("https://example.com/program",
+				EpisodeMetadataFormatting.formatSource(httpsEpisode));
+	}
+
+	@Test
+	public void formatStatusLabelTrimsWhitespace() {
+		assertEquals("DONE", EpisodeMetadataFormatting.formatStatusLabel("  DONE  "));
+	}
+
+	@Test
+	public void formatProgramLinkLabelReturnsUnknownWhenCategoryIsNullAndNoUrl() {
+		final EpisodeDTO nullCategoryEpisode = new EpisodeDTO(null, "ep1", "episode-id");
+		assertEquals("Inconnu", EpisodeMetadataFormatting.formatProgramLinkLabel(nullCategoryEpisode));
+	}
+
+	@Test
+	public void formatSourceReturnsEpisodeIdWhenCategoryIdIsNotHttpUrl() {
+		final EpisodeDTO episode = new EpisodeDTO(
+				new CategoryDTO("plugin", "program", "category-id", "mp4"), "ep1", "  episode-id  ");
+		assertEquals("episode-id", EpisodeMetadataFormatting.formatSource(episode));
+	}
+
+	@Test
+	public void formatSourceReturnsUnknownWhenEpisodeIdIsBlankAndNoProgramUrl() {
+		final EpisodeDTO episode = new EpisodeDTO(
+				new CategoryDTO("plugin", "program", "category-id", "mp4"), "ep1", "  ");
+		assertEquals("Inconnu", EpisodeMetadataFormatting.formatSource(episode));
+	}
+
+	@Test
+	public void shortenUrlDoesNotTruncateShortUrls() {
+		final String shortUrl = "https://example.com/short";
+		final EpisodeDTO episode = new EpisodeDTO(
+				new CategoryDTO("plugin", null, shortUrl, "mp4"), "ep1", "id");
+		assertEquals(shortUrl, EpisodeMetadataFormatting.formatProgramLinkLabel(episode));
+	}
+
+	@Test
+	public void shortenUrlTruncatesAtExactlyMaxLength() {
+		final String urlExactly48 = "https://example.com/xxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+		final EpisodeDTO episode48 = new EpisodeDTO(
+				new CategoryDTO("plugin", null, urlExactly48, "mp4"), "ep1", "id");
+		assertEquals(urlExactly48, EpisodeMetadataFormatting.formatProgramLinkLabel(episode48));
+
+		final String urlExactly49 = "https://example.com/xxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+		final EpisodeDTO episode49 = new EpisodeDTO(
+				new CategoryDTO("plugin", null, urlExactly49, "mp4"), "ep1", "id");
+		assertEquals("https://example.com/xxxxxxxxxxxxxxxxxxxxxxxxx...",
+				EpisodeMetadataFormatting.formatProgramLinkLabel(episode49));
 	}
 }

--- a/application/core/test/com/dabi/habitv/core/task/SearchCategoryTaskTest.java
+++ b/application/core/test/com/dabi/habitv/core/task/SearchCategoryTaskTest.java
@@ -137,6 +137,57 @@ public class SearchCategoryTaskTest {
 		assertTrue(done);
 	}
 
+	@Test
+	public void testSearchCategoryTaskNormalizesShallowTree() {
+		final PluginProviderDownloaderInterface provider = new PluginProviderDownloaderInterface() {
+
+			@Override
+			public String getName() {
+				return "provider";
+			}
+
+			@Override
+			public Set<EpisodeDTO> findEpisode(final CategoryDTO category) {
+				return null;
+			}
+
+			@Override
+			public Set<CategoryDTO> findCategory() {
+				final Set<CategoryDTO> roots = new LinkedHashSet<>();
+				roots.add(new CategoryDTO("provider", "Emission A", "emission-a", "mp4"));
+				return roots;
+			}
+
+			@Override
+			public ProcessHolder download(final DownloadParamDTO downloadParam,
+					final DownloaderPluginHolder downloaders) throws DownloadFailedException {
+				return ProcessHolder.EMPTY_PROCESS_HOLDER;
+			}
+
+			@Override
+			public DownloadableState canDownload(final String downloadInput) {
+				return DownloadableState.IMPOSSIBLE;
+			}
+		};
+
+		final SearchCategoryTask localTask = new SearchCategoryTask("provider", provider,
+				new Publisher<SearchCategoryEvent>());
+		final SearchCategoryResult result = localTask.call();
+		assertTrue(result.isSuccess());
+		assertEquals(1, result.getCategoryList().size());
+
+		final CategoryDTO channel = result.getCategoryList().iterator().next();
+		assertEquals("Principal", channel.getName());
+		assertEquals(1, channel.getSubCategories().size());
+
+		final CategoryDTO category = channel.getSubCategories().iterator().next();
+		assertEquals("Programmes", category.getName());
+		assertEquals(1, category.getSubCategories().size());
+
+		final CategoryDTO emission = category.getSubCategories().iterator().next();
+		assertEquals("Emission A", emission.getName());
+	}
+
 	public final void testSearchCategoryTaskFailed() {
 		init(true);
 		task.adding();


### PR DESCRIPTION
## Summary
- Improve episode source formatting fallbacks.
- Prefer safe program-page URLs over raw episode identifiers when available.
- Shorten long source URLs for display.
- Honor PROGRAM_URL category parameter for program page links (http/https only).
- Normalize provider category trees in SearchCategoryTask.
- Add focused regression coverage.

## Scope
- Core metadata formatting.
- Search category tree normalization.
- Offline regression tests.

## Out of scope
- Batch download behavior.
- JavaFX runtime launcher cleanup.
- Provider rewrites.
- Stop/cancel download handling.
- Persistent queue recovery.

## Validation
- git diff --check
- mvn -B -ntp -DskipTests validate
- mvn -B -ntp -pl application/core -am "-Dsurefire.failIfNoSpecifiedTests=false" test

## Supersedes
- Clean replacement for polluted PR #83.
- Replaces PR #108 because GitHub Actions did not queue the required `validate (zulu-8)` check on that PR/branch even after close/reopen and an empty retrigger commit.
