### PR TITLE
ci(dependabot): allow updates so PRs are actually opened

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # Major bumps are allowed (opened as individual PRs for review) except
+    # for artifacts whose major release crosses into the jakarta.* namespace.
+    # Those would violate the Java 8 / no-jakarta-migration hard rule
+    # (AGENTS.md section 2) and must not be proposed automatically.
     ignore:
-      - dependency-name: "*"
+      - dependency-name: "javax.xml.bind:jaxb-api"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.glassfish.jaxb:jaxb-runtime"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "javax.mail:mail"
         update-types:
           - "version-update:semver-major"
 
@@ -35,11 +45,11 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    # No ignore filter: every action is pinned to a floating major tag
+    # (for example actions/checkout@v6), so the only update Dependabot can
+    # ever offer is the next major. Ignoring majors here suppressed all
+    # action PRs, so majors are allowed and grouped into a single PR.
     groups:
       github-actions:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-26 | TBD | Relax Dependabot policy so it can actually open PRs: allow GitHub Actions major bumps (every action is pinned to a floating major tag, so majors were the only possible update and the blanket ignore suppressed all PRs) and allow Maven majors except for jakarta-crossing artifacts (`jaxb-api`, `jaxb-runtime`, `javax.mail:mail`) guarded by the Java 8 / no-jakarta hard rule |
 | 2026-05-21 | TBD | Define `plugin-versioning-policy` ADR in `docs/decision-log.md`, document the policy in `CONTRIBUTING.md`, extend `AGENTS.md` §4 / `.github/copilot-instructions.md` / `.github/pull_request_template.md`, and bump `youtube` (`4.1.1-SNAPSHOT`), `arte` (`4.1.1-SNAPSHOT`), `francetv` (`4.1.2-SNAPSHOT`) accordingly |
 | 2026-05-17 | `d68f795` | Align JDT compliance with Java 8 (PR [#32](https://github.com/Mika3578/habitv/pull/32)) |
 | 2026-05-17 | `a659383` | Standardize static repository workspace layout (PR [#34](https://github.com/Mika3578/habitv/pull/34)) |


### PR DESCRIPTION
## Related issue
_None._

## Scope
`dependabot-update-policy`

## Summary
Dependabot was never opening version-update PRs. The root cause is the
configuration, not a disabled Dependabot: both ecosystems ignored **all**
`version-update:semver-major` updates.

- **GitHub Actions**: every action is pinned to a floating major tag
  (e.g. `actions/checkout@v6`, `setup-java@v5`, `stale@v10`). On such a pin
  the only update Dependabot can ever offer is the next major. With majors
  ignored, the action ecosystem produced **zero** PRs by construction.
- **Maven**: the oldest dependencies (`guava 20.0`, `rome 1.0`,
  `commons-lang 2.6`, `javax.mail 1.4.7`, …) only have major upgrades
  available, all of which were ignored.

The dependency graph itself is enabled (the push reported 124 Dependabot
vulnerability alerts on `develop`), confirming Dependabot runs — only the
policy was suppressing PRs.

## Changes
- `.github/dependabot.yml`
  - GitHub Actions: remove the blanket major-version `ignore`; majors are
    now allowed and still grouped into a single PR.
  - Maven: allow majors (opened as individual PRs for review) **except**
    `javax.xml.bind:jaxb-api`, `org.glassfish.jaxb:jaxb-runtime`, and
    `javax.mail:mail`, whose major releases cross into the `jakarta.*`
    namespace and would violate the Java 8 / no-jakarta hard rule
    (`AGENTS.md` §2). Minor/patch grouping is unchanged.
- `CHANGELOG.md`: add a Build & infrastructure entry under `Unreleased`.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`
  → parses OK, ecosystems `['maven', 'github-actions']`.
- `mvn validate` not required: no Maven build file changed (config/docs only,
  per `AGENTS.md` §6).

## Risk / rollback
Low. Only the Dependabot policy changes — no source or build files. Newly
allowed major PRs remain human-reviewed and are not auto-merged. The
jakarta-crossing artifacts remain guarded against major bumps. Rollback by
reverting this commit restores the previous (PR-suppressing) behaviour.

## Notes
`open-pull-requests-limit` and the schedule are unchanged. Maven dependencies
that only have major upgrades available outside the guarded set will now start
receiving individual PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAAEA3k9GHap7bfyEr9NPf)_