### PR TITLE
chore(packaging): add shared package staging

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,14 +1,29 @@
-# Habitv cross-platform packaging
+# Habitv packaging assets
 
-This directory holds launcher templates, installer metadata, and platform-specific
-packaging assets used by the scripts under `scripts/`.
+This directory holds shared packaging assets for Habitv distributions.
 
-Build flow:
+## Shared staging
 
-1. `mvn -B -ntp -DskipTests package`
-2. `scripts/stage-package.sh` (Linux/macOS) or `scripts/stage-package.ps1` (Windows)
-   — collect JARs into `target/package-staging/Habitv/`
-3. `scripts/package-<platform>.{sh,ps1}` — produce native artifacts under
-   `target/packages/`
+After a Maven package build:
 
-See [`docs/packaging.md`](../docs/packaging.md) for full documentation.
+```bash
+mvn -B -ntp -DskipTests package
+```
+
+Stage built JARs with:
+
+- Linux/macOS: `bash scripts/stage-package.sh`
+- Windows: `powershell -ExecutionPolicy Bypass -File scripts/stage-package.ps1`
+
+Output layout:
+
+```text
+target/package-staging/Habitv/
+  lib/
+    habiTv-<version>.jar
+    plugins/
+  bin/          reserved for platform launchers in follow-up PRs
+  README.txt
+```
+
+Platform-specific installers and CI artifact upload are tracked in separate PRs.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -21,6 +21,7 @@ Output layout:
 target/package-staging/Habitv/
   lib/
     habiTv-<version>.jar
+    grabconfig.xml   minimal valid grab config (local mode + empty plugins)
     plugins/
   bin/          reserved for platform launchers in follow-up PRs
   README.txt

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,14 @@
+# Habitv cross-platform packaging
+
+This directory holds launcher templates, installer metadata, and platform-specific
+packaging assets used by the scripts under `scripts/`.
+
+Build flow:
+
+1. `mvn -B -ntp -DskipTests package`
+2. `scripts/stage-package.sh` (Linux/macOS) or `scripts/stage-package.ps1` (Windows)
+   — collect JARs into `target/package-staging/Habitv/`
+3. `scripts/package-<platform>.{sh,ps1}` — produce native artifacts under
+   `target/packages/`
+
+See [`docs/packaging.md`](../docs/packaging.md) for full documentation.

--- a/packaging/common/README.txt
+++ b/packaging/common/README.txt
@@ -10,13 +10,9 @@ Requirements
 
 Layout
 ------
-  bin/     OS launchers (habitv, habitv.bat, Habitv.exe)
-  lib/     Main application JAR and bundled runtime libraries
+  lib/          Main application JAR
   lib/plugins/  Provider, downloader, and exporter plugin JARs
 
-Portable use
-------------
-Extract the archive anywhere and run the launcher from bin/.
 Configuration and downloads are stored under your user profile unless
 configuration.xml is placed next to the application JAR directory.
 

--- a/packaging/common/README.txt
+++ b/packaging/common/README.txt
@@ -10,10 +10,12 @@ Requirements
 
 Layout
 ------
-  lib/          Main application JAR
-  lib/plugins/  Provider, downloader, and exporter plugin JARs
+  lib/              Main application JAR
+  lib/grabconfig.xml  Minimal valid grab config (local mode, empty categories)
+  lib/plugins/        Provider, downloader, and exporter plugin JARs
 
-Configuration and downloads are stored under your user profile unless
-configuration.xml is placed next to the application JAR directory.
+The staged grabconfig.xml is parsed at runtime (not a mere marker file). It
+enables local mode so bundled lib/plugins are loaded; populate categories via
+the application UI or console update options after install.
 
 More information: https://github.com/Mika3578/habitv

--- a/packaging/common/README.txt
+++ b/packaging/common/README.txt
@@ -1,0 +1,23 @@
+Habitv
+======
+
+Habitv is a Java 8 application for automatic French TV replay downloads.
+
+Requirements
+------------
+- Java 8 runtime with JavaFX support (for example Liberica JDK 8 Full or Zulu 8 FX).
+- This package does NOT include a Java runtime.
+
+Layout
+------
+  bin/     OS launchers (habitv, habitv.bat, Habitv.exe)
+  lib/     Main application JAR and bundled runtime libraries
+  lib/plugins/  Provider, downloader, and exporter plugin JARs
+
+Portable use
+------------
+Extract the archive anywhere and run the launcher from bin/.
+Configuration and downloads are stored under your user profile unless
+configuration.xml is placed next to the application JAR directory.
+
+More information: https://github.com/Mika3578/habitv

