### PR TITLE
chore: enforce agent branch naming

### DIFF
--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -39,6 +39,13 @@ They exist to keep modernization safe, incremental, and reviewable.
 - Follow `AGENTS.md` as the source of truth for PR target policy,
   branch naming, duplicate branch/PR prevention, commit style, PR
   structure, validation, and linear history.
+- Never create branches with tool prefixes (`claude/`, `anthropic/`,
+  `ai/`, `assistant/`, `cursor/`, `codex/`, `temp/`, `wip/`) or
+  generated, poetic, random, or session-based names.
+- Use only `feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`,
+  or `ci/` plus a short lowercase kebab-case scope.
+- Propose the branch name before `git checkout -b`; if already on an
+  invalid branch, rename and fix the remote before opening a PR.
 - Use small PRs scoped to a single descriptive scope (see `docs/dev-tracker.md`).
 - Use English for branches, commits, comments, docs, and PR text.
 

--- a/.cursor/rules/pr-style.mdc
+++ b/.cursor/rules/pr-style.mdc
@@ -13,6 +13,11 @@ Follow `AGENTS.md` as the source of truth for PR target policy, branch
 naming, duplicate branch/PR prevention, commit style, PR structure,
 validation, and linear history.
 
+Branch names for agent-created PRs must use allowed Habitv prefixes only
+(`feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, `ci/`).
+Never open a PR from `claude/**`, `cursor/**`, or other forbidden
+prefixes — rename per `AGENTS.md` §4 first.
+
 ## Pull requests
 
 - Use English for PR titles, bodies, review comments, and merge metadata.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,6 +40,7 @@
 ## Checklist
 
 - [ ] Branch was created from `develop`
+- [ ] Branch name uses an allowed prefix (`feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, `ci/`) — not `claude/**`, `cursor/**`, `ai/**`, `wip/**`, or other tool/session names (see `AGENTS.md` §4)
 - [ ] Duplicate-prevention checks completed before branch creation (see `AGENTS.md`)
 - [ ] No open PR already covered the same scope before opening this PR
 - [ ] No unrelated source changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ French TV catch-up content via pluggable provider plugins.
 | Add OWASP / SBOM / static-analysis plugins | Out of restart phase |
 | Commit secrets, tokens, local paths, IDE files | 🚨 never, period |
 | Write non-English content (branches, code, docs) | English-only policy |
+| Create branches with `claude/**`, `cursor/**`, `ai/**`, or random names | Violates §4; rename before any PR |
 
 ---
 
@@ -88,31 +89,69 @@ Conventional Commits, English, imperative, lowercase, ≤ 72 chars.
 
 ## 🌿 4. Branch naming and duplicate prevention
 
-Allowed work branch prefixes (only):
-- `fix/`
+### Allowed prefixes (only)
+
+AI agents and human contributors must use **one** of these prefixes:
+
 - `feat/`
-- `chore/`
+- `fix/`
 - `docs/`
+- `chore/`
 - `test/`
-- `ci/`
 - `refactor/`
+- `ci/`
+
+Branch format: `<prefix>/<short-scope>` — lowercase, kebab-case, short and
+descriptive. No camelCase, no spaces, no bare names without a prefix.
+
+✅ Valid examples:
+
+- `feat/ytdlp-runtime-diagnostics`
+- `fix/canalplus-endpoint-warning`
+- `docs/javafx-runtime-baseline`
+- `chore/rules-branch-naming`
+- `ci/maven-validation-matrix`
+
+❌ Invalid examples:
+
+- `claude/youthful-albattani-rH19M` — tool-generated prefix
+- `claude/fix-thing`, `anthropic/session-123`, `cursor/quick-fix`
+- `ai/generated-patch`, `wip/test` — forbidden prefixes (see below)
+- `feature/some-change` — use `feat/` instead
+- `fixStuff`, `my-branch` — wrong shape (no prefix or not kebab-case)
+
+### Forbidden prefixes for AI agents
+
+AI agents (Claude Code, Cursor, Codex, Copilot, or any assistant) must
+**never** create, push, or open PRs from branches with these prefixes:
+
+- `claude/`
+- `anthropic/`
+- `ai/`
+- `assistant/`
+- `cursor/`
+- `codex/`
+- `temp/`
+- `wip/`
+
+AI agents must **never** use generated, poetic, random, or session-based
+branch names (for example auto-suffixed hashes, adjective-noun pairs, or
+IDE session IDs).
 
 Deprecated prefixes (do not create new branches with these):
+
 - `feature/` → `feat/`
 - `build/` → `ci/` for CI/build automation, or `chore/` for maintenance
 - `runtime/` → `fix/`, `feat/`, or `refactor/` depending on scope
 - `provider/` → `fix/provider-...`, `feat/provider-...`,
   `refactor/provider-...`, `docs/provider-...`, or `test/provider-...`
 
-Branch format:
-`<type>/<short-scope>`
+Additional examples (allowed prefix + scope):
 
-Examples:
 - `fix/provider-youtube-ytdlp`
 - `feat/provider-francetv-metadata`
 - `docs/provider-inventory-update`
 - `test/provider-offline-fixtures`
-- `ci/maven-pr-validation`
 - `refactor/provider-canalplus-cleanup`
 
 HBTV-style tracker IDs are deprecated.
@@ -134,17 +173,39 @@ Examples:
 - `test(providers): add offline fixtures`
 - `ci(maven): harden PR validation`
 
-Before creating any branch, run:
+### Before creating a branch
+
+1. Inspect the current branch (`git branch --show-current`). If it is
+   invalid (forbidden prefix or wrong shape), recover first (see below).
+2. Propose the final branch name and confirm it matches an allowed
+   prefix and kebab-case scope.
+3. Run duplicate-prevention checks, then create the branch:
+
 ```bash
 git fetch --all --prune
 git branch -a --list "*<short-scope>*"
 gh pr list --repo Mika3578/habitv --state open --search "<short-scope>"
 git check-ref-format --branch "<branch-name>"
+git checkout -b "<prefix>/<short-scope>"
 ```
 
 If an existing branch or open PR already covers the same scope, do not
 create a duplicate. Reuse the existing branch/PR, or create a clearly
 scoped follow-up branch.
+
+### Recover from an invalid branch
+
+If the agent is already on an invalid branch (for example `claude/**`):
+
+1. Do **not** open a PR from it.
+2. Rename locally, push the corrected name, delete the invalid remote
+   branch if it was pushed, then continue only from the corrected branch:
+
+```bash
+git branch -m chore/enforce-agent-branch-naming
+git push -u origin chore/enforce-agent-branch-naming
+git push origin --delete <invalid-branch-name>
+```
 
 Keep history linear on work branches (no merge commits).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,17 @@ If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
 
 Use English for code comments, commit messages, PR text, and
 documentation.
+
+## Branch naming (Claude Code)
+
+Never let Claude Code pick a branch name. Forbidden prefixes and
+recovery steps are in `AGENTS.md` §4.
+
+When using Claude Code worktrees, always pass an explicit branch name:
+
+```bash
+claude --worktree feat/descriptive-scope
+```
+
+Never run `claude --worktree` without a branch argument — that produces
+random `claude/**` names that violate repository policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,13 @@ Before creating a new branch, follow the duplicate-prevention checks
 defined in `AGENTS.md` (`git fetch --all --prune`, matching branch/PR
 search, and `git check-ref-format --branch`).
 
+**AI agents** must not use tool-specific or session-generated branch
+names (`claude/**`, `anthropic/**`, `ai/**`, `cursor/**`, `codex/**`,
+`wip/**`, and similar). Use only `feat/`, `fix/`, `docs/`, `chore/`,
+`test/`, `refactor/`, or `ci/` plus a short kebab-case scope — see
+`AGENTS.md` §4 for valid/invalid examples and recovery when already on
+an invalid branch.
+
 For AI-agent workflow, PR target policy is defined in `AGENTS.md`:
 agent-created PRs target `Mika3578/habitv` (not `ikfon10/habitv`).
 


### PR DESCRIPTION
## Summary

- Forbid AI-generated branch prefixes such as `claude/**`, `anthropic/**`, `ai/**`, `cursor/**`, and `codex/**`.
- Require standard Habitv branch prefixes such as `feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, and `ci/`.
- Add guidance for Claude Code worktrees to always pass an explicit branch name.
- Document how to recover when an invalid branch already exists.

## Scope

- agent-branch-naming

## Related issue

- N/A

## Changes

- Expand `AGENTS.md` §4 with forbidden prefixes, valid/invalid examples, pre-create checklist, and invalid-branch recovery.
- Add hard-rule row in `AGENTS.md` §2.
- Add Claude Code worktree note in `CLAUDE.md`.
- Cross-reference in `CONTRIBUTING.md`, `.cursor/rules/habitv-master.mdc`, `.cursor/rules/pr-style.mdc`, and PR template checklist.

## Validation

- `git diff --check` (pass)
- Manual Markdown review only; no Java code changed.

## Risk / rollback

- Risk: Low. Documentation/rules-only change. This only affects AI agent workflow and branch hygiene.
- Rollback: Revert this documentation commit if the branch naming rule is too restrictive.

## Notes

- No Maven validation (docs-only).

## Checklist

- [x] Branch was created from `develop`
- [x] Branch name uses an allowed prefix
- [x] Duplicate-prevention checks completed before branch creation
- [x] No unrelated source changes
- [x] `git diff --check` passed
- [x] `mvn -B -ntp -DskipTests validate` N/A (docs-only, no build file changes)
- [x] PR keeps linear history
- [x] English used for branches, commits, comments, docs, and PR text
- [ ] Documentation tracker sync N/A (workflow policy only)
