### PR TITLE
chore: clean up agent rules

### DIFF
--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -5,61 +5,32 @@ alwaysApply: true
 
 # Habitv master modernization rules
 
-These rules apply to all AI-assisted work on the Habitv repository.
-They exist to keep modernization safe, incremental, and reviewable.
+`AGENTS.md` is the **canonical** enforcement document for repository
+and AI-agent policy. This file adds Cursor-specific reminders only.
 
-## Java baseline
+## Before acting
 
-- Always keep Java 8 compatibility unless an explicit tracked migration
-  item says otherwise and is referenced in the PR.
-- Do not introduce Java 9+ language features or JDK 11/17/21-only APIs.
-- Any Java baseline migration must happen in a dedicated migration PR
-  with an ADR in `docs/decision-log.md`.
+1. Read `AGENTS.md` (hard rules, governance L0/L1/L2, branch naming,
+   PR policy, validation, doc sync at PR readiness).
+2. Use **audit mode** for read-only questions; use **delivery mode**
+   when implementing or opening a PR.
 
-## Architecture and scope
+## Cursor-specific
 
-- Do not rewrite architecture without a tracker item AND an ADR.
-- Do not perform opportunistic refactors or formatting changes.
-- Do not remove legacy code unless there is a dedicated deprecation PR
-  with a tracker item and migration notes.
-- Never mix unrelated fixes in the same branch.
+- **Branch names** — never let the IDE pick a name. Use only allowed
+  prefixes (`feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`,
+  `ci/`). Forbidden: `claude/`, `anthropic/`, `ai/`, `assistant/`,
+  `cursor/`, `codex/`, `temp/`, `wip/`, `feature/`, and generated or
+  session-based names. Rename invalid branches before commit, push, or
+  PR (`AGENTS.md` branch naming).
+- **PR target** — agent PRs go to `Mika3578/habitv` only, never
+  `ikfon10/habitv`.
+- **Default validation** — `mvn -B -ntp -DskipTests validate` for code
+  changes; `git diff --check` for docs-only.
+- **Hooks** — never use `--no-verify`.
 
-## Build and tests
+## Do not duplicate
 
-- Prefer deterministic Maven commands. Default validation:
-  `mvn -B -ntp -DskipTests validate`.
-- Do not run live provider/network tests in the default lifecycle.
-  Network or provider live tests must be opt-in via an explicit
-  profile or tracker item.
-- Do not change Maven module topology, plugin versions, or dependency
-  versions outside a scoped tracker item.
-
-## Branching and PRs
-
-- Follow `AGENTS.md` as the source of truth for PR target policy,
-  branch naming, duplicate branch/PR prevention, commit style, PR
-  structure, validation, and linear history.
-- Never create branches with tool prefixes (`claude/`, `anthropic/`,
-  `ai/`, `assistant/`, `cursor/`, `codex/`, `temp/`, `wip/`) or
-  generated, poetic, random, or session-based names.
-- Use only `feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`,
-  or `ci/` plus a short lowercase kebab-case scope.
-- Propose the branch name before `git checkout -b`; if already on an
-  invalid branch, rename and fix the remote before opening a PR.
-- Use small PRs scoped to a single descriptive scope (see `docs/dev-tracker.md`).
-- Use English for branches, commits, comments, docs, and PR text.
-
-## Documentation discipline
-
-- Update `docs/dev-tracker.md` AND `docs/dev-tracker.json` for every
-  meaningful change so machine and human views stay aligned.
-- Update `docs/risk-register.md` when a risk is added, mitigated, or
-  realized.
-- Record cross-cutting decisions in `docs/decision-log.md` (ADR format).
-
-## Forbidden in this restart phase
-
-- No provider rewrites, no JavaFX migration, no JAXB regeneration,
-  no Maven deploy or distribution changes, and no runtime updater
-  changes unless an explicit dedicated tracker item covers them.
-- Never commit secrets, tokens, local absolute paths, or build outputs.
+Java baseline, JavaFX/JAXB, security, Maven topology, provider rewrites,
+and tracker/ADR requirements are defined once in `AGENTS.md` Section 2
+and Governance levels. Do not restate them here.

--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -39,6 +39,13 @@ They exist to keep modernization safe, incremental, and reviewable.
 - Follow `AGENTS.md` as the source of truth for PR target policy,
   branch naming, duplicate branch/PR prevention, commit style, PR
   structure, validation, and linear history.