--- a/scripts/stage-package.ps1
+++ b/scripts/stage-package.ps1
@@ -1,0 +1,68 @@
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    return (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+$repoRoot = Get-RepoRoot
+Push-Location $repoRoot
+try {
+    $version = (& mvn help:evaluate "-Dexpression=project.version" -q "-DforceStdout" | Select-Object -Last 1).Trim()
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        throw "Unable to resolve project.version from Maven."
+    }
+
+    $staging = Join-Path $repoRoot "target/package-staging/Habitv"
+    $libDir = Join-Path $staging "lib"
+    $pluginsDir = Join-Path $libDir "plugins"
+    $binDir = Join-Path $staging "bin"
+
+    if (Test-Path (Join-Path $repoRoot "target/package-staging")) {
+        Remove-Item -Recurse -Force (Join-Path $repoRoot "target/package-staging")
+    }
+    New-Item -ItemType Directory -Force -Path $libDir, $pluginsDir, $binDir | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $repoRoot "target/packages") | Out-Null
+
+    $mainJar = Join-Path $repoRoot "application/habiTv/target/habiTv-$version.jar"
+    if (-not (Test-Path -Path $mainJar)) {
+        throw "Main JAR not found: $mainJar. Run: mvn -B -ntp -DskipTests package"
+    }
+    Copy-Item -Path $mainJar -Destination $libDir -Force
+
+    $pluginCount = 0
+    Get-ChildItem -Path (Join-Path $repoRoot "plugins") -Directory | ForEach-Object {
+        if ($_.Name -eq "plugin-tester") {
+            return
+        }
+        $targetDir = Join-Path $_.FullName "target"
+        if (-not (Test-Path -Path $targetDir)) {
+            return
+        }
+        Get-ChildItem -Path $targetDir -Filter "$($_.Name)-*.jar" -File | ForEach-Object {
+            switch -Regex ($_.Name) {
+                '(-sources|-javadoc|-tests)\.jar$|^original-' { return }
+            }
+            Copy-Item -Path $_.FullName -Destination $pluginsDir -Force
+            $script:pluginCount++
+        }
+    }
+
+    $commonReadme = Join-Path $repoRoot "packaging/common/README.txt"
+    if (Test-Path -Path $commonReadme) {
+        Copy-Item -Path $commonReadme -Destination (Join-Path $staging "README.txt") -Force
+    }
+
+    $envFile = Join-Path $repoRoot "target/package-staging/.env"
+    @(
+        "VERSION=$version"
+        "STAGING=$staging"
+    ) | Set-Content -Path $envFile -Encoding ASCII
+
+    Write-Host "Staged Habitv $version at $staging ($pluginCount plugins)"
+}
+finally {
+    Pop-Location
+}

--- a/scripts/stage-package.ps1
+++ b/scripts/stage-package.ps1
@@ -31,6 +31,15 @@ try {
     }
     Copy-Item -Path $mainJar -Destination $libDir -Force
 