+- Never create branches with tool prefixes (`claude/`, `anthropic/`,
+  `ai/`, `assistant/`, `cursor/`, `codex/`, `temp/`, `wip/`) or
+  generated, poetic, random, or session-based names.
+- Use only `feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`,
+  or `ci/` plus a short lowercase kebab-case scope.
+- Propose the branch name before `git checkout -b`; if already on an
+  invalid branch, rename and fix the remote before opening a PR.
 - Use small PRs scoped to a single descriptive scope (see `docs/dev-tracker.md`).
 - Use English for branches, commits, comments, docs, and PR text.
 

--- a/.cursor/rules/pr-style.mdc
+++ b/.cursor/rules/pr-style.mdc
@@ -13,6 +13,11 @@ Follow `AGENTS.md` as the source of truth for PR target policy, branch
 naming, duplicate branch/PR prevention, commit style, PR structure,
 validation, and linear history.
 
+Branch names for agent-created PRs must use allowed Habitv prefixes only
+(`feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, `ci/`).
+Never open a PR from `claude/**`, `cursor/**`, or other forbidden
+prefixes — rename per `AGENTS.md` §4 first.
+
 ## Pull requests
 
 - Use English for PR titles, bodies, review comments, and merge metadata.

--- a/.cursor/rules/pr-style.mdc
+++ b/.cursor/rules/pr-style.mdc
@@ -9,58 +9,23 @@ globs:
 
 # Habitv PR and squash merge style
 
-Follow `AGENTS.md` as the source of truth for PR target policy, branch
-naming, duplicate branch/PR prevention, commit style, PR structure,
-validation, and linear history.
-
-Branch names for agent-created PRs must use allowed Habitv prefixes only
-(`feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, `ci/`).
-Never open a PR from `claude/**`, `cursor/**`, or other forbidden
-prefixes — rename per `AGENTS.md` §4 first.
+Follow `AGENTS.md` for PR target policy, branch naming, governance
+levels, validation, doc sync at PR readiness, boy-scout limits, and
+justified N/A in PR sections.
 
 ## Pull requests
 
-- Use English for PR titles, bodies, review comments, and merge metadata.
-- Keep PRs scoped to one descriptive scope item when applicable.
-- Document validation commands actually run; default safe command is
-  `mvn -B -ntp -DskipTests validate`.
-- Fill every required (non-optional) section of
-  `.github/pull_request_template.md` honestly.
+- English for titles, bodies, and review comments.
+- Fill `.github/pull_request_template.md` honestly; justified N/A is OK.
+- Document commands actually run.
 
 ## Squash merge instructions
 
-When generating merge instructions, always include a clean squash merge title
-and body.
+When generating merge instructions, provide a clean squash title and body.
 
-- Never recommend keeping GitHub's default generated squash description when it
-  contains intermediate commit bullets or repeated `Co-authored-by` trailers.
-- Always provide a cleaned replacement body for the GitHub **Extended
-  description** field.
-- The squash title must use Conventional Commit style and must include the PR
-  number when merging through GitHub.
-- The squash body must describe the final result, validation, and important
-  scope notes only.
+- Do not keep GitHub's default squash description when it lists
+  intermediate commits or repeated `Co-authored-by` trailers.
+- Squash title: Conventional Commits + PR number when merging on GitHub.
+- Squash body: final outcome, validation, and scope notes only.
 
-### Example for PR #65
-
-**Squash title:**
-
-```text
-ci: add Maven PR validation workflow (#65)
-```
-
-**Squash body:**
-
-```text
-Establish Java 8 Maven validation as the pull request CI baseline.
-
-Includes:
-- Required Java 8 validation, deterministic test, and package jobs.
-- Non-blocking diagnostic jobs for newer Java versions.
-- CI documentation for required checks and local command parity.
-```
-
-## References
-
-- `docs/pull-request-style-guide.md`
-- `docs/repository-maintenance.md`
+See `docs/pull-request-style-guide.md` and `docs/repository-maintenance.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ Follow `AGENTS.md` as the source of truth for:
 - PR structure
 - validation commands
 - linear Git history
-- documentation sync requirements
+- documentation sync at PR readiness (L0/L1/L2 governance levels)
 
 ## Compatibility constraints
 
@@ -59,13 +59,15 @@ yet stabilized (see `docs/audit-master-baseline.md`).
 ## Things to avoid suggesting
 
 - Replacing `javax.xml.bind` with `jakarta.xml.bind`.
-- Replacing `youtube-dl` with `yt-dlp` (tracked under `ytdlp-migration`).
+- Changing download behavior or default downloader selection without
+  `ytdlp-migration` or a dedicated PR scope.
 - Upgrading or replacing JavaFX dependencies (tracked under
   `javafx-modernization`).
 - Adding network-dependent tests to the default lifecycle.
-- Adding OWASP, SBOM, or static-analysis plugins in this phase.
-- Reformatting files, renaming variables outside a change, or moving
-  packages.
+- Adding blocking security, SBOM, or static-analysis gates without a
+  tracker item and CI policy decision.
+- Reformatting files or drive-by refactors beyond the boy-scout limits
+  in `AGENTS.md`.
 - Bumping a `plugins/*/pom.xml` `<version>` for changes that do not
   match a `plugin-versioning-policy` trigger (downloader/parser
   behaviour, user-facing endpoint, user-facing configuration). See
@@ -80,6 +82,5 @@ yet stabilized (see `docs/audit-master-baseline.md`).
 - English-only comments and identifiers in new code.
 - Explicit error handling at meaningful boundaries (no swallow,
   no broad catch).
-- Updating `docs/dev-tracker.md`, `docs/dev-tracker.json`,
-  `docs/risk-register.md`, and `docs/decision-log.md` when the
-  change is meaningful.
+- Updating tracker, risk register, and decision log at PR readiness
+  when the change is meaningful (per `AGENTS.md` Section 12).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,6 +40,7 @@
 ## Checklist
 
 - [ ] Branch was created from `develop`
+- [ ] Branch name uses an allowed prefix (`feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, `ci/`) — not `claude/**`, `cursor/**`, `ai/**`, `wip/**`, or other tool/session names (see `AGENTS.md` §4)
 - [ ] Duplicate-prevention checks completed before branch creation (see `AGENTS.md`)
 - [ ] No open PR already covered the same scope before opening this PR
 - [ ] No unrelated source changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 
 ## Related issue
 