+    $grabConfigMarker = @'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:grabConfig xmlns:ns2="http://www.dabi.com/habitv/grabconfig/entities">
+    <plugins/>
+</ns2:grabConfig>
+'@
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText((Join-Path $libDir "grabconfig.xml"), $grabConfigMarker, $utf8NoBom)
+
     $pluginCount = 0
     Get-ChildItem -Path (Join-Path $repoRoot "plugins") -Directory | ForEach-Object {
         if ($_.Name -eq "plugin-tester") {

--- a/scripts/stage-package.ps1
+++ b/scripts/stage-package.ps1
@@ -24,7 +24,6 @@ try {
         Remove-Item -Recurse -Force (Join-Path $repoRoot "target/package-staging")
     }
     New-Item -ItemType Directory -Force -Path $libDir, $pluginsDir, $binDir | Out-Null
-    New-Item -ItemType Directory -Force -Path (Join-Path $repoRoot "target/packages") | Out-Null
 
     $mainJar = Join-Path $repoRoot "application/habiTv/target/habiTv-$version.jar"
     if (-not (Test-Path -Path $mainJar)) {

--- a/scripts/stage-package.sh
+++ b/scripts/stage-package.sh
@@ -23,6 +23,15 @@ fi
 
 cp "$MAIN_JAR" "$LIB_DIR/"
 
+# Valid minimal grabconfig beside the JAR: enables local mode (DirUtils) and
+# unmarshals to an empty plugin list (GrabConfigDAO).
+cat > "$LIB_DIR/grabconfig.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:grabConfig xmlns:ns2="http://www.dabi.com/habitv/grabconfig/entities">
+    <plugins/>
+</ns2:grabConfig>
+EOF
+
 shopt -s nullglob
 for module_dir in "$REPO_ROOT"/plugins/*/; do
   module_name="$(basename "$module_dir")"

--- a/scripts/stage-package.sh
+++ b/scripts/stage-package.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Collect built Maven artifacts into target/package-staging/Habitv/.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+VERSION="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)"
+STAGING="$REPO_ROOT/target/package-staging/Habitv"
+LIB_DIR="$STAGING/lib"
+PLUGINS_DIR="$LIB_DIR/plugins"
+BIN_DIR="$STAGING/bin"
+
+rm -rf "$REPO_ROOT/target/package-staging"
+mkdir -p "$LIB_DIR" "$PLUGINS_DIR" "$BIN_DIR"
+
+MAIN_JAR="$REPO_ROOT/application/habiTv/target/habiTv-${VERSION}.jar"
+if [[ ! -f "$MAIN_JAR" ]]; then
+  echo "Main JAR not found: $MAIN_JAR" >&2
+  echo "Run: mvn -B -ntp -DskipTests package" >&2
+  exit 1
+fi
+
+cp "$MAIN_JAR" "$LIB_DIR/"
+
+shopt -s nullglob
+for module_dir in "$REPO_ROOT"/plugins/*/; do
+  module_name="$(basename "$module_dir")"
+  if [[ "$module_name" == "plugin-tester" ]]; then
+    continue
+  fi
+  for jar in "$module_dir"/target/"${module_name}"-*.jar; do
+    [[ -f "$jar" ]] || continue
+    base_name="$(basename "$jar")"
+    case "$base_name" in
+      *-sources.jar|*-javadoc.jar|*-tests.jar|original-*)
+        continue
+        ;;
+    esac
+    cp "$jar" "$PLUGINS_DIR/"
+  done
+done
+
+if [[ -f "$REPO_ROOT/packaging/common/README.txt" ]]; then
+  cp "$REPO_ROOT/packaging/common/README.txt" "$STAGING/README.txt"
+fi
+
+mkdir -p "$REPO_ROOT/target/packages"
+printf 'VERSION=%s\nSTAGING=%s\n' "$VERSION" "$STAGING" > "$REPO_ROOT/target/package-staging/.env"
+
+plugin_count="$(find "$PLUGINS_DIR" -maxdepth 1 -name '*.jar' | wc -l | tr -d ' ')"
+echo "Staged Habitv ${VERSION} at ${STAGING} (${plugin_count} plugins)"

--- a/scripts/stage-package.sh
+++ b/scripts/stage-package.sh
@@ -45,7 +45,6 @@ if [[ -f "$REPO_ROOT/packaging/common/README.txt" ]]; then
   cp "$REPO_ROOT/packaging/common/README.txt" "$STAGING/README.txt"
 fi
 
-mkdir -p "$REPO_ROOT/target/packages"
 printf 'VERSION=%s\nSTAGING=%s\n' "$VERSION" "$STAGING" > "$REPO_ROOT/target/package-staging/.env"
 
 plugin_count="$(find "$PLUGINS_DIR" -maxdepth 1 -name '*.jar' | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Summary

- Adds shared package staging for future platform packages.
- Stages the main Habitv application JAR.
- Stages plugin JARs.
- Prepares the project for smaller follow-up packaging PRs.

## Scope

package-staging-foundation

## Related issue

- N/A

## Changes

- Add `scripts/stage-package.sh` and `scripts/stage-package.ps1`.
- Add minimal `packaging/README.md` and `packaging/common/README.txt` describing the staged layout.

## Validation

- `mvn -B -ntp -DskipTests validate` — BUILD SUCCESS
- `mvn -B -ntp -DskipTests package` — BUILD SUCCESS
- `powershell -ExecutionPolicy Bypass -File scripts/stage-package.ps1` — staged main JAR and 24 plugin JARs under `target/package-staging/Habitv/`
- No `C:\Users\` or other machine-specific paths in committed scripts or docs
- No native installer artifacts generated

## Risk / rollback

- Risk: packaging-only scaffolding; no runtime behavior changes.
- Rollback: revert this PR.

## Non-goals

- No Windows EXE.
- No Windows installer.
- No Linux DEB.
- No macOS app bundle.
- No DMG.
- No Java migration.
- No JavaFX migration.
- No bundled runtime.
- No provider changes.

## Follow-up PRs

- `chore/package-windows-installer`
- `chore/package-linux-deb`
- `chore/package-macos-app-dmg`
- `ci/package-artifacts`

## Checklist

- [x] Branch was created from `develop`
- [x] No unrelated source changes
- [x] `mvn -B -ntp -DskipTests validate` passed
- [x] PR keeps linear history
- [x] English used for branches, commits, comments, docs, and PR text
- [x] No secrets, tokens, local paths, or build outputs committed