-<!-- Optional: include a real GitHub issue number, e.g. #123. -->
+<!-- Optional: #123, or N/A with brief reason. -->
 - N/A
 
 ## Changes
@@ -21,35 +21,34 @@
 
 ## Validation
 
-<!-- Commands actually run locally and their honest outcome. -->
-- `git status --short`
-- `git diff --check`
-- `mvn -B -ntp -DskipTests validate` (required for code changes; optional for docs-only unless build files changed)
+<!-- Commands actually run, or justified N/A. Example for docs-only:
+N/A — docs-only change; reviewed Markdown diff and ran git diff --check. -->
+-
 
 ## Risk / rollback
 
-<!-- Reference docs/risk-register.md IDs impacted/introduced and describe rollback. -->
-- Risk:
-- Rollback:
+<!-- Honest risk level and rollback steps. Example for docs-only:
+Low — rules/documentation-only change. Rollback: revert this commit. -->
+-
 
 ## Notes
 
-<!-- Bullet list of intentional non-changes to avoid scope creep. -->
+<!-- Intentional non-changes, or N/A. -->
 -
 
 ## Checklist
 
 - [ ] Branch was created from `develop`
-- [ ] Branch name uses an allowed prefix (`feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, `ci/`) — not `claude/**`, `cursor/**`, `ai/**`, `wip/**`, or other tool/session names (see `AGENTS.md` §4)
-- [ ] Duplicate-prevention checks completed before branch creation (see `AGENTS.md`)
+- [ ] Branch name uses an allowed prefix (`feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, `ci/`) — not `claude/**`, `cursor/**`, `ai/**`, `codex/**`, `wip/**`, `feature/**`, or other tool/session names (`AGENTS.md` branch naming)
+- [ ] Duplicate-prevention checks run before **new PR branch** creation (optional for local WIP / existing branch — `AGENTS.md`)
 - [ ] No open PR already covered the same scope before opening this PR
-- [ ] No unrelated source changes
+- [ ] Scope matches governance level (L0/L1/L2 in `AGENTS.md`)
 - [ ] `git diff --check` passed
-- [ ] `mvn -B -ntp -DskipTests validate` passed (or was N/A for docs-only PRs with no build file changes)
+- [ ] `mvn -B -ntp -DskipTests validate` passed, or justified N/A in Validation
 - [ ] PR keeps linear history
 - [ ] English used for branches, commits, comments, docs, and PR text
-- [ ] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`, risk register, decision log as needed)
-- [ ] If a `plugins/*/pom.xml` `<version>` is bumped, the trigger from `plugin-versioning-policy` is named in Summary/Changes (downloader/parser, user-facing endpoint, or user-facing configuration), and internal deps use `${project.parent.version}`
+- [ ] Documentation updated at PR readiness when required (tracker, risk, ADR per L1/L2)
+- [ ] If a `plugins/*/pom.xml` `<version>` is bumped, the `plugin-versioning-policy` trigger is named and internal deps use `${project.parent.version}`
 - [ ] No secrets, tokens, local paths, or build outputs committed
 
 ## Suggested squash merge commit (optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ French TV catch-up content via pluggable provider plugins.
 | Add OWASP / SBOM / static-analysis plugins | Out of restart phase |
 | Commit secrets, tokens, local paths, IDE files | 🚨 never, period |
 | Write non-English content (branches, code, docs) | English-only policy |
+| Create branches with `claude/**`, `cursor/**`, `ai/**`, or random names | Violates §4; rename before any PR |
 
 ---
 
@@ -88,31 +89,69 @@ Conventional Commits, English, imperative, lowercase, ≤ 72 chars.
 
 ## 🌿 4. Branch naming and duplicate prevention
 
-Allowed work branch prefixes (only):
-- `fix/`
+### Allowed prefixes (only)
+
+AI agents and human contributors must use **one** of these prefixes:
+
 - `feat/`
-- `chore/`
+- `fix/`
 - `docs/`
+- `chore/`
 - `test/`
-- `ci/`
 - `refactor/`
+- `ci/`
+
+Branch format: `<prefix>/<short-scope>` — lowercase, kebab-case, short and
+descriptive. No camelCase, no spaces, no bare names without a prefix.
+
+✅ Valid examples:
+
+- `feat/ytdlp-runtime-diagnostics`
+- `fix/canalplus-endpoint-warning`
+- `docs/javafx-runtime-baseline`
+- `chore/rules-branch-naming`
+- `ci/maven-validation-matrix`
+
+❌ Invalid examples:
+
+- `claude/youthful-albattani-rH19M` — tool-generated prefix
+- `claude/fix-thing`, `anthropic/session-123`, `cursor/quick-fix`
+- `ai/generated-patch`, `wip/test` — forbidden prefixes (see below)
+- `feature/some-change` — use `feat/` instead
+- `fixStuff`, `my-branch` — wrong shape (no prefix or not kebab-case)
+
+### Forbidden prefixes for AI agents
+
+AI agents (Claude Code, Cursor, Codex, Copilot, or any assistant) must
+**never** create, push, or open PRs from branches with these prefixes:
+
+- `claude/`
+- `anthropic/`
+- `ai/`
+- `assistant/`
+- `cursor/`
+- `codex/`
+- `temp/`
+- `wip/`
+
+AI agents must **never** use generated, poetic, random, or session-based
+branch names (for example auto-suffixed hashes, adjective-noun pairs, or
+IDE session IDs).
 
 Deprecated prefixes (do not create new branches with these):
+
 - `feature/` → `feat/`
 - `build/` → `ci/` for CI/build automation, or `chore/` for maintenance
 - `runtime/` → `fix/`, `feat/`, or `refactor/` depending on scope
 - `provider/` → `fix/provider-...`, `feat/provider-...`,
   `refactor/provider-...`, `docs/provider-...`, or `test/provider-...`
 
-Branch format:
-`<type>/<short-scope>`
+Additional examples (allowed prefix + scope):
 
-Examples:
 - `fix/provider-youtube-ytdlp`
 - `feat/provider-francetv-metadata`
 - `docs/provider-inventory-update`
 - `test/provider-offline-fixtures`
-- `ci/maven-pr-validation`
 - `refactor/provider-canalplus-cleanup`
 
 HBTV-style tracker IDs are deprecated.
@@ -134,17 +173,39 @@ Examples:
 - `test(providers): add offline fixtures`
 - `ci(maven): harden PR validation`
 
-Before creating any branch, run:
+### Before creating a branch
+
+1. Inspect the current branch (`git branch --show-current`). If it is
+   invalid (forbidden prefix or wrong shape), recover first (see below).
+2. Propose the final branch name and confirm it matches an allowed
+   prefix and kebab-case scope.
+3. Run duplicate-prevention checks, then create the branch:
+
 ```bash
 git fetch --all --prune
 git branch -a --list "*<short-scope>*"
 gh pr list --repo Mika3578/habitv --state open --search "<short-scope>"
 git check-ref-format --branch "<branch-name>"
+git checkout -b "<prefix>/<short-scope>"
 ```
 
 If an existing branch or open PR already covers the same scope, do not
 create a duplicate. Reuse the existing branch/PR, or create a clearly
 scoped follow-up branch.
+
+### Recover from an invalid branch
+
+If the agent is already on an invalid branch (for example `claude/**`):
+
+1. Do **not** open a PR from it.
+2. Rename locally, push the corrected name, delete the invalid remote
+   branch if it was pushed, then continue only from the corrected branch:
+
+```bash
+git branch -m chore/enforce-agent-branch-naming
+git push -u origin chore/enforce-agent-branch-naming
+git push origin --delete <invalid-branch-name>
+```
 
 Keep history linear on work branches (no merge commits).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,14 +59,41 @@ French TV catch-up content via pluggable provider plugins.
 | Bump Java baseline beyond **Java 8** | JavaFX 2.x and `javax.xml.bind` 2.0 assume JDK 8 |
 | Migrate JavaFX (`jfxrt`) to OpenJFX | Tracked under `javafx-modernization` |
 | Regenerate JAXB classes or move to `jakarta.*` | Risk `jaxb-mismatch` |
-| Replace `youtube-dl` plugin behavior with `yt-dlp` | Tracked under `ytdlp-migration` |
+| Change download behavior or default downloader selection | Unless covered by `ytdlp-migration` or a dedicated PR scope; wiring-only, behavior-preserving prep allowed when tracked |
 | Change runtime updater URLs or layout | Tracked under `static-repo-publish` |
-| Migrate FTP/HTTP repositories | Tracked under `legacy-url-migration` |
+| Reintroduce obsolete HTTP/FTP hosts as runtime or build dependencies | Tracked under `legacy-url-migration`; docs may mention historical hosts as archived context only |
 | Remove or rename provider/plugin modules | Tracked under `provider-inventory` |
-| Add OWASP / SBOM / static-analysis plugins | Out of restart phase |
+| Add blocking security / SBOM / static-analysis gates | Requires dedicated tracker item and CI policy ADR; non-blocking exploratory jobs may be proposed in a dedicated CI PR |
 | Commit secrets, tokens, local paths, IDE files | 🚨 never, period |
 | Write non-English content (branches, code, docs) | English-only policy |
-| Create branches with `claude/**`, `cursor/**`, `ai/**`, or random names | Violates §4; rename before any PR |
+| Create branches with `claude/**`, `cursor/**`, `ai/**`, `codex/**`, or random names | See branch naming; rename before commit, push, or PR |
+
+---
+
+## 📊 Governance levels (L0 / L1 / L2)
+
+Use this matrix to decide tracker and ADR requirements. Hard rules in
+Section 2 always apply regardless of level.
+
+| Level | Tracker | ADR | Examples |
+|:-----:|:-------:|:---:|----------|
+| **L0** | No | No | Typo fixes; comment-only fixes; small documentation cleanup; Markdown formatting that does not change scope or acceptance criteria; PR/template wording that does not weaken rules |
+| **L1** | Yes | No | Scoped bug fix; offline test add/update; minor CI tied to an existing item; small docs that advance an existing tracker item; behavior-preserving cleanup required for a fix |
+| **L2** | Yes | Yes | Java baseline change; JavaFX/OpenJFX strategy; JAXB/Jakarta strategy; Maven reactor structure; plugin update policy; external repo or artifact publishing policy; removal of legacy compatibility; broad refactor; runtime architecture change |
+
+L0 work still follows commit, branch, PR, validation, and English
+conventions. L1/L2 work must name the tracker slug in the PR body.
+
+---
+
+## 🔀 Agent operating modes
+
+| Mode | When | Expectations |
+|------|------|----------------|
+| **Audit / discussion** | User asks for review, explanation, or exploration only | Read and analyze freely; no code changes unless explicitly requested; no approval required to inspect files |
+| **Delivery** | User requests implementation, fixes, or a PR | Keep scope small; run appropriate validation; provide commit message, PR summary, validation, risk, and rollback notes |
+
+Default to audit mode when the request is ambiguous.
 
 ---
 
@@ -133,6 +160,7 @@ AI agents (Claude Code, Cursor, Codex, Copilot, or any assistant) must
 - `codex/`
 - `temp/`
 - `wip/`
+- `feature/` (use `feat/` instead)
 
 AI agents must **never** use generated, poetic, random, or session-based
 branch names (for example auto-suffixed hashes, adjective-noun pairs, or
@@ -179,14 +207,21 @@ Examples:
    invalid (forbidden prefix or wrong shape), recover first (see below).
 2. Propose the final branch name and confirm it matches an allowed
    prefix and kebab-case scope.
-3. Run duplicate-prevention checks, then create the branch:
+3. Create the branch when the name is valid:
+
+```bash
+git check-ref-format --branch "<branch-name>"
+git checkout -b "<prefix>/<short-scope>"
+```
+
+**Duplicate branch and open PR checks** — required before creating a
+**new PR branch**; optional for local WIP or when continuing an existing
+branch:
 
 ```bash
 git fetch --all --prune
 git branch -a --list "*<short-scope>*"
 gh pr list --repo Mika3578/habitv --state open --search "<short-scope>"
-git check-ref-format --branch "<branch-name>"
-git checkout -b "<prefix>/<short-scope>"
 ```
 
 If an existing branch or open PR already covers the same scope, do not
@@ -202,8 +237,9 @@ If the agent is already on an invalid branch (for example `claude/**`):
    branch if it was pushed, then continue only from the corrected branch:
 
 ```bash
-git branch -m chore/enforce-agent-branch-naming
-git push -u origin chore/enforce-agent-branch-naming
+git branch --show-current
+git branch -m chore/clean-agent-rules
+git push -u origin chore/clean-agent-rules
 git push origin --delete <invalid-branch-name>
 ```
 
@@ -217,9 +253,9 @@ Keep history linear on work branches (no merge commits).
 |------|--------|
 | Related issue / scope | Optionally reference a real GitHub issue (e.g. `#123`) and include a clear descriptive scope |
 | Template | Fill every section of `.github/pull_request_template.md` |
-| Diff size | Keep small and focused; reject opportunistic refactors |
+| Diff size | Keep small and focused; see limited boy-scout cleanup below |
 | History | Linear inside work branches; no merge commits |
-| Doc sync | Update tracker, risk register, decision log on meaningful changes |
+| Doc sync | At PR readiness or before merge — see Section 12 |
 | Plugin version bump | A `plugins/*/pom.xml` `<version>` override must match a `plugin-versioning-policy` trigger (downloader/parser, user-facing endpoint, user-facing configuration). Name the trigger in the PR body. Internal reactor deps in a bumped plugin MUST use `${project.parent.version}`. |
 
 AI-agent PR target policy:
@@ -285,6 +321,28 @@ If tracking is needed, use GitHub-native tracking:
 
 Do not invent local tracker IDs.
 
+### Limited boy-scout cleanup
+
+A PR may include limited neighboring cleanup only when required to
+compile, test, or make the scoped fix coherent:
+
+- at most **one** neighboring file, **or**
+- at most **10 lines** outside the main scope.
+
+Anything larger must be split into a separate PR.
+
+### PR body sections and justified N/A
+
+Required sections (`Related issue`, `Scope`, `Summary`, `Changes`,
+`Validation`, `Risk / rollback`, `Notes`) must be honest. Use
+justified **N/A** when a section does not apply — avoid ritual filler.
+
+Examples:
+
+- **Validation:** `N/A — docs-only change; reviewed Markdown diff and ran git diff --check.`
+- **Risk:** `Low — rules/documentation-only change.`
+- **Rollback:** `Revert this documentation commit.`
+
 ---
 
 ## 🧪 6. Validation policy
@@ -326,7 +384,8 @@ command + output** in the PR body.
 ## 🛠️ 7. How to maintain trackers
 
 `docs/dev-tracker.md` and `docs/dev-tracker.json` are **mirrors**.
-Always update both in the same commit. Fields per item:
+When a tracker update is required (L1/L2), update both in the same PR
+before merge. Fields per item:
 
 - `id` — descriptive kebab-case slug (e.g. `legacy-url-migration`)
 - `legacyCode` — old opaque code preserved for compat (`HBTV-XXX`)
@@ -389,6 +448,14 @@ You **must**:
   exact command outputs, file paths, and line numbers.
 - Disagree with the user when their suggestion would break a hard
   rule above; surface the conflict instead of complying silently.
+- **Planning** — required for broad, ambiguous, risky, or multi-step
+  changes. Small obvious multi-file fixes may proceed when scoped and
+  validated.
+- **TODOs** — no TODO or placeholder in production code at PR readiness
+  unless linked to a tracker item. Temporary TODOs during local work
+  must be removed before opening a PR.
+- **Responses** — avoid noisy postambles; include only useful summary,
+  validation, risk, commit, and PR information when delivering work.
 
 ---
 
@@ -404,14 +471,21 @@ Last refresh: see the latest commit touching this file.
 
 ---
 
-## 🔄 12. Doc sync protocol (after every step)
+## 🔄 12. Doc sync protocol (at PR readiness)
 
-**Rule** — every commit that changes meaningful state must keep the
-documentation set in lockstep. A "meaningful state change" is any
-commit that creates, advances, completes, mitigates, supersedes, or
-contradicts an item that is already documented.
+**Rule** — documentation synchronization is required at **PR
+readiness or before merge**, not after every local commit.
 
-### 12.1 What to update, by commit type
+A **meaningful change** is one that:
+
+- advances a tracker item;
+- modifies acceptance criteria;
+- alters documented behavior, validation, compatibility, packaging, or risk.
+
+L0 changes (see Governance levels) usually need no tracker update.
+L1/L2 changes must update the docs required by their level before merge.
+
+### 12.1 What to update, by change type (at PR readiness)
 
 | Type | `CHANGELOG.md` | `dev-tracker.{md,json}` | `risk-register.md` | `decision-log.md` |
 |------|:---:|:---:|:---:|:---:|
@@ -492,7 +566,7 @@ the rules in this very section.
 
 Every rule is uniquely identified by its **section heading + index**:
 
-- `2.5` — "Replace `youtube-dl` plugin behavior with `yt-dlp`"
+- `2` — download behavior / default downloader selection
   (a hard rule from Section 2's table)
 - `3` — "Conventional Commits …" (a process rule from Section 3)
 - `13.3` — "Modify a rule" (a meta-rule, this section)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,17 @@ If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
 
 Use English for code comments, commit messages, PR text, and
 documentation.
+
+## Branch naming (Claude Code)
+
+Never let Claude Code pick a branch name. Forbidden prefixes and
+recovery steps are in `AGENTS.md` §4.
+
+When using Claude Code worktrees, always pass an explicit branch name:
+
+```bash
+claude --worktree feat/descriptive-scope
+```
+
+Never run `claude --worktree` without a branch argument — that produces
+random `claude/**` names that violate repository policy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,27 +1,21 @@
 # Claude Code instructions for Habitv
 
 `AGENTS.md` is the single source of truth for repository-wide AI agent
-workflow policy.
+workflow policy. If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
 
-Before making changes, read and follow `AGENTS.md` for branch naming,
-duplicate branch/PR prevention, commit style, PR structure, validation,
-PR target policy, and documentation sync.
+Read `AGENTS.md` before making changes (hard rules, L0/L1/L2 governance,
+branch naming, PR policy, validation, doc sync at PR readiness).
 
-If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
+## Claude Code–specific
 
-Use English for code comments, commit messages, PR text, and
-documentation.
-
-## Branch naming (Claude Code)
-
-Never let Claude Code pick a branch name. Forbidden prefixes and
-recovery steps are in `AGENTS.md` §4.
-
-When using Claude Code worktrees, always pass an explicit branch name:
+- Use English for code comments, commit messages, PR text, and docs.
+- **Never** let Claude Code pick a branch name. Forbidden prefixes and
+  recovery: `AGENTS.md` branch naming.
+- Always pass an explicit branch when using worktrees:
 
 ```bash
 claude --worktree feat/descriptive-scope
 ```
 
 Never run `claude --worktree` without a branch argument — that produces
-random `claude/**` names that violate repository policy.
+invalid `claude/**` names.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,13 @@ Before creating a new branch, follow the duplicate-prevention checks
 defined in `AGENTS.md` (`git fetch --all --prune`, matching branch/PR
 search, and `git check-ref-format --branch`).
 
+**AI agents** must not use tool-specific or session-generated branch
+names (`claude/**`, `anthropic/**`, `ai/**`, `cursor/**`, `codex/**`,
+`wip/**`, and similar). Use only `feat/`, `fix/`, `docs/`, `chore/`,
+`test/`, `refactor/`, or `ci/` plus a short kebab-case scope — see
+`AGENTS.md` §4 for valid/invalid examples and recovery when already on
+an invalid branch.
+
 For AI-agent workflow, PR target policy is defined in `AGENTS.md`:
 agent-created PRs target `Mika3578/habitv` (not `ikfon10/habitv`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,10 @@ contributions follow a stricter-than-usual workflow.
 All modernization branches must target **`develop`**.
 The restart bootstrap PR targets `master`. Everything else targets `develop`.
 
-Before creating a new branch, follow the duplicate-prevention checks
-defined in `AGENTS.md` (`git fetch --all --prune`, matching branch/PR
-search, and `git check-ref-format --branch`).
+Before creating a **new PR branch**, run the duplicate-prevention checks
+in `AGENTS.md` (optional for local WIP or when continuing an existing
+branch). Always validate the branch name with
+`git check-ref-format --branch`.
 
 **AI agents** must not use tool-specific or session-generated branch
 names (`claude/**`, `anthropic/**`, `ai/**`, `cursor/**`, `codex/**`,
@@ -118,9 +119,10 @@ for the full rationale.
 |------|--------|
 | Related issue | Optional: reference a real GitHub issue (e.g. `#123`) when one exists |
 | Scope | Use one clear descriptive scope in branch name and PR body (e.g. `provider-youtube-ytdlp`) |
-| Scope discipline | One logical change. No opportunistic refactors or formatting passes |
+| Scope discipline | One logical change; limited boy-scout cleanup per `AGENTS.md` |
 | Linear history | No merge commits inside work branches; squash or rebase only |
-| Doc sync | Update `docs/dev-tracker.{md,json}`, `docs/risk-register.md`, `docs/decision-log.md` when behavior or scope changes |
+| Doc sync | At PR readiness — see `AGENTS.md` governance levels and doc sync |
+| Governance | L0/L1/L2 matrix in `AGENTS.md` defines tracker and ADR requirements |
 | English only | Branches, commits, code comments, docs, PR text |
 
 Do not use local tracker IDs (e.g. `hbtv-*` / `HBTV-*`) for new branch
@@ -158,11 +160,15 @@ Do not, without a dedicated tracker item and an accepted ADR:
   packaging (compile bridge on JDK 11+ is not sufficient — see
   `docs/java-runtime-policy.md`).
 - Regenerate JAXB-bound classes or move to `jakarta.*`.
-- Replace `youtube-dl` with `yt-dlp` (see `ytdlp-migration`).
+- Change download behavior or default downloader selection without
+  `ytdlp-migration` or a dedicated PR scope (wiring-only prep allowed
+  when tracked and behavior-preserving).
 - Change runtime updater URLs or layout (see `static-repo-publish`).
-- Migrate FTP/HTTP repositories (see `legacy-url-migration`).
+- Reintroduce obsolete HTTP/FTP hosts as runtime or build dependencies
+  (see `legacy-url-migration`; historical hosts in docs only as context).
 - Remove or rename provider/plugin modules (see `provider-inventory`).
-- Add OWASP, SBOM, or static-analysis plugins.
+- Add blocking security, SBOM, or static-analysis gates without a
+  tracker item and CI policy ADR.
 
 ---
 


### PR DESCRIPTION
## Summary

- Make AGENTS.md the canonical source for repository and agent rules.
- Add L0/L1/L2 governance levels for tracker and ADR requirements.
- Reduce doc-sync friction by moving synchronization expectations to PR readiness.
- Allow justified N/A entries in PR documentation.
- Add limited boy-scout cleanup rules.
- Forbid generated AI branch names such as claude/**, cursor/**, ai/**, and codex/**.
- Clarify yt-dlp, security tooling, and legacy repository wording without changing runtime behavior.

## Scope

clean-agent-rules

## Related issue

N/A

## Changes

- AGENTS.md: governance matrix, agent modes, clarified hard rules, boy-scout, PR N/A guidance, doc sync at PR readiness.
- CONTRIBUTING.md, PR template, Copilot instructions: align with AGENTS.md; less duplication.
- CLAUDE.md, .cursor/rules/*.mdc: short references to AGENTS.md only.

## Validation

- \git diff --check\ — passed (no whitespace errors).
- Manual Markdown review only; no Java code changed.

## Risk / rollback

- Low. Documentation/rules-only change.
- Core safety rules remain unchanged (Java 8, JavaFX, JAXB, secrets, PR target, validation, linear history).
- Rollback: revert this documentation commit if the cleaned rules create ambiguity.

## Notes

- No tracker or ADR update (L0 documentation cleanup).

Made with [Cursor](https://cursor.com)