### PR TITLE
docs(ai-rules): centralize safe agent workflow rules

### DIFF
--- a/.cursor/rules/00-canonical-source.mdc
+++ b/.cursor/rules/00-canonical-source.mdc
@@ -1,0 +1,24 @@
+---
+description: Canonical AGENTS.md pointer — always apply first
+alwaysApply: true
+---
+
+# Canonical source
+
+**Purpose:** Ensure every Cursor session treats `AGENTS.md` as the single
+source of truth for repository-wide AI agent behavior.
+
+**When it applies:** Every task.
+
+**Mandatory rules:**
+
+- Read `AGENTS.md` metadata and relevant sections before editing.
+- Report **Agent startup checklist** (Section 16.17) and **Instruction
+  files loaded** (Section 15.1).
+- Tool-specific files may reference, summarize, or extend `AGENTS.md` only.
+- On conflict, `AGENTS.md` wins.
+
+**Canonical reference:** [`AGENTS.md`](../../AGENTS.md) — current version
+in metadata block at top.
+
+**Lifecycle:** mandatory (Section 17.2).

--- a/.cursor/rules/90-rule-evolution.mdc
+++ b/.cursor/rules/90-rule-evolution.mdc
@@ -1,0 +1,38 @@
+---
+description: Rule evolution, drift audit, changelog, and backlog
+globs:
+  - "AGENTS.md"
+  - ".cursor/rules/**"
+  - ".github/copilot-instructions.md"
+  - ".github/instructions/**"
+  - "docs/agent-rules-*.md"
+  - "docs/dev-workflow.md"
+  - "CLAUDE.md"
+  - "GEMINI.md"
+---
+
+# Rule evolution
+
+**Purpose:** Keep AI rules maintainable, versioned, auditable, and
+retireable over time.
+
+**When it applies:** Any PR that changes AI agent rules or instruction
+files.
+
+**Mandatory rules:**
+
+- Change rules through dedicated reviewable PRs — not silently during
+  unrelated work (Section 17.1).
+- Update `AGENTS.md` metadata version and `docs/agent-rules-changelog.md`.
+- Run **Rule drift audit** (Section 17.6) before finishing.
+- End with **Agent rules update report** (Section 17.14).
+- Score new mandatory rules (Section 17.11); use backlog for candidates.
+- Habitv automation maturity: **Level 1 — Assisted** (Section 17.10).
+
+**Suggested rule improvement:** use when the same agent mistake happens
+twice (Section 17.4).
+
+**Canonical reference:** [`AGENTS.md`](../../AGENTS.md) Section 17;
+[`docs/agent-rules-backlog.md`](../../docs/agent-rules-backlog.md).
+
+**Lifecycle:** mandatory for AI-rule PRs.

--- a/.cursor/rules/90-rule-evolution.mdc
+++ b/.cursor/rules/90-rule-evolution.mdc
@@ -27,6 +27,7 @@ files.
 - Run **Rule drift audit** (Section 17.6) before finishing.
 - End with **Agent rules update report** (Section 17.14).
 - Score new mandatory rules (Section 17.11); use backlog for candidates.
+- Apply rule budget and stop condition (Section 20.6, 20.10).
 - Habitv automation maturity: **Level 1 — Assisted** (Section 17.10).
 
 **Suggested rule improvement:** use when the same agent mistake happens

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -1,0 +1,42 @@
+# Cursor rules index
+
+Canonical source: [`AGENTS.md`](../AGENTS.md). Cursor rules **extend** it;
+they must not contradict it or hold unique critical policy.
+
+## Purpose
+
+Modular, path-scoped rules for Cursor agents. Update through dedicated
+AI-rules PRs with changelog entry (Section 17).
+
+## Module map
+
+| File | Recommended # | Applies | AGENTS.md |
+|------|---------------|---------|-----------|
+| `00-canonical-source.mdc` | 00 | always | metadata, §17 |
+| `habitv-master.mdc` | — | always | §1–2, §16 |
+| `git-safety.mdc` | 10 | always | §14, §15.5–15.8, §15.20 |
+| `maven-validation.mdc` | 20 | Java/POM | §6, §14.2, §16.11 |
+| `java8-compatibility.mdc` | 30 | Java/POM | §2, §14.9, §16.10 |
+| `pr-review.mdc` | 40 | PR/docs | §5, §14.4, §15.16–15.19 |
+| `pr-style.mdc` | 40 | PR metadata | §5, §14.12 |
+| `dependencies.mdc` | 50 | POM/deps | §16.3–16.6 |
+| `workflows.mdc` | 60 | `.github/workflows` | §16.8–16.9 |
+| `cursor-ide.mdc` | — | `.vscode`, `.cursor` | §16.13–16.16 |
+| `habitv-maintainability.mdc` | — | code/build/config | §19 |
+| `habitv-providers.mdc` | 70 | `plugins/**` | §18 |
+| `90-rule-evolution.mdc` | 90 | AI-rule PRs | §17 |
+
+Path-specific: `plugins/AGENTS.md`, `.github/AGENTS.md`, etc.
+
+## Updating rules
+
+1. Change `AGENTS.md` first.
+2. Update related `.mdc` / Copilot files.
+3. Bump version metadata and `docs/agent-rules-changelog.md`.
+4. Run **Rule drift audit** (Section 17.6).
+5. End with **Agent rules update report** (Section 17.14).
+
+## Lifecycle
+
+Rules may be **mandatory**, **recommended**, **experimental**,
+**deprecated**, or **removed** (Section 17.2).

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -22,6 +22,7 @@ AI-rules PRs with changelog entry (Section 17).
 | `dependencies.mdc` | 50 | POM/deps | §16.3–16.6 |
 | `workflows.mdc` | 60 | `.github/workflows` | §16.8–16.9 |
 | `cursor-ide.mdc` | — | `.vscode`, `.cursor` | §16.13–16.16 |
+| `agent-productivity.mdc` | — | always | §20 |
 | `habitv-maintainability.mdc` | — | code/build/config | §19 |
 | `habitv-providers.mdc` | 70 | `plugins/**` | §18 |
 | `90-rule-evolution.mdc` | 90 | AI-rule PRs | §17 |

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -1,6 +1,6 @@
 # Cursor rules index
 
-Canonical source: [`AGENTS.md`](../AGENTS.md). Cursor rules **extend** it;
+Canonical source: [`AGENTS.md`](../../AGENTS.md). Cursor rules **extend** it;
 they must not contradict it or hold unique critical policy.
 
 ## Purpose

--- a/.cursor/rules/agent-productivity.mdc
+++ b/.cursor/rules/agent-productivity.mdc
@@ -1,0 +1,27 @@
+---
+description: Productivity and anti-bloat — profiles, speed/deep mode, rule budget
+alwaysApply: true
+---
+
+# Agent productivity and scope control
+
+**Purpose:** Keep AI rules useful and fast. Avoid oversized rulebooks that
+slow every task.
+
+**When it applies:** Every task — pick a rule profile before editing.
+
+**Mandatory highlights (`AGENTS.md` Section 20):**
+
+- **Minimum viable ruleset** — mandatory rules in `AGENTS.md`; details in
+  `docs/dev-workflow.md`, path-specific `AGENTS.md`, `.github/instructions/`.
+- **Rule profile** — classify task; do not apply heavy gates to docs-only
+  work (Section 20.2).
+- **Speed mode** vs **deep mode** — match validation to risk (20.8–20.9).
+- **Rule budget** — merge/replace duplicates before adding rules (20.6).
+- **Stop condition** — prefer backlog over new mandatory rules (20.10).
+- **Conflict precedence** — developer instruction → safety → approval →
+  `AGENTS.md` (20.5).
+
+**Canonical reference:** [`docs/agent-rule-profiles.md`](../../docs/agent-rule-profiles.md)
+
+**Lifecycle:** always on; complements Sections 16–19 without replacing them.

--- a/.cursor/rules/cursor-ide.mdc
+++ b/.cursor/rules/cursor-ide.mdc
@@ -1,0 +1,41 @@
+---
+description: Cursor and VS Code project configuration rules
+globs:
+  - ".vscode/**"
+  - ".cursor/**"
+  - "docs/dev-workflow.md"
+---
+
+# Habitv Cursor / VS Code rules
+
+Canonical source: `AGENTS.md` Sections 16.13–16.16; `docs/dev-workflow.md`.
+
+## Repository rules first
+
+`AGENTS.md` and `.cursor/rules/` define repository-critical behavior.
+Never assume user-level Cursor settings are correct.
+
+## Project files
+
+- `.vscode/extensions.json` — recommended extensions (not forced)
+- `.vscode/settings.example.json` — safe examples only
+- `.cursor/rules/*.mdc` — topic-split agent rules
+
+## Forbidden in committed settings
+
+Machine-specific `JAVA_HOME`, absolute paths, usernames, tokens, private
+tool paths.
+
+## Formatting
+
+Do not enable broad format-on-save that reformats legacy files (Section
+16.23). Dedicated formatting PRs only.
+
+## Tasks
+
+Do not add `.vscode/tasks.json` in feature PRs. Use dedicated tooling PR.
+Tasks must never commit, push, merge, or resolve PR comments.
+
+## Scratch space
+
+Use `agent_space/` for temporary work; never commit from it (Section 15.21).

--- a/.cursor/rules/dependencies.mdc
+++ b/.cursor/rules/dependencies.mdc
@@ -1,0 +1,41 @@
+---
+description: Dependency and security update rules for Habitv
+globs:
+  - "**/pom.xml"
+  - ".github/dependabot.yml"
+  - "docs/dependency-policy.md"
+  - "docs/security-policy.md"
+---
+
+# Habitv dependency and security rules
+
+Canonical source: `AGENTS.md` Sections 14.9, 16.3–16.6, 16.19;
+`docs/dependency-policy.md`; `docs/security-policy.md`.
+
+## Dependency PRs
+
+- One topic per PR; do not mix with feature work.
+- Preserve Java 8 compatibility unless dedicated migration task says otherwise.
+- Run full Maven validation after any dependency change.
+- Provide **Dependency update report** before commit approval.
+- Check release notes for non-trivial updates (Section 16.22).
+
+## Security priority
+
+Security alerts outrank cosmetic work (Section 16.19). Prefer compatible
+upgrades; document if no Java 8 fix exists. Never silence alerts without
+reason.
+
+## Dependabot
+
+Inspect `.github/dependabot.yml` before dependency automation changes.
+Never enable auto-merge unless developer explicitly asks.
+
+## Forbidden
+
+- batching unrelated dependency updates
+- disabling Dependabot or dependency review
+- weakening branch protection for green CI
+- dependency changes without validation evidence
+
+Ask developer approval before dependency **major** updates.

--- a/.cursor/rules/git-safety.mdc
+++ b/.cursor/rules/git-safety.mdc
@@ -1,0 +1,145 @@
+---
+description: Git workflow, workspace safety, and commit/push approval gates
+alwaysApply: true
+---
+
+# Habitv Git safety rules
+
+Canonical source: `AGENTS.md` Sections 3, 4, 14.1, 14.5, 14.6, 14.8,
+14.11–14.14, 15.1, 15.5, 15.6, 15.8–15.10, 15.13, 15.17, 15.20–15.23,
+15.27–15.28.
+
+At task start, report **Instruction files loaded** per `AGENTS.md`
+Section 15.1 before editing files.
+
+## Workspace safety (before any edit, commit, rebase, push, or PR action)
+
+Run:
+
+```bash
+git status --short
+git branch --show-current
+git remote -v
+git log --oneline --decorate -n 10
+```
+
+Do not work directly on `develop`, `main`, or `master`.
+
+Do not overwrite, delete, stage, or commit uncommitted developer changes
+without explicit approval. Distinguish agent changes from pre-existing
+local changes.
+
+## Never automatic
+
+Never run without explicit developer approval in the **current**
+conversation:
+
+- `git commit`
+- `git push`
+- `git push --force`
+- `git push --force-with-lease`
+- `gh pr create`, `gh pr merge`, `gh pr review`, `gh pr comment`
+- any command that publishes, merges, comments, or changes remote state
+
+Previous session approval is never valid.
+
+## Chained commands
+
+Never chain approval-gated actions without separate approval for each
+(Section 15.8). Forbidden without approval:
+
+```bash
+git add -A
+git add .
+git add --all
+git add -A && git commit -m "..."
+git commit -m "..." && git push
+```
+
+## Explicit staging
+
+Stage only intentional files by explicit path (Section 15.20). Before
+**Approve commit?**, run:
+
+```bash
+git diff --stat
+git diff --check
+git diff --cached --stat
+git diff --cached --check
+```
+
+If nothing is staged, say so and list exact files planned to stage.
+
+## Secrets, artifacts, and attribution
+
+Inspect diffs for secrets before commit approval (Section 15.9). No AI
+attribution in commits or PRs (Section 15.10). Leave build outputs,
+binaries, logs, and IDE caches unstaged (Section 15.23). Use `agent_space/`
+for scratch work; never commit from it (Section 15.21).
+
+## Commit classification
+
+Classify each commit as exactly one type per Section 15.28. No silent
+unrelated auto-fixes (Section 15.27).
+
+## Approval prompts
+
+Ask exactly:
+
+- **Approve commit?** — before any commit
+- **Approve push?** — before any normal push
+- **Approve force-with-lease push?** — after rebase or rewritten history
+
+## Branch updates (linear history)
+
+Allowed:
+
+```bash
+git fetch origin --prune
+git rebase origin/develop
+git push --force-with-lease   # only after rebase, with approval
+```
+
+Disallowed:
+
+- `git merge origin/develop`
+- plain `git pull` or `git pull` without `--rebase`
+- GitHub **Update branch** if it creates a merge commit
+- `git push --force` (never)
+
+On rebase conflicts: stop, list files, explain resolution, rerun
+validation after `git rebase --continue`.
+
+## Branch naming
+
+Use conventional prefixes only: `feat/`, `fix/`, `docs/`, `test/`,
+`refactor/`, `chore/`, `ci/`, `build/`. No random tool-generated names.
+English only. No `hbtv-*` or `HBTV*` IDs.
+
+## Destructive commands
+
+Require explicit approval with explanation before:
+
+- `git reset --hard`, `git clean -fd`, `git checkout -- <file>`,
+  `git restore <file>`, `git branch -D`
+- deleting files outside requested scope
+- force-pushing without `--force-with-lease`
+
+## Checklists
+
+Provide `AGENTS.md` Section 14.13 pre-commit checklist before
+**Approve commit?**
+
+Provide `AGENTS.md` Section 14.14 pre-push checklist before
+**Approve push?** or **Approve force-with-lease push?**
+
+## No intermediate commits
+
+Do not create WIP commits. Keep working locally until the change is
+complete, validated, and developer-approved. Push only when coherent and
+explicitly approved (root `AGENTS.md` Section 15.5).
+
+## Session handoff
+
+When stopping before commit/push/PR, provide the **Handoff** block from
+root `AGENTS.md` Section 15.6.

--- a/.cursor/rules/git-safety.mdc
+++ b/.cursor/rules/git-safety.mdc
@@ -113,7 +113,7 @@ validation after `git rebase --continue`.
 ## Branch naming
 
 Use conventional prefixes only: `feat/`, `fix/`, `docs/`, `test/`,
-`refactor/`, `chore/`, `ci/`, `build/`. No random tool-generated names.
+`refactor/`, `chore/`, `ci/`. No random tool-generated names.
 English only. No `hbtv-*` or `HBTV*` IDs.
 
 ## Destructive commands

--- a/.cursor/rules/habitv-maintainability.mdc
+++ b/.cursor/rules/habitv-maintainability.mdc
@@ -1,0 +1,34 @@
+---
+description: Habitv maintainability guardrails — DoD, tests, config, user data
+alwaysApply: false
+globs:
+  - "**/*.java"
+  - "**/pom.xml"
+  - "application/**"
+  - "plugins/**"
+  - "scripts/**"
+  - "docs/**"
+---
+
+# Habitv maintainability rules
+
+**Purpose:** Long-term maintainability, reproducible builds, dependency
+safety, config compatibility, test reliability, decision tracking.
+
+**When it applies:** Code, build, config, script, or docs changes affecting
+runtime, packaging, providers, or dependencies.
+
+**Mandatory highlights (`AGENTS.md` Section 19):**
+
+- Declare **Definition of Done** before work (19.2).
+- Document decisions via ADR when durable (19.1).
+- Classify **PR risk** and scale validation (19.16).
+- **Manual test evidence** before commit on behavior changes (19.15).
+- Protect **XML config** and **user data** (19.10–19.11).
+- **Windows-first** path/script validation (19.13–19.14).
+- Provide **rollback plan** for medium+ risk (19.17).
+- End with **Maintainability report** (19.25).
+
+**Canonical reference:** [`docs/maintainability-policy.md`](../../docs/maintainability-policy.md)
+
+**Lifecycle:** mandatory for behavior/build/config PRs; recommended for docs.

--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -10,11 +10,9 @@ They exist to keep modernization safe, incremental, and reviewable.
 
 ## Java baseline
 
+- See `.cursor/rules/java8-compatibility.mdc` and `AGENTS.md` Section 2.
 - Always keep Java 8 compatibility unless an explicit tracked migration
   item says otherwise and is referenced in the PR.
-- Do not introduce Java 9+ language features or JDK 11/17/21-only APIs.
-- Any Java baseline migration must happen in a dedicated migration PR
-  with an ADR in `docs/decision-log.md`.
 
 ## Architecture and scope
 
@@ -26,8 +24,9 @@ They exist to keep modernization safe, incremental, and reviewable.
 
 ## Build and tests
 
-- Prefer deterministic Maven commands. Default validation:
-  `mvn -B -ntp -DskipTests validate`.
+- Pre-commit validation gate: `AGENTS.md` Section 14.2 and
+  `.cursor/rules/maven-validation.mdc`.
+- CI-safe baseline: `mvn -B -ntp -DskipTests validate`.
 - Do not run live provider/network tests in the default lifecycle.
   Network or provider live tests must be opt-in via an explicit
   profile or tracker item.
@@ -36,9 +35,30 @@ They exist to keep modernization safe, incremental, and reviewable.
 
 ## Branching and PRs
 
-- Follow `AGENTS.md` as the source of truth for PR target policy,
-  branch naming, duplicate branch/PR prevention, commit style, PR
-  structure, validation, and linear history.
+- Follow `AGENTS.md` as the canonical source for all AI workflow policy.
+- At task start, report **Agent startup checklist** (Section 16.17).
+- Prefer small focused PRs; stop and split if scope grows (Section 16.1).
+- Security and dependency work: see `.cursor/rules/dependencies.mdc` and
+  `docs/dependency-policy.md`.
+- CI/workflow work: see `.cursor/rules/workflows.mdc` and Section 16.8.
+- Cursor/VS Code config: see `.cursor/rules/cursor-ide.mdc`.
+- Provider/plugin work: see `.cursor/rules/habitv-providers.mdc` and
+  `docs/provider-policy.md` (Section 18).
+- Behavior/build/config work: see `.cursor/rules/habitv-maintainability.mdc`
+  and `docs/maintainability-policy.md` (Section 19).
+- Follow `.cursor/rules/git-safety.mdc` for Git workflow and approval
+  gates; `.cursor/rules/pr-review.mdc` for PR and Copilot review rules.
+- When AI rules change, run drift audit (Section 17.6), update
+  `docs/agent-rules-changelog.md`, and bump metadata version.
+- Never chain approval-gated Git/GitHub commands (Section 15.8).
+- Stage only intentional files; no blind `git add -A` (Section 15.20).
+- Record tool versions when changing build/deps/packaging (Section 15.22).
+- Inspect diffs for secrets; no AI attribution (Sections 15.9–15.10);
+  leave artifacts unstaged (Section 15.23); use `agent_space/` for scratch
+  work (Section 15.21).
+- No silent unrelated auto-fixes; classify commits (Sections 15.27–15.28).
+- Never commit, push, create PRs, merge PRs, or resolve review threads
+  without explicit developer approval in the current conversation.
 - Use small PRs scoped to a single descriptive scope (see `docs/dev-tracker.md`).
 - Use English for branches, commits, comments, docs, and PR text.
 

--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -46,6 +46,9 @@ They exist to keep modernization safe, incremental, and reviewable.
   `docs/provider-policy.md` (Section 18).
 - Behavior/build/config work: see `.cursor/rules/habitv-maintainability.mdc`
   and `docs/maintainability-policy.md` (Section 19).
+- Every task: see `.cursor/rules/agent-productivity.mdc` and
+  `docs/agent-rule-profiles.md` (Section 20) — pick profile; avoid
+  applying heavy gates to docs-only work.
 - Follow `.cursor/rules/git-safety.mdc` for Git workflow and approval
   gates; `.cursor/rules/pr-review.mdc` for PR and Copilot review rules.
 - When AI rules change, run drift audit (Section 17.6), update

--- a/.cursor/rules/habitv-providers.mdc
+++ b/.cursor/rules/habitv-providers.mdc
@@ -1,0 +1,30 @@
+---
+description: Habitv provider and plugin modernization rules
+globs:
+  - "plugins/**"
+  - "docs/provider-inventory.md"
+  - "docs/provider-policy.md"
+  - "docs/obsolescence-register.md"
+---
+
+# Habitv provider rules
+
+**Purpose:** Safe, fast provider/plugin modernization with offline tests
+and clear status tracking.
+
+**When it applies:** Work under `plugins/` or provider documentation.
+
+**Mandatory rules (see `AGENTS.md` Section 18):**
+
+- Declare project **phase** before editing (18.1).
+- Update provider **status** in inventory/obsolescence register (18.2).
+- Preserve/improve **metadata** where validated (18.3).
+- Prefer **offline fixture tests**; live checks supplementary (18.4).
+- **External tool** updates in dedicated PRs with report (18.5).
+- No DRM bypass; no cookies/tokens/sessions in repo (18.4).
+- End tasks with **Habitv final report** (18.19).
+
+**Canonical reference:** [`docs/provider-policy.md`](../../docs/provider-policy.md),
+[`plugins/AGENTS.md`](../../plugins/AGENTS.md).
+
+**Lifecycle:** mandatory for provider/plugin PRs.

--- a/.cursor/rules/java8-compatibility.mdc
+++ b/.cursor/rules/java8-compatibility.mdc
@@ -1,0 +1,46 @@
+---
+description: Java 8 baseline and dependency change constraints
+globs:
+  - "**/*.java"
+  - "**/pom.xml"
+---
+
+# Habitv Java 8 compatibility rules
+
+Canonical source: `AGENTS.md` Sections 2, 14.9, 18.6–18.7.
+
+## Java baseline
+
+- Target **Java 8 only** unless a dedicated migration tracker item and
+  ADR explicitly authorize a higher baseline.
+- Do not introduce Java 9+ language features (`var`, records, switch
+  expressions, sealed types, pattern matching).
+- Do not introduce Java 9+ APIs (`List.of`, `HttpClient`, `Stream.toList`,
+  module-system constructs).
+
+## Forbidden without tracker item + ADR
+
+- Bump Java baseline beyond Java 8
+- Migrate JavaFX (`jfxrt`) to OpenJFX
+- Regenerate JAXB or move to `jakarta.*`
+- Restructure Maven reactor topology
+- Replace `youtube-dl` with `yt-dlp` behavior
+- Provider rewrites, JavaFX migration, runtime updater URL changes
+
+## Dependency changes
+
+Do not add, remove, or upgrade dependencies unless the task explicitly
+requires it. When required, document:
+
+- dependency name, old version, new version
+- reason for the change
+- Java 8 compatibility impact
+- validation performed
+
+Plugin version bumps must match `plugin-versioning-policy` triggers in
+`CONTRIBUTING.md`.
+
+## JavaFX (Section 18.7)
+
+Do not claim JavaFX is always bundled with Java. See
+[`docs/java-runtime-policy.md`](../../docs/java-runtime-policy.md).

--- a/.cursor/rules/maven-validation.mdc
+++ b/.cursor/rules/maven-validation.mdc
@@ -1,0 +1,74 @@
+---
+description: Pre-commit Maven build and test validation gates
+globs:
+  - "**/*.java"
+  - "**/pom.xml"
+  - "fwk/**"
+  - "application/**"
+  - "plugins/**"
+---
+
+# Habitv Maven validation rules
+
+Canonical source: `AGENTS.md` Sections 6 and 14.2–14.3, 15.11, 15.15.
+
+## Pre-commit validation (code changes)
+
+Before asking **Approve commit?**, run unless the developer explicitly
+relaxes this gate:
+
+```bash
+mvn -B -ntp -DskipTests clean package
+mvn -B -ntp test
+```
+
+When a specific module changed, also run:
+
+```bash
+mvn -B -ntp -pl <module> -am test
+```
+
+If full build or full tests are skipped for any code-impacting change,
+mark the work:
+
+> Not ready to commit.
+
+If tests fail, list the failing command, summarize the failure, identify
+relation to the change, and propose the next fix (Section 15.11). Do not
+ask for commit approval unless status is **Not ready to commit** and
+developer explicitly approves committing despite failures.
+
+## Validation evidence
+
+Provide exact command lines and pass/fail results (Section 15.15). Do
+not write vague validation such as "tests pass" or "build ok".
+
+## Docs-only skip
+
+Skip Maven only when all are true:
+
+- documentation-only change;
+- no Java source, POM, workflow, or runtime file changed;
+- full Maven validation was not run;
+- branch is not validated for runtime behavior.
+
+## CI-safe baseline (not sufficient alone for commit approval)
+
+```bash
+mvn -B -ntp -DskipTests validate
+```
+
+Do not run live provider/network tests in the default lifecycle.
+
+Do not change Maven module topology, plugin versions, or dependency
+versions outside a scoped tracker item.
+
+## Real application testing
+
+Before commit approval, include exactly:
+
+> Please test the real application behavior affected by this change
+> before approving the commit.
+
+Include the repo health / review readiness status from root `AGENTS.md`
+Sections 15.4 and 15.16.

--- a/.cursor/rules/maven-validation.mdc
+++ b/.cursor/rules/maven-validation.mdc
@@ -14,22 +14,17 @@ Canonical source: `AGENTS.md` Sections 6 and 14.2–14.3, 15.11, 15.15.
 
 ## Pre-commit validation (code changes)
 
-Before asking **Approve commit?**, run unless the developer explicitly
-relaxes this gate:
+Before asking **Approve commit?**, run the tier from `AGENTS.md` Section
+14.2 unless the developer explicitly relaxes this gate:
 
-```bash
-mvn -B -ntp -DskipTests clean package
-mvn -B -ntp test
-```
+| Tier | Commands |
+|------|----------|
+| Standard code | `mvn -B -ntp validate` + targeted `-pl <module> -am test` when relevant |
+| Risky / code-wide | `mvn -B -ntp validate` + `mvn -B -ntp test` |
+| Packaging / full-app | `mvn -B -ntp -DskipTests clean package` only when in scope and JavaFX/`jdk.home` environment supports it |
 
-When a specific module changed, also run:
-
-```bash
-mvn -B -ntp -pl <module> -am test
-```
-
-If full build or full tests are skipped for any code-impacting change,
-mark the work:
+If the required tier was skipped for a code-impacting change without
+developer approval, mark the work:
 
 > Not ready to commit.
 

--- a/.cursor/rules/pr-review.mdc
+++ b/.cursor/rules/pr-review.mdc
@@ -1,0 +1,80 @@
+---
+description: PR policy, Copilot review handling, and PR target gates
+globs:
+  - ".github/**"
+  - "AGENTS.md"
+  - "CONTRIBUTING.md"
+  - "docs/**"
+---
+
+# Habitv PR review rules
+
+Canonical source: `AGENTS.md` Sections 5, 14.4, 14.10–14.12, 15.7,
+15.10, 15.15–15.19, 15.25–15.26.
+
+## PR target (mandatory)
+
+- Repository: `Mika3578/habitv`
+- Base branch: `develop`
+- Never open PRs against `ikfon10/habitv` or other forks
+
+Before `gh pr create`, show source branch, target repo, base branch,
+PR title, PR body, and validation result. Ask for explicit approval.
+
+## PR readiness
+
+- Fill every required section of `.github/pull_request_template.md`
+- Keep diffs small and scoped; no opportunistic refactors
+- Linear history only (rebase, not merge commits)
+- English-only titles, bodies, and review comments
+- Conventional Commits for titles; no `hbtv-*` or `HBTV*` IDs
+
+## Copilot review comments
+
+Before a PR is ready:
+
+1. Inspect all Copilot review comments and unresolved conversations.
+2. Classify each as: accepted and fixed; intentionally rejected with
+   reason; not applicable; outside current PR scope; needs developer
+   decision.
+3. Implement accepted recommendations.
+4. Reply to each comment in English with what was done or why not applied.
+5. Resolve only after review, handling, reply, and commit/push (if
+   applicable).
+6. Never resolve just to silence the review.
+
+If resolution needs a GitHub command or UI action, ask for developer
+approval first.
+
+Never resolve conversations silently (root `AGENTS.md` Section 15.7).
+
+## Review readiness
+
+A PR is not review-ready until Section 15.16 criteria are met, including
+branch protection alignment (15.17), status checks (15.18), and
+CODEOWNERS review (15.19). Do not say "CI is green" without verifying
+current PR checks.
+
+Final status must include **Not ready to merge** when checks are pending
+or failing, or code-owner review is missing.
+
+No AI attribution (Section 15.10). Provide exact validation evidence
+(Section 15.15). List **Follow-up candidates** for out-of-scope work
+(Section 15.26).
+
+## PR comment actions
+
+Ask explicit approval before any PR comment, Copilot reply, review
+request, label change, title/body edit, or conversation resolution
+(Section 15.25). Show the exact English comment before posting.
+
+## Instruction alignment
+
+When changing AI rules, run the drift check in root `AGENTS.md`
+Section 15.3 and keep this file aligned with root `AGENTS.md`.
+
+## Doc sync
+
+Update `docs/dev-tracker.{md,json}`, `docs/risk-register.md`, and
+`docs/decision-log.md` when the change is meaningful (see `AGENTS.md`
+Section 12).

--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -1,0 +1,47 @@
+---
+description: GitHub Actions, CI, CodeQL, and workflow security rules
+globs:
+  - ".github/workflows/**"
+  - ".github/dependabot.yml"
+  - "docs/ci.md"
+---
+
+# Habitv workflow and CI rules
+
+Canonical source: `AGENTS.md` Sections 16.6–16.9; `.github/AGENTS.md`;
+`docs/dev-workflow.md`.
+
+## Least privilege
+
+Default workflow permissions: `contents: read`. Add write only when required.
+
+## Before changing workflows
+
+Provide **Workflow safety checklist** (Section 16.8). Ask developer
+approval before broadening permissions or adding `pull_request_target`.
+
+## Existing workflows
+
+- `ci-maven.yml` — primary Java 8 Maven CI
+- `dependency-review.yml` — high-severity dependency gate on PRs
+- `build.yml`, `stale.yml`, `labeler.yml` — supporting automation
+
+## CodeQL and Dependency Review
+
+Do not remove CodeQL without approval. Fix Java 8 JDK setup instead of
+disabling analysis. Document if Dependency Review unavailable on plan.
+
+## CI speed and workflow tiers
+
+See `AGENTS.md` Section 18.13. Tiers: PR fast validation; targeted module;
+security (CodeQL, dependency review, OWASP, SBOM); packaging; scheduled
+maintenance.
+
+## Forbidden workflow patterns
+
+- executing untrusted PR body text as shell commands
+- echoing secrets/tokens
+- exposing secrets to fork PRs
+- auto-merge for dependency updates
+
+Never chain workflow-triggered publish actions without explicit approval.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,46 @@
+# GitHub workflow agent instructions
+
+Extends the root [`AGENTS.md`](../AGENTS.md). When they conflict, the
+root file wins.
+
+## Scope
+
+This file applies to work under `.github/` — workflows, branch protection
+docs, PR templates, Copilot instructions, and repository governance.
+
+## Path-specific rules
+
+- PRs must target `Mika3578/habitv` → `develop` (root `AGENTS.md`
+  Section 14.10).
+- Keep `.github/copilot-instructions.md` and
+  `.github/instructions/*.instructions.md` aligned with root `AGENTS.md`.
+- When changing AI workflow rules, run the rule drift check (root
+  `AGENTS.md` Section 15.3).
+- Do not use `secrets: inherit` in workflows unless explicitly justified
+  and documented.
+- Be aware of branch protection and required checks in
+  `docs/repository-governance.md` (Section 15.17).
+- Inspect `.github/CODEOWNERS` when governance files change (Section 15.19).
+- Verify PR status checks before declaring ready; never say "CI is green"
+  without verification (Section 15.18).
+- Do not suggest bypassing branch protection unless developer asks for
+  admin guidance.
+- Ask approval before PR comments, labels, review requests, or resolution
+  (Section 15.25).
+- Fill every required section of `.github/pull_request_template.md`.
+- No chained approval-gated commands (Section 15.8).
+
+## Instruction loading
+
+At task start, report **Instruction files loaded** including this file,
+`.github/copilot-instructions.md`, `.github/instructions/github-actions.instructions.md`,
+and `.github/instructions/github-pr.instructions.md`.
+
+## Fast modernization
+
+Follow Section 16 for CI/workflow changes: provide Workflow safety
+checklist (16.8), least-privilege permissions, no auto-merge for deps.
+## Copilot and review
+
+Follow root `AGENTS.md` Sections 14.4 and 15.7 for Copilot and GitHub
+review resolution. Never resolve conversations silently.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,12 @@ See Section 19 and `docs/maintainability-policy.md`. Declare Definition of
 Done; classify PR risk; document ADRs for durable decisions; manual test
 evidence before commit on behavior changes.
 
+## Productivity and anti-bloat
+
+See Section 20 and `docs/agent-rule-profiles.md`. Pick a rule profile at
+task start; use speed mode for low-risk docs-only work; prefer backlog
+over new mandatory rules.
+
 AI agents must never commit, push, create PRs, merge PRs, or resolve
 review threads without explicit developer approval in the current
 conversation. See `AGENTS.md` Section 14. Never resolve GitHub review

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,15 +94,33 @@ See `.github/instructions/maven-java.instructions.md` and
 ## Default validation
 
 Pre-commit validation for AI agents is defined in `AGENTS.md` Section
-14.2. Default for code changes:
+14.2 (tiered). Do **not** require root `clean package` for every code change.
+
+**Standard code** tier:
 
 ```
-mvn -B -ntp -DskipTests clean package
+mvn -B -ntp validate
+mvn -B -ntp -pl <module> -am test   # when module-specific
+```
+
+**Risky / code-wide** tier:
+
+```
+mvn -B -ntp validate
 mvn -B -ntp test
 ```
 
-For a quick CI-safe sanity check (not sufficient alone before commit
-approval unless the developer explicitly relaxes Section 14.2):
+**Packaging / full-app** tier (only when in scope and JavaFX/`jdk.home`
+environment supports it):
+
+```
+mvn -B -ntp -DskipTests clean package
+```
+
+**Docs-only:** Maven may be skipped with a clear note.
+
+CI-safe sanity check (not sufficient alone before commit approval unless
+the developer explicitly relaxes Section 14.2):
 
 ```
 mvn -B -ntp -DskipTests validate

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,28 +9,69 @@ narrowly-scoped suggestions over rewrites.
 
 ## Workflow policy source of truth
 
-Follow `AGENTS.md` as the source of truth for:
-- PR target policy
-- branch naming
-- duplicate branch and PR prevention
-- commit style
-- PR structure
-- validation commands
-- linear Git history
-- documentation sync requirements
+`AGENTS.md` is the canonical source for all AI agent behavior. These
+companion files mirror or point to the same mandatory rules:
+
+- `.cursor/rules/git-safety.mdc` — Git workflow and approval gates
+- `.cursor/rules/maven-validation.mdc` — pre-commit Maven validation
+- `.cursor/rules/pr-review.mdc` — PR policy and Copilot review handling
+- `.cursor/rules/java8-compatibility.mdc` — Java 8 and dependency rules
+- `.github/instructions/maven-java.instructions.md` — Java/POM path rules
+- `.github/instructions/plugins.instructions.md` — plugin path rules
+- `.github/instructions/github-actions.instructions.md` — GitHub Actions
+- `.github/instructions/github-pr.instructions.md` — PR/GitHub path rules
+- `.github/instructions/packaging.instructions.md` — packaging path rules
+- nested `AGENTS.md` files — path-specific extensions (Section 15.2)
+- `docs/dev-workflow.md`, `docs/dependency-policy.md`, `docs/security-policy.md`
+- `docs/provider-policy.md`, `docs/release-policy.md`, `docs/modernization-backlog.md`
+- `.cursor/rules/habitv-providers.mdc`, `90-rule-evolution.mdc`
+
+When any file conflicts with `AGENTS.md`, `AGENTS.md` wins.
+
+At task start, report **Instruction files loaded** (Section 15.1).
+
+When changing AI rules, run drift audit (Section 17.6), update changelog,
+and bump `AGENTS.md` metadata version (Section 17).
+
+Never chain approval-gated commands (Section 15.8). Stage only intentional
+files by path (Section 15.20). Inspect diffs for secrets (Section 15.9).
+No AI attribution (Section 15.10). Provide exact validation evidence
+(Section 15.15). Verify status checks before PR merge readiness (15.18).
+Ask approval before PR comment actions (Section 15.25).
+
+## Fast safe modernization
+
+See `AGENTS.md` Section 16 and `docs/dev-workflow.md`. Classify tasks
+before editing (16.2). Prefer small focused PRs. Security fixes outrank
+cosmetic work (16.19). Dependency updates need focused PRs and the
+Dependency update report (16.3).
+
+## Rule evolution
+
+See Section 17. AI rules change through dedicated PRs with changelog entry.
+Automation maturity: Level 1 — Assisted.
+
+## Habitv-specific modernization
+
+See Section 18 and `docs/provider-policy.md`. Declare phase before work.
+Provider status, metadata, offline tests, external tools, Java/JavaFX,
+release readiness — see companion docs in metadata block.
+
+## Maintainability
+
+See Section 19 and `docs/maintainability-policy.md`. Declare Definition of
+Done; classify PR risk; document ADRs for durable decisions; manual test
+evidence before commit on behavior changes.
+
+AI agents must never commit, push, create PRs, merge PRs, or resolve
+review threads without explicit developer approval in the current
+conversation. See `AGENTS.md` Section 14. Never resolve GitHub review
+conversations silently (Section 15.7).
 
 ## Compatibility constraints
 
-- Target Java 8 only. Do not suggest Java 9+ language features
-  (e.g. `var`, records, switch expressions, sealed types, pattern
-  matching), Java 9+ APIs (e.g. `List.of`, `Optional.orPrimitive`,
-  `HttpClient`, `Stream.toList`), or module-system constructs.
-- Preserve the existing Maven multi-module layout. Do not propose
-  reactor restructures, parent POM rewrites, or aggregator merges
-  unless an explicit tracker item is referenced in the prompt.
-- Do not propose provider rewrites (e.g. canalPlus, arte, pluzz,
-  6play, youtube). Provider changes go through dedicated scoped work
-  tracked in repository docs.
+See `.github/instructions/maven-java.instructions.md` and
+`.cursor/rules/java8-compatibility.mdc` for Java 8 and Maven constraints.
 
 ## Key modules
 
@@ -46,15 +87,24 @@ Follow `AGENTS.md` as the source of truth for:
 
 ## Default validation
 
-Use this command as the default sanity check before opening a PR:
+Pre-commit validation for AI agents is defined in `AGENTS.md` Section
+14.2. Default for code changes:
+
+```
+mvn -B -ntp -DskipTests clean package
+mvn -B -ntp test
+```
+
+For a quick CI-safe sanity check (not sufficient alone before commit
+approval unless the developer explicitly relaxes Section 14.2):
 
 ```
 mvn -B -ntp -DskipTests validate
 ```
 
-Do not invent richer commands (e.g. `verify`, `install`, `package`)
-unless a tracker item explicitly requires them — the reactor is not
-yet stabilized (see `docs/audit-master-baseline.md`).
+Do not invent richer commands (e.g. `verify`, `install`) unless a
+tracker item explicitly requires them — the reactor is not yet
+stabilized (see `docs/audit-master-baseline.md`).
 
 ## Things to avoid suggesting
 

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,35 @@
+---
+applyTo: "docs/**,*.md,AGENTS.md,CONTRIBUTING.md,CHANGELOG.md"
+---
+
+# Habitv documentation instructions (Copilot)
+
+Extends `AGENTS.md` and `docs/AGENTS.md`. Do not contradict them.
+
+## Applies to
+
+Documentation under `docs/`, root policy files, and Markdown contributing
+guides.
+
+## Extends AGENTS.md
+
+- Section 16.21 — documentation freshness; verify claims against repo state.
+- Section 17 — rule changes need changelog + version bump.
+- Section 15.20 — no blind staging; explicit paths only.
+
+## Validation expected
+
+- `git diff --check` for docs-only PRs.
+- No runtime claims without source or tracker reference.
+- Rule doc changes: drift audit + changelog entry.
+
+## Do not change
+
+- Java source, POMs, or workflows in a docs-only PR without reclassification.
+- Do not document future Java/support as current without CI proof.
+- Do not add AI attribution (Section 15.10).
+
+## Agent rules docs
+
+When editing `AGENTS.md` or agent instruction files, update
+`docs/agent-rules-changelog.md` and bump metadata version.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -15,6 +15,8 @@ guides.
 
 - Section 16.21 — documentation freshness; verify claims against repo state.
 - Section 17 — rule changes need changelog + version bump.
+- Section 20 — docs-only speed mode; no Maven unless build/runtime docs
+  change; prefer backlog over new mandatory rules.
 - Section 15.20 — no blind staging; explicit paths only.
 
 ## Validation expected

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -1,0 +1,41 @@
+---
+applyTo: ".github/workflows/**,.github/actions/**"
+---
+
+# Habitv GitHub Actions instructions (Copilot)
+
+Extends `AGENTS.md` and `.github/AGENTS.md`. Do not contradict them.
+
+## Scope
+
+GitHub Actions workflows and related CI configuration under `.github/`.
+
+## Rules
+
+- Do not weaken branch protection or required checks without explicit
+  maintainer approval.
+- Do not use `secrets: inherit` unless explicitly justified and
+  documented.
+- Never commit secrets, tokens, or credentials in workflow files.
+- Keep workflow changes scoped; document validation commands run.
+- Align AI instruction files with root `AGENTS.md` when changing
+  governance docs.
+
+## Validation
+
+For workflow-only changes:
+
+- verify YAML syntax manually or with `actionlint` if available;
+- complete **Workflow safety checklist** (Section 16.8);
+- verify required checks remain aligned with `docs/required-checks-roadmap.md`
+  when applicable;
+- state whether CI was run locally or why it was skipped;
+- use least-privilege `permissions: contents: read` by default.
+
+For code-impacting CI changes, follow root `AGENTS.md` Section 14.2.
+
+## Safety
+
+No chained commands that bypass commit/push/PR approval. No AI
+attribution in commits or PR bodies. See Section 16.7–16.9 for CodeQL,
+dependency review, and CI speed rules.

--- a/.github/instructions/github-pr.instructions.md
+++ b/.github/instructions/github-pr.instructions.md
@@ -1,0 +1,67 @@
+---
+applyTo: ".github/**,AGENTS.md,CONTRIBUTING.md,docs/**,*.md"
+---
+
+# Habitv GitHub and PR instructions (Copilot)
+
+Canonical workflow policy: `AGENTS.md`. Do not contradict it.
+
+## PR target
+
+- Repository: `Mika3578/habitv`
+- Base branch: `develop`
+- Never target `ikfon10/habitv` or other forks
+
+## Git workflow
+
+Never commit, push, create PRs, merge PRs, or resolve review threads
+without explicit developer approval in the current conversation.
+
+Approval prompts (exact wording):
+
+- **Approve commit?**
+- **Approve push?**
+- **Approve force-with-lease push?** (after rebase only)
+
+Branch updates: rebase on `origin/develop` only. Never merge
+`origin/develop`, plain `git pull`, or GitHub Update branch when it
+creates a merge commit. After rebase, push with `--force-with-lease`
+only (never `--force`).
+
+## Copilot review comments
+
+Before PR readiness:
+
+1. Inspect all Copilot review comments and unresolved conversations.
+2. Classify each: accepted and fixed; intentionally rejected with reason;
+   not applicable; outside current PR scope; needs developer decision.
+3. Implement accepted items; reply in English to each comment.
+4. Resolve only after handling and reply. Never resolve to silence review.
+5. Ask developer approval before GitHub commands that resolve threads.
+6. Never resolve conversations silently (`AGENTS.md` Section 15.7).
+
+## Instruction alignment
+
+At task start, report **Instruction files loaded**. When changing AI
+rules, run drift check (`AGENTS.md` Section 15.3).
+
+No AI attribution in commits or PRs (Section 15.10). No chained
+approval-gated commands (Section 15.8). Stage only by explicit path
+(Section 15.20). Provide exact validation evidence (Section 15.15).
+
+Verify branch protection alignment, status checks, and CODEOWNERS before
+PR merge readiness (Sections 15.17–15.19). Ask approval before PR
+comments, labels, review requests, or resolution (Section 15.25).
+
+## PR content
+
+- English only for titles, bodies, and comments
+- Conventional Commits for PR titles
+- No `hbtv-*` or `HBTV*` IDs in branch names, commits, or PR text
+- Fill required sections of `.github/pull_request_template.md`
+- Include exact validation results in the PR body
+
+## Branch naming
+
+Allowed prefixes: `feat/`, `fix/`, `docs/`, `test/`, `refactor/`,
+`chore/`, `ci/`, `build/`. No random tool-generated branch names.

--- a/.github/instructions/github-pr.instructions.md
+++ b/.github/instructions/github-pr.instructions.md
@@ -64,4 +64,4 @@ comments, labels, review requests, or resolution (Section 15.25).
 ## Branch naming
 
 Allowed prefixes: `feat/`, `fix/`, `docs/`, `test/`, `refactor/`,
-`chore/`, `ci/`, `build/`. No random tool-generated branch names.
+`chore/`, `ci/`. No random tool-generated branch names.

--- a/.github/instructions/maven-java.instructions.md
+++ b/.github/instructions/maven-java.instructions.md
@@ -14,20 +14,31 @@ Canonical workflow policy: `AGENTS.md`. Do not contradict it.
 
 ## Pre-commit validation
 
-Before commit approval, default validation for code changes:
+Before commit approval, use the tier from `AGENTS.md` Section 14.2. Do
+**not** require root `clean package` for every code change.
+
+**Standard code:**
 
 ```
-mvn -B -ntp -DskipTests clean package
-mvn -B -ntp test
-```
-
-Targeted module validation when relevant:
-
-```
+mvn -B -ntp validate
 mvn -B -ntp -pl <module> -am test
 ```
 
-If validation is skipped for a code-impacting change, mark:
+**Risky / code-wide:**
+
+```
+mvn -B -ntp validate
+mvn -B -ntp test
+```
+
+**Packaging / full-app** (when in scope and environment supports JavaFX):
+
+```
+mvn -B -ntp -DskipTests clean package
+```
+
+If the required tier was skipped for a code-impacting change without
+developer approval, mark:
 
 > Not ready to commit.
 

--- a/.github/instructions/maven-java.instructions.md
+++ b/.github/instructions/maven-java.instructions.md
@@ -1,0 +1,67 @@
+---
+applyTo: "**/*.java,**/pom.xml,fwk/**,application/**,plugins/**"
+---
+
+# Habitv Maven and Java instructions (Copilot)
+
+Canonical workflow policy: `AGENTS.md`. Do not contradict it.
+
+## Java 8
+
+- Target Java 8 only. No Java 9+ language features or APIs.
+- Preserve the existing Maven multi-module layout.
+- Do not propose reactor restructures without a referenced tracker item.
+
+## Pre-commit validation
+
+Before commit approval, default validation for code changes:
+
+```
+mvn -B -ntp -DskipTests clean package
+mvn -B -ntp test
+```
+
+Targeted module validation when relevant:
+
+```
+mvn -B -ntp -pl <module> -am test
+```
+
+If validation is skipped for a code-impacting change, mark:
+
+> Not ready to commit.
+
+CI-safe baseline (`mvn -B -ntp -DskipTests validate`) is not sufficient
+alone unless the developer explicitly relaxes `AGENTS.md` Section 14.2.
+
+## Dependencies
+
+Do not add, remove, or upgrade dependencies unless the task explicitly
+requires it. Document Java 8 compatibility impact when a change is
+required.
+
+## Avoid suggesting
+
+- `javax.xml.bind` → `jakarta.xml.bind`
+- `youtube-dl` → `yt-dlp` (tracked separately)
+- JavaFX upgrades (tracked separately)
+- Network-dependent tests in the default lifecycle
+- OWASP, SBOM, or static-analysis plugins in this phase
+- Reformatting or renaming outside the change scope
+
+## Real application testing
+
+Before commit approval, prompt the developer to test affected runtime
+behavior. List exact manual tests when UI, plugins, downloads, packaging,
+or external tools are affected.
+
+## Approval gates
+
+Never commit or push automatically. Never chain approval-gated commands
+(Section 15.8). See `AGENTS.md` Section 14 and `.cursor/rules/git-safety.mdc`.
+
+## Generated files
+
+Do not edit generated JAXB/XML files manually unless explicitly required
+(Section 15.12). Document generation command and validation when they
+change.

--- a/.github/instructions/packaging.instructions.md
+++ b/.github/instructions/packaging.instructions.md
@@ -1,0 +1,37 @@
+---
+applyTo: "**/packaging/**,application/habiTv*/**,scripts/stage-package.*"
+---
+
+# Habitv packaging instructions (Copilot)
+
+Extends `AGENTS.md` and `packaging/AGENTS.md` (when present). Do not
+contradict them.
+
+## Scope
+
+Packaging, installers, and platform bundling work.
+
+## Rules
+
+- No installer or binary scope creep unless explicitly requested.
+- No platform packaging (Windows/Linux installers) unless the task
+  requires it.
+- Do not add `.exe`, `.zip`, `.dll`, or other binaries by default.
+- JavaFX packaging constraints apply (Java 8, JavaFX-capable JDK).
+- Document Java 8 and JavaFX assumptions in validation evidence.
+
+## Validation
+
+When packaging scripts or POMs change:
+
+- document exact commands run and pass/fail results;
+- list affected modules;
+- request manual testing of the packaged artifact when runtime behavior
+  changes.
+
+If full build cannot run, mark **Not ready to commit**.
+
+## Safety
+
+No secrets, no downloaded tools committed, no `target/` outputs staged.
+Ask developer before staging any binary or large file.

--- a/.github/instructions/plugins.instructions.md
+++ b/.github/instructions/plugins.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: "plugins/**"
+---
+
+# Habitv plugin instructions (Copilot)
+
+Extends `AGENTS.md` Section 18 and `docs/provider-policy.md`.
+
+## Scope
+
+Provider, downloader, and export plugins under `plugins/`.
+
+## Extends AGENTS.md
+
+- Phase declaration (18.1); status matrix (18.2); metadata contract (18.3).
+- Offline-first testing (18.4); external tools in dedicated PRs (18.5).
+
+## Validation expected
+
+- `mvn -B -ntp -pl plugins/<module> -am test`
+- offline fixtures preferred; document skipped live tests
+
+## Do not change
+
+- DRM bypass; cookies/tokens in repo; provider + dependency in same PR.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,17 @@
+{
+  "recommendations": [
+    "vscjava.vscode-java-pack",
+    "redhat.java",
+    "vscjava.vscode-maven",
+    "vscjava.vscode-java-test",
+    "vscjava.vscode-java-debug",
+    "github.vscode-pull-request-github",
+    "github.vscode-github-actions",
+    "github.copilot",
+    "github.copilot-chat",
+    "redhat.vscode-yaml",
+    "editorconfig.editorconfig",
+    "yzhang.markdown-all-in-one"
+  ],
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -1,0 +1,18 @@
+{
+  "//": "Example workspace settings for Habitv. Copy to settings.json locally.",
+  "//_note": "Do NOT commit machine-specific JAVA_HOME or absolute paths.",
+  "java.configuration.updateBuildConfiguration": "automatic",
+  "java.compile.nullAnalysis.mode": "disabled",
+  "java.import.maven.enabled": true,
+  "maven.terminal.useJavaHome": true,
+  "editor.formatOnSave": false,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[markdown]": {
+    "editor.wordWrap": "on"
+  },
+  "[java]": {
+    "editor.tabSize": 4
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,7 +337,7 @@ Before opening a PR:
    Section 14.5).
 3. Complete Section 14 pre-commit and pre-push gates, including
    Copilot review handling (Section 14.4).
-4. Run validation per Section 14.2 (full gate) or document why it was
+4. Run validation per Section 14.2 (tiered gate) or document why it was
    skipped for docs-only work.
 5. Include exact validation results in the PR body.
 6. Ask for explicit developer approval before `gh pr create`
@@ -726,23 +726,36 @@ exactly:
 
 > Approve force-with-lease push?
 
-### 14.2 Full build and test validation gate
+### 14.2 Maven validation gate (tiered)
 
-Before asking for commit approval, the agent must run the complete
-validation gate unless explicitly told otherwise by the developer.
+Before asking for commit approval, run the validation tier that matches the
+change unless the developer explicitly relaxes this gate.
 
-Default validation for code changes:
+| Tier | When | Commands |
+|------|------|----------|
+| **Docs-only** | Markdown/rules only; no Java, POM, workflow, or runtime files | Maven **may be skipped** with a clear note |
+| **Standard code** | Typical module or narrow code changes | `mvn -B -ntp validate` plus targeted module tests when relevant |
+| **Risky / code-wide** | Multi-module, core framework, or broad behavior changes | `mvn -B -ntp test` (add `-pl <module> -am` when scoped) |
+| **Packaging / release / JavaFX / full app** | Packaging, release prep, or full-app validation | `mvn -B -ntp -DskipTests clean package` **only** when the environment supports it (JavaFX/`jdk.home`) and scope requires it |
+
+**Standard code** example:
 
 ```bash
-mvn -B -ntp -DskipTests clean package
+mvn -B -ntp validate
+mvn -B -ntp -pl <module> -am test   # when module-specific
+```
+
+**Risky / code-wide** example:
+
+```bash
+mvn -B -ntp validate
 mvn -B -ntp test
 ```
 
-When a specific Maven module is changed, also run the relevant targeted
-module validation, for example:
+**Packaging / full-app** example (when in scope and environment supports it):
 
 ```bash
-mvn -B -ntp -pl <module> -am test
+mvn -B -ntp -DskipTests clean package
 ```
 
 For documentation-only changes, the agent may skip Maven validation only
@@ -750,17 +763,16 @@ if it clearly states:
 
 - this is documentation-only;
 - no Java source, POM, workflow, or runtime file was changed;
-- full Maven validation was not run;
+- Maven validation was not run;
 - the branch is not validated for runtime behavior.
 
-If full build or full tests are skipped for any code-impacting change,
-the agent must mark the work as:
+If the required tier for a code-impacting change was skipped without
+developer approval, mark the work as:
 
 > Not ready to commit.
 
 Section 6 documents CI-safe baselines; this subsection is the
-**pre-commit** gate and is stricter unless the developer explicitly
-relaxes it.
+**pre-commit** gate unless the developer explicitly relaxes it.
 
 ### 14.3 Real functional testing gate
 
@@ -984,7 +996,6 @@ Branch names must use allowed conventional prefixes such as:
 - `refactor/`
 - `chore/`
 - `ci/`
-- `build/`
 
 The agent must not create random Claude/Cursor-style branch names.
 
@@ -1172,13 +1183,22 @@ Document the drift check result in the pre-commit checklist.
 Before asking for commit approval, the agent must run or document the
 relevant repository health checks.
 
-**For code changes:**
+**For code changes:** run the tier from Section 14.2 (docs-only skip,
+standard `validate` + targeted tests, risky `test`, packaging `clean package`
+when in scope).
+
+Example **standard code** tier:
 
 ```bash
-mvn -B -ntp -DskipTests clean package
+mvn -B -ntp validate
+mvn -B -ntp -pl <module> -am test   # when module-specific
+```
+
+Example **risky / code-wide** tier:
+
+```bash
+mvn -B -ntp validate
 mvn -B -ntp test
-# plus targeted module tests when relevant:
-mvn -B -ntp -pl <module> -am test
 ```
 
 **For documentation-only AI-rule changes:**
@@ -1948,15 +1968,27 @@ yet validated**.
 
 ### 16.11 Maven quality gate
 
-For Maven changes, prefer explicit validation.
+For Maven changes, prefer explicit validation per Section 14.2 tiers.
 
-Default commands:
+**Standard code** (typical module or POM change):
 
 ```bash
 mvn -B -ntp validate
-mvn -B -ntp -DskipTests clean package
-mvn -B -ntp test
 mvn -B -ntp -pl <module> -am test   # when module-specific
+```
+
+**Risky / code-wide** changes:
+
+```bash
+mvn -B -ntp validate
+mvn -B -ntp test
+```
+
+**Packaging / release / full-app** (only when in scope and JavaFX/`jdk.home`
+environment supports it):
+
+```bash
+mvn -B -ntp -DskipTests clean package
 ```
 
 For dependency analysis:
@@ -2118,7 +2150,7 @@ PR separate from behavior changes.
 ### 16.24 Branch naming for fast work
 
 Use predictable branch names: `fix/`, `feat/`, `docs/`, `test/`, `ci/`,
-`chore/`, `build/`, `refactor/` + short topic.
+`chore/`, `refactor/` + short topic.
 
 Avoid: `claude/*`, `cursor/*`, random generated names, ticket/style IDs,
 vague names like `update-stuff`. See Section 4.
@@ -2514,12 +2546,34 @@ See [`docs/dependency-policy.md`](docs/dependency-policy.md).
 SBOM generation (e.g. CycloneDX Maven plugin) belongs in a **dedicated
 security/tooling PR** — not unrelated work.
 
+**Prerequisites before enablement or CI changes:**
+
+- a dedicated tracker item;
+- a dedicated security/tooling PR;
+- an ADR when the change affects repository policy or CI behavior;
+- no enablement in unrelated PRs.
+
+Section 2 still forbids adding OWASP/SBOM/static-analysis plugins without
+an explicit tracker item and ADR.
+
 Document where SBOM is generated. Do not commit generated SBOM files unless
 required. Prefer CI artifact upload.
 
 ### 18.10 OWASP Dependency-Check rule
 
 If OWASP Dependency-Check is used:
+
+**Prerequisites before enablement or CI changes:**
+
+- a dedicated tracker item;
+- a dedicated security/tooling PR;
+- an ADR when the change affects repository policy or CI behavior;
+- no enablement in unrelated PRs.
+
+Section 2 still forbids adding OWASP/SBOM/static-analysis plugins without
+an explicit tracker item and ADR.
+
+Operational rules:
 
 - do not disable it to green CI;
 - do not cache corrupted vulnerability databases;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,128 @@ Instructions for **Codex, Cursor, Claude, Copilot** and any other AI
 coding agent working on the Habitv repository. These instructions
 complement, but do not replace, the human review process.
 
-**Source of truth policy** — `AGENTS.md` is the single source of truth
-for AI-agent workflow policy in this repository. Tool-specific files
-must reference `AGENTS.md` and must not duplicate conflicting workflow
-rules.
+## Agent rules metadata
+
+* **Version:** 1.3.0
+* **Last updated:** 2026-05-28
+* **Maintainer:** repository maintainer
+* **Scope:** Habitv AI-assisted development workflow
+* **Canonical source:** `AGENTS.md`
+* **Related files:** `.cursor/rules/`, `.github/copilot-instructions.md`,
+  `.github/instructions/`, `CLAUDE.md`, `GEMINI.md`, nested `AGENTS.md`,
+  `docs/dev-workflow.md`, `docs/provider-policy.md`, `docs/release-policy.md`,
+  `docs/dependency-policy.md`, `docs/security-policy.md`,
+  `docs/agent-rules-changelog.md`, `docs/agent-rules-backlog.md`,
+  `docs/modernization-backlog.md`, `docs/obsolescence-register.md`,
+  `docs/maintainability-policy.md`, `docs/maintenance-dashboard.md`,
+  `docs/adr/`, `docs/decision-log.md`
+
+When rules change, update **Version** and **Last updated**, and add an
+entry to [`docs/agent-rules-changelog.md`](docs/agent-rules-changelog.md).
+
+Versioning: **patch** — wording/examples; **minor** — new rule/section;
+**major** — stricter workflow, changed approval model, validation policy,
+or removed major rule.
+
+**Source of truth policy** — `AGENTS.md` is the **canonical source of
+truth** for repository-wide AI agent behavior. All other AI instruction
+files must either:
+
+- point to `AGENTS.md`;
+- summarize `AGENTS.md` without contradicting it; or
+- contain path-specific rules that **extend** `AGENTS.md`.
+
+When they conflict with `AGENTS.md`, `AGENTS.md` wins.
+
+**Files that must not drift from `AGENTS.md`:**
+
+- `.cursor/rules/*.mdc`
+- `.cursor/rules/*.md`
+- `.github/copilot-instructions.md`
+- `.github/instructions/*.instructions.md`
+- `CLAUDE.md`
+- `GEMINI.md`
+- any Codex, Cursor, Copilot, Claude, or Gemini instruction file
+- nested `AGENTS.md` files (they extend; they do not replace)
+
+If a rule is changed in one place, the agent must inspect the related
+instruction files and update them, or explicitly state why no update
+is needed.
+
+### Tool-specific instruction files
+
+These files mirror or point to the same mandatory rules. When they
+conflict with `AGENTS.md`, `AGENTS.md` wins.
+
+| File | Role |
+|------|------|
+| [`.cursor/rules/habitv-master.mdc`](.cursor/rules/habitv-master.mdc) | Always-on Habitv modernization guardrails |
+| [`.cursor/rules/git-safety.mdc`](.cursor/rules/git-safety.mdc) | Git workflow, workspace safety, approval gates |
+| [`.cursor/rules/maven-validation.mdc`](.cursor/rules/maven-validation.mdc) | Pre-commit Maven build/test validation |
+| [`.cursor/rules/pr-review.mdc`](.cursor/rules/pr-review.mdc) | PR policy, Copilot review handling |
+| [`.cursor/rules/java8-compatibility.mdc`](.cursor/rules/java8-compatibility.mdc) | Java 8 and dependency constraints |
+| [`.cursor/rules/pr-style.mdc`](.cursor/rules/pr-style.mdc) | PR and squash-merge metadata style |
+| [`.github/copilot-instructions.md`](.github/copilot-instructions.md) | Repository-wide Copilot instructions |
+| [`.github/instructions/maven-java.instructions.md`](.github/instructions/maven-java.instructions.md) | Path-specific Copilot rules for Java/POM |
+| [`.github/instructions/github-pr.instructions.md`](.github/instructions/github-pr.instructions.md) | Path-specific Copilot rules for PR/GitHub workflow |
+| [`.github/instructions/plugins.instructions.md`](.github/instructions/plugins.instructions.md) | Path-specific Copilot rules for plugins |
+| [`.github/instructions/github-actions.instructions.md`](.github/instructions/github-actions.instructions.md) | Path-specific Copilot rules for GitHub Actions |
+| [`.github/instructions/packaging.instructions.md`](.github/instructions/packaging.instructions.md) | Path-specific Copilot rules for packaging |
+| [`CLAUDE.md`](CLAUDE.md) | Claude Code pointer to `AGENTS.md` |
+| [`GEMINI.md`](GEMINI.md) | Gemini pointer to `AGENTS.md` |
+| [`plugins/AGENTS.md`](plugins/AGENTS.md) | Provider/plugin path-specific extensions |
+| [`.github/AGENTS.md`](.github/AGENTS.md) | CI, branch protection, PR, GitHub Actions |
+| [`docs/AGENTS.md`](docs/AGENTS.md) | Documentation-only work |
+| [`scripts/AGENTS.md`](scripts/AGENTS.md) | Maintenance scripts |
+| [`packaging/AGENTS.md`](packaging/AGENTS.md) | Packaging and installer work (when present) |
+| [`docs/dev-workflow.md`](docs/dev-workflow.md) | Developer and agent workflow guide |
+| [`docs/dependency-policy.md`](docs/dependency-policy.md) | Dependency update policy |
+| [`docs/security-policy.md`](docs/security-policy.md) | Security update policy for agents |
+| [`docs/provider-policy.md`](docs/provider-policy.md) | Provider status, metadata, testing |
+| [`docs/release-policy.md`](docs/release-policy.md) | Release and packaging readiness |
+| [`docs/modernization-backlog.md`](docs/modernization-backlog.md) | Fast modernization backlog |
+| [`docs/obsolescence-register.md`](docs/obsolescence-register.md) | Obsolete providers and endpoints |
+| [`.cursor/rules/habitv-providers.mdc`](.cursor/rules/habitv-providers.mdc) | Provider/plugin Habitv rules |
+| [`.cursor/rules/habitv-maintainability.mdc`](.cursor/rules/habitv-maintainability.mdc) | Maintainability guardrails |
+| [`docs/maintainability-policy.md`](docs/maintainability-policy.md) | DoD, tests, config, user data |
+| [`docs/maintenance-dashboard.md`](docs/maintenance-dashboard.md) | Lightweight maintenance dashboard |
+| [`docs/adr/README.md`](docs/adr/README.md) | ADR template and workflow |
+| [`.vscode/extensions.json`](.vscode/extensions.json) | Recommended VS Code/Cursor extensions |
+| [`.vscode/settings.example.json`](.vscode/settings.example.json) | Example workspace settings (no machine paths) |
+| [`.cursor/rules/dependencies.mdc`](.cursor/rules/dependencies.mdc) | Dependency and security update rules |
+| [`.cursor/rules/workflows.mdc`](.cursor/rules/workflows.mdc) | GitHub Actions and CI rules |
+| [`.cursor/rules/cursor-ide.mdc`](.cursor/rules/cursor-ide.mdc) | Cursor/VS Code project configuration |
+| [`.cursor/rules/00-canonical-source.mdc`](.cursor/rules/00-canonical-source.mdc) | Canonical source pointer (always on) |
+| [`.cursor/rules/90-rule-evolution.mdc`](.cursor/rules/90-rule-evolution.mdc) | Rule evolution and drift audit |
+| [`.cursor/rules/README.md`](.cursor/rules/README.md) | Cursor rules index and module map |
+| [`docs/agent-rules-changelog.md`](docs/agent-rules-changelog.md) | AI rules version history |
+| [`docs/agent-rules-backlog.md`](docs/agent-rules-backlog.md) | Future rule improvements |
+| [`.github/instructions/docs.instructions.md`](.github/instructions/docs.instructions.md) | Path-specific Copilot rules for docs |
+
+### AI agent workflow index
+
+Use this map to find the canonical rule for each workflow area:
+
+| Area | Primary sections |
+|------|------------------|
+| Repository context | §1 |
+| Mandatory safety rules | §2, §14.6–14.8 |
+| Git workflow | §3, §4, §14.5, §14.11–14.12 |
+| Validation workflow | §6, §14.2–14.3 |
+| Maven / Java 8 compatibility | §2, §6, §14.9 |
+| PR review workflow | §5, §14.10 |
+| Copilot comments workflow | §14.4 |
+| Commit and push approval gates | §14.1, §14.13–14.14 |
+| Prohibited actions | §2, §14.1, §14.8 |
+| Instruction governance | §15 |
+| Safety and validation hardening | §15.8–15.28 |
+| Branch protection and PR readiness | §15.16–15.19, §15.25 |
+| Fast safe modernization | §16 |
+| Evolutionary rules governance | §17 |
+| Habitv-specific modernization | §18 |
+| Habitv maintainability guardrails | §19 |
+| Documentation sync | §12 |
+| Hard-rule ADR lifecycle | §13 |
 
 > 📚 **Companion files** (read them before acting):
 > - [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch / commit / PR policy
@@ -146,7 +264,8 @@ If an existing branch or open PR already covers the same scope, do not
 create a duplicate. Reuse the existing branch/PR, or create a clearly
 scoped follow-up branch.
 
-Keep history linear on work branches (no merge commits).
+Keep history linear on work branches (no merge commits). See Section 14.5
+for the required rebase-only branch update flow.
 
 ---
 
@@ -209,12 +328,15 @@ Required PR body sections:
 
 Before opening a PR:
 1. Verify no open PR already covers the same scope.
-2. Verify the branch is based on the latest `develop`.
-3. Run:
-   - `git status --short`
-   - docs-only PR: `git diff --check`
-   - non-docs PR: `mvn -B -ntp -DskipTests validate`
-4. Include exact validation results in the PR body.
+2. Verify the branch is based on the latest `develop` (rebase only;
+   Section 14.5).
+3. Complete Section 14 pre-commit and pre-push gates, including
+   Copilot review handling (Section 14.4).
+4. Run validation per Section 14.2 (full gate) or document why it was
+   skipped for docs-only work.
+5. Include exact validation results in the PR body.
+6. Ask for explicit developer approval before `gh pr create`
+   (Section 14.1).
 
 If tracking is needed, use GitHub-native tracking:
 - a real GitHub issue number (e.g. `#123`)
@@ -227,6 +349,10 @@ Do not invent local tracker IDs.
 ---
 
 ## 🧪 6. Validation policy
+
+**Pre-commit gate** — Section 14.2 requires full build and test
+validation before commit approval unless the developer explicitly relaxes
+it or the change is documentation-only with a clear skip statement.
 
 Validation baseline by PR type:
 
@@ -441,7 +567,7 @@ Rule classes and their breakage consequence:
 | Class | Found in | Breakage consequence |
 |------|---------|----------------------|
 | 🔴 **Hard rule** | Section 2 | PR reverted; incident logged |
-| 🟠 **Process rule** | Sections 3–12 | PR amended; warning logged |
+| 🟠 **Process rule** | Sections 3–15 | PR amended; warning logged |
 | 🟣 **Meta-rule** | Section 13 | PR blocked at review; cannot proceed without compliance |
 
 ### 13.2 Create a rule
@@ -531,3 +657,2204 @@ Any change to `AGENTS.md` must leave traceable evidence:
 
 A change that breaks the audit trail is invalid and must be
 reverted.
+
+---
+
+## 🛑 14. Manual validation gate before commit and push
+
+These gates apply to **every** AI coding agent (Cursor, Claude, Codex,
+Copilot, and equivalents). They are mandatory before commit, push, PR
+creation, branch update, or any action that changes remote state.
+
+Previous approval from another session is **never** valid.
+
+### 14.1 Manual commit and push approval gate
+
+AI agents **may**:
+
+- inspect files;
+- edit files;
+- propose patches;
+- run safe validation commands;
+- prepare a commit plan;
+- prepare a PR description.
+
+AI agents **must not** run any of these commands without explicit
+developer approval **in the current conversation**:
+
+- `git commit`
+- `git push`
+- `git push --force`
+- `git push --force-with-lease`
+- `gh pr create`
+- `gh pr merge`
+- `gh pr review`
+- `gh pr comment`
+- requesting or re-requesting review
+- adding PR labels
+- editing PR title or body
+- resolving GitHub review conversations
+- deleting branches
+- deleting files outside the requested scope
+- destructive cleanup commands
+- any equivalent command that publishes, merges, comments, or changes
+  remote state
+
+Do not chain approval-gated actions without separate approval for each
+(Section 15.8). Forbidden without approval:
+
+```bash
+git add -A && git commit -m "..."
+git commit -m "..." && git push
+```
+
+Before any commit, the agent must ask exactly:
+
+> Approve commit?
+
+Before any normal push, the agent must ask exactly:
+
+> Approve push?
+
+Before any rebased push or rewritten-history push, the agent must ask
+exactly:
+
+> Approve force-with-lease push?
+
+### 14.2 Full build and test validation gate
+
+Before asking for commit approval, the agent must run the complete
+validation gate unless explicitly told otherwise by the developer.
+
+Default validation for code changes:
+
+```bash
+mvn -B -ntp -DskipTests clean package
+mvn -B -ntp test
+```
+
+When a specific Maven module is changed, also run the relevant targeted
+module validation, for example:
+
+```bash
+mvn -B -ntp -pl <module> -am test
+```
+
+For documentation-only changes, the agent may skip Maven validation only
+if it clearly states:
+
+- this is documentation-only;
+- no Java source, POM, workflow, or runtime file was changed;
+- full Maven validation was not run;
+- the branch is not validated for runtime behavior.
+
+If full build or full tests are skipped for any code-impacting change,
+the agent must mark the work as:
+
+> Not ready to commit.
+
+Section 6 documents CI-safe baselines; this subsection is the
+**pre-commit** gate and is stricter unless the developer explicitly
+relaxes it.
+
+### 14.3 Real functional testing gate
+
+Before asking for commit approval, the agent must invite the developer
+to test the real application behavior affected by the change.
+
+Required wording:
+
+> Please test the real application behavior affected by this change
+> before approving the commit.
+
+If the change affects Habitv runtime behavior, UI behavior, plugin
+discovery, downloads, packaging, update behavior, or external tools,
+the agent must list the exact manual tests the developer should
+perform.
+
+### 14.4 Copilot review comments gate
+
+Before a PR is considered ready, the agent must inspect all GitHub
+Copilot review comments and all unresolved PR review conversations.
+
+Each Copilot recommendation must be classified as one of:
+
+- accepted and fixed;
+- intentionally rejected with a clear reason;
+- not applicable;
+- outside current PR scope;
+- needs developer decision.
+
+The agent must implement accepted recommendations before marking the
+work ready.
+
+The agent must reply to each Copilot comment in English with a short
+explanation of what was done or why it was not applied.
+
+The agent must **not** mark a Copilot conversation as resolved before:
+
+- the recommendation has been reviewed;
+- the recommendation has been handled;
+- the reply has been posted;
+- any required code/doc change has been committed and pushed, if
+  applicable.
+
+The agent must never mark Copilot comments as resolved just to silence
+the review.
+
+If a Copilot recommendation is risky or outside the PR scope, the agent
+must explain that in a reply and ask the developer whether to defer it.
+
+If resolving review conversations requires a GitHub command or UI
+action, the agent must ask for explicit developer approval before
+doing it.
+
+See also Section 15.7 (GitHub review resolution gate).
+
+### 14.5 Branch update and linear history gate
+
+AI agents must keep Habitv PR history linear.
+
+When a PR branch needs to be updated with the latest `develop`, the
+branch must be rebased on `origin/develop`.
+
+Allowed branch update flow:
+
+```bash
+git fetch origin --prune
+git rebase origin/develop
+```
+
+Disallowed branch update flow:
+
+- `git merge origin/develop`
+- plain `git pull`
+- `git pull` without `--rebase`
+- GitHub **Update branch** if it creates a merge commit
+- any workflow that creates a merge commit just to update the PR branch
+
+If rebase conflicts occur, the agent must:
+
+- stop and list the conflicting files;
+- explain the intended conflict resolution;
+- resolve conflicts carefully;
+- continue with `git rebase --continue` only after the resolution is
+  clear;
+- rerun the relevant build and test validation after the rebase.
+
+If the branch was already pushed before the rebase, the rebased branch
+may only be pushed with:
+
+```bash
+git push --force-with-lease
+```
+
+The agent must never run:
+
+```bash
+git push --force
+```
+
+Before any force-with-lease push, the agent must ask exactly:
+
+> Approve force-with-lease push?
+
+### 14.6 Workspace safety gate
+
+Before editing files, committing, rebasing, pushing, or resolving PR
+comments, the agent must inspect the current Git state:
+
+```bash
+git status --short
+git branch --show-current
+git remote -v
+git log --oneline --decorate -n 10
+```
+
+The agent must not work directly on:
+
+- `develop`
+- `main`
+- `master`
+
+If the workspace contains uncommitted developer changes, the agent must
+not overwrite, delete, stage, or commit them without explicit developer
+approval.
+
+The agent must distinguish clearly between:
+
+- files changed by the agent;
+- files already modified before the task started;
+- generated files;
+- unrelated local changes.
+
+### 14.7 Scope control gate
+
+The agent must keep the change limited to the requested task.
+
+The agent must **not**:
+
+- perform unrelated cleanup;
+- reformat unrelated files;
+- rename files unless required;
+- update dependencies unless explicitly requested;
+- change generated files unless the generation command is part of the
+  task;
+- mix documentation, refactoring, behavior changes, dependency
+  changes, and formatting changes in the same commit unless explicitly
+  approved.
+
+Before asking for commit approval, the agent must list any out-of-scope
+change and explain why it was necessary.
+
+### 14.8 Destructive command gate
+
+The agent must never run destructive Git or filesystem commands without
+explicit developer approval.
+
+Restricted commands include:
+
+- `git reset --hard`
+- `git clean -fd`
+- `git checkout -- <file>`
+- `git restore <file>`
+- `git branch -D`
+- deleting files or directories outside the requested scope
+- force-pushing without `--force-with-lease`
+
+If one of these commands is needed, the agent must explain:
+
+- why it is needed;
+- what data may be lost;
+- the safer alternative if available;
+- the exact command it wants to run.
+
+Only then may the agent ask for explicit approval.
+
+### 14.9 Dependency change gate
+
+The agent must not add, remove, or upgrade dependencies unless the task
+explicitly requires it.
+
+If a dependency change is required, the agent must document:
+
+- dependency name;
+- old version;
+- new version;
+- reason for the change;
+- compatibility impact with Java 8;
+- validation performed.
+
+For Habitv, Java 8 compatibility must be preserved unless a dedicated
+migration task explicitly says otherwise.
+
+### 14.10 PR target and repository gate
+
+PRs must target:
+
+- repository: `Mika3578/habitv`
+- base branch: `develop`
+
+The agent must never open PRs against forks such as `ikfon10/habitv`.
+
+Before PR creation, the agent must show:
+
+- source branch;
+- target repository;
+- target base branch;
+- PR title;
+- PR body;
+- validation result.
+
+The agent must ask for explicit approval before running `gh pr create`.
+
+### 14.11 Branch naming gate
+
+Branch names must use allowed conventional prefixes such as:
+
+- `feat/`
+- `fix/`
+- `docs/`
+- `test/`
+- `refactor/`
+- `chore/`
+- `ci/`
+- `build/`
+
+The agent must not create random Claude/Cursor-style branch names.
+
+See Section 4 for duplicate-prevention checks before creating a branch.
+
+### 14.12 Commit and PR naming gate
+
+Commit messages, PR titles, docs, and comments must be in English.
+
+Use Conventional Commits (Section 3).
+
+Do not use internal style IDs in branch names, commit messages, PR
+titles, PR bodies, or docs. Forbidden patterns include `hbtv-006`,
+`HBTV-015`, `hbtv-*`, and `HBTV*`.
+
+Commit messages, PR titles, PR bodies, and documentation must **not**
+include AI attribution (Section 15.10).
+
+### 14.13 Required pre-commit checklist
+
+Before asking **Approve commit?**, the agent must provide:
+
+```markdown
+## Pre-commit checklist
+
+* Current branch:
+* Base branch:
+* Changed files:
+* Functional impact:
+* Out-of-scope changes:
+* Copilot comments handled:
+* Build commands run:
+* Test commands run:
+* Manual real-application testing requested:
+* Sensitive-data check:
+* Validation evidence:
+* Known failing tests:
+* Known risks:
+* Repo health status:
+* Review readiness status:
+* Commit classification:
+* Staging check:
+* Tool versions recorded:
+* Branch protection alignment:
+* Status checks summary:
+* Instruction drift check:
+* Proposed commit message:
+
+If useful out-of-scope work was found, also include **Follow-up
+candidates** (Section 15.26).
+```
+
+The agent must not commit until the developer explicitly replies with
+commit approval.
+
+### 14.14 Required pre-push checklist
+
+Before asking **Approve push?** or **Approve force-with-lease push?**,
+the agent must provide:
+
+```markdown
+## Pre-push checklist
+
+* Current branch:
+* Remote target:
+* Push command planned:
+* Whether the branch was rebased:
+* Whether --force-with-lease is required:
+* Latest validation result:
+* PR target repository must be Mika3578/habitv:
+* PR target branch must be develop:
+```
+
+The agent must not push until the developer explicitly replies with
+push approval.
+
+---
+
+## 📋 15. Agent instruction governance and session gates
+
+These gates apply at task start, during AI-rule updates, and when
+stopping before commit, push, PR creation, or unresolved review work.
+
+### 15.1 Instruction loading check
+
+At the start of **every** coding task, the agent must identify which
+instruction files were found and read.
+
+The agent must report:
+
+```markdown
+## Instruction files loaded
+
+* AGENTS.md:
+* .cursor/rules:
+* .github/copilot-instructions.md:
+* .github/instructions:
+* CLAUDE.md:
+* Other agent files:
+```
+
+If a relevant instruction file exists but was not read, the agent must
+stop and read it before editing files.
+
+Relevant files include any path-specific nested `AGENTS.md` under the
+directories being edited (Section 15.3).
+
+### 15.2 Nested AGENTS.md gate
+
+Use nested `AGENTS.md` files only when a subdirectory needs specific
+rules.
+
+Recommended nested files:
+
+| Path | Scope |
+|------|-------|
+| [`plugins/AGENTS.md`](plugins/AGENTS.md) | Provider/plugin work |
+| [`.github/AGENTS.md`](.github/AGENTS.md) | CI, branch protection, PR, GitHub Actions |
+| [`packaging/AGENTS.md`](packaging/AGENTS.md) | Packaging and installer work |
+| [`docs/AGENTS.md`](docs/AGENTS.md) | Documentation-only work |
+| [`scripts/AGENTS.md`](scripts/AGENTS.md) | Maintenance scripts |
+
+Nested rules must **extend** the root `AGENTS.md`, not replace it.
+When nested rules add path-specific constraints, they must reference
+the root section they extend.
+
+Recommended path-specific Copilot instruction files:
+
+| Path | Scope |
+|------|-------|
+| [`.github/instructions/plugins.instructions.md`](.github/instructions/plugins.instructions.md) | Provider/plugin work |
+| [`.github/instructions/maven-java.instructions.md`](.github/instructions/maven-java.instructions.md) | Java/POM changes |
+| [`.github/instructions/github-actions.instructions.md`](.github/instructions/github-actions.instructions.md) | GitHub Actions workflows |
+| [`.github/instructions/github-pr.instructions.md`](.github/instructions/github-pr.instructions.md) | PR and GitHub workflow |
+| [`.github/instructions/packaging.instructions.md`](.github/instructions/packaging.instructions.md) | Packaging and installers |
+
+Recommended path-specific content:
+
+- **`plugins/`** — provider/plugin changes, offline fixtures, no
+  live-network-only validation, Java 8 compatibility.
+- **`.github/`** — CI workflow safety, no `secrets: inherit` unless
+  explicitly justified, branch protection awareness.
+- **`packaging/`** — no installer/binary scope creep, no platform
+  packaging unless requested.
+- **`docs/`** — docs-only validation, no runtime claims without source.
+- **`scripts/`** — no destructive scripts, cross-platform
+  PowerShell/Bash parity when applicable.
+
+### 15.3 Rule drift prevention gate
+
+The repository must avoid contradictory AI rules.
+
+Before finishing an AI-rule update, the agent must check for conflicting
+instructions about:
+
+- commit approval;
+- push approval;
+- PR creation;
+- PR merge;
+- rebase vs merge;
+- Maven validation;
+- Java 8 compatibility;
+- Copilot comment handling;
+- branch naming;
+- PR target repository;
+- destructive commands;
+- chained commands that bypass approval;
+- secret/credential handling;
+- AI attribution in commits or PRs;
+- generated-file and binary-file rules;
+- branch protection alignment;
+- status check verification;
+- CODEOWNERS review;
+- explicit staging rules;
+- PR comment actions;
+- commit content classification.
+
+If conflicts are found, resolve them by making `AGENTS.md` the source
+of truth and updating or trimming conflicting tool-specific files.
+
+Document the drift check result in the pre-commit checklist.
+
+### 15.4 Repo health gate
+
+Before asking for commit approval, the agent must run or document the
+relevant repository health checks.
+
+**For code changes:**
+
+```bash
+mvn -B -ntp -DskipTests clean package
+mvn -B -ntp test
+# plus targeted module tests when relevant:
+mvn -B -ntp -pl <module> -am test
+```
+
+**For documentation-only AI-rule changes:**
+
+- verify Markdown formatting manually;
+- verify there are no contradictory duplicate rules;
+- verify instruction files point to the same workflow;
+- verify no Java source, POM, dependency, workflow, or runtime file
+  changed.
+
+The final status must be exactly one of:
+
+- **Ready for developer manual testing**
+- **Ready for commit approval**
+- **Ready for push approval**
+- **Ready for PR review**
+- **Not ready to commit**
+- **Not ready to merge**
+- **Needs developer decision**
+
+Use **Not ready to merge** when required status checks are pending or
+failing (Section 15.18), or when required code-owner review is missing
+(Section 15.19).
+
+Include the chosen status in the pre-commit checklist. See Section 15.16
+for PR review readiness criteria.
+
+### 15.5 No intermediate commit gate
+
+The agent must not create incremental "work in progress" commits.
+
+The agent must keep working locally until:
+
+- the requested change is complete;
+- validation is run or clearly marked as skipped;
+- known risks are documented;
+- the manual testing request is written;
+- the developer approves the commit.
+
+The agent must not push after every commit. Push only when the work is
+coherent, reviewed, and explicitly approved.
+
+### 15.6 Session handoff gate
+
+When stopping before commit, push, PR creation, PR merge, or unresolved
+review work, the agent must provide a handoff:
+
+```markdown
+## Handoff
+
+* Current branch:
+* Latest local commit:
+* Files changed:
+* Validation run:
+* Validation not run:
+* Manual tests still needed:
+* Copilot comments still open:
+* PR status:
+* Next recommended action:
+* Exact command not yet approved:
+```
+
+### 15.7 GitHub review resolution gate
+
+A GitHub PR review conversation may only be resolved when:
+
+- the recommendation was implemented; **or**
+- a clear English reply explains why it was rejected, not applicable,
+  or deferred;
+- the developer approved resolving it if the action changes GitHub
+  state.
+
+Never resolve conversations silently.
+
+This applies to Copilot review comments (Section 14.4) and all other
+GitHub PR review threads.
+
+### 15.8 Chained command safety gate
+
+AI agents must not hide or bypass approval requirements through chained
+commands.
+
+The agent must never run a command chain that includes any approval-gated
+action unless **each** gated action was explicitly approved first.
+
+Approval-gated actions include:
+
+- `git commit`
+- `git push`
+- `git push --force-with-lease`
+- `git push --force`
+- `gh pr create`
+- `gh pr merge`
+- `gh pr comment`
+- `gh pr review`
+- resolving GitHub review conversations
+- deleting branches
+- deleting files outside the requested scope
+- destructive cleanup commands
+
+Forbidden examples without explicit approval:
+
+```bash
+git add -A && git commit -m "..."
+git commit -m "..." && git push
+git fetch origin && git rebase origin/develop && git push --force-with-lease
+gh pr comment ... && gh pr merge ...
+```
+
+Any script that performs commit, push, PR creation, PR merge, or review
+resolution indirectly is also forbidden without approval.
+
+Each gated action requires a separate checklist and separate developer
+approval.
+
+### 15.9 Secret and credential safety gate
+
+The agent must never commit secrets, credentials, private tokens,
+cookies, browser sessions, API keys, Maven credentials, GitHub tokens,
+local paths containing credentials, or private machine-specific
+configuration.
+
+Before asking for commit approval, the agent must inspect the diff for
+sensitive data.
+
+Sensitive files and patterns include:
+
+- `.env`
+- `settings.xml`
+- credentials files
+- browser cookie exports
+- session files
+- access tokens and refresh tokens
+- private keys
+- local absolute paths that reveal private setup
+- generated logs containing tokens, cookies, headers, or credentials
+
+If sensitive data is found, the agent must stop and ask the developer
+how to remove or redact it.
+
+### 15.10 AI attribution gate
+
+Commit messages, PR titles, PR bodies, and documentation must **not**
+include AI attribution.
+
+Forbidden examples:
+
+- `Generated by Claude`, `Generated by Cursor`, `Generated by Copilot`,
+  `Generated by ChatGPT`, `AI-generated`
+- `Co-authored-by: Claude`, `Co-authored-by: Cursor`,
+  `Co-authored-by: Copilot`, `Co-authored-by: ChatGPT`
+
+The author and committer identity must remain the developer's normal Git
+identity.
+
+### 15.11 Known failing tests gate
+
+The agent must not ask for commit or push approval if there are known
+failing tests unless the final status is clearly marked:
+
+> Not ready to commit.
+
+If tests fail, the agent must:
+
+- list the failing command;
+- summarize the failure;
+- identify whether the failure is related to the current change;
+- propose the next fix;
+- avoid committing until the developer explicitly approves committing
+  despite the failure.
+
+### 15.12 Generated files gate
+
+The agent must not edit generated files manually unless the task
+explicitly requires it.
+
+If generated files changed, the agent must document:
+
+- which generation command produced them;
+- why the generated output is expected;
+- whether source files were changed consistently;
+- how the generated output was validated.
+
+For Habitv, generated JAXB/XML-related files must not be changed
+casually. Any generated-source change requires a dedicated explanation
+and validation.
+
+### 15.13 Binary and large file gate
+
+The agent must not add binaries, archives, installers, downloaded tools,
+videos, screenshots, or large generated artifacts unless explicitly
+requested.
+
+Forbidden by default:
+
+- `.zip`, `.exe`, `.dll`
+- `.jar` generated artifacts
+- `target/` outputs
+- downloaded external tools
+- video/audio files
+- local logs
+- IDE caches
+
+If a binary or large file is required, the agent must ask the developer
+before staging it.
+
+### 15.14 Path-specific rule gate
+
+Use path-specific instructions for areas that need stricter rules. See
+Section 15.2 for the recommended nested `AGENTS.md` and
+`.github/instructions/*.instructions.md` files.
+
+Each path-specific file must extend `AGENTS.md` and must not contradict
+it. When editing under a scoped path, read the matching path-specific
+file before making changes.
+
+### 15.15 Validation evidence gate
+
+Before handoff, commit approval, push approval, or PR readiness, the
+agent must provide evidence for the touched surface.
+
+Required evidence:
+
+- exact commands run;
+- pass/fail result;
+- affected modules;
+- files inspected;
+- tests intentionally skipped;
+- reason skipped tests were acceptable;
+- manual test request for real application behavior.
+
+The agent must **not** write vague validation such as:
+
+- "tests pass"
+- "build ok"
+- "should work"
+- "validated locally"
+
+The agent must provide exact command lines and concrete results.
+
+### 15.16 Review readiness gate
+
+A PR is not review-ready until:
+
+- full required validation is complete or clearly marked as not complete;
+- Copilot comments are handled or explicitly listed as pending;
+- unresolved GitHub conversations are listed;
+- known risks are listed;
+- branch is rebased on latest `origin/develop`;
+- no merge commit was introduced;
+- no sensitive data is present (Section 15.9);
+- no unrelated files are included;
+- commit history is coherent and not WIP;
+- no AI attribution is present (Section 15.10);
+- no unapproved binaries or generated files are included (Sections 15.12,
+  15.13, 15.23);
+- branch protection expectations are met or documented (Section 15.17);
+- required status checks are verified or listed as pending/failing
+  (Section 15.18);
+- CODEOWNERS coverage is reviewed when applicable (Section 15.19).
+
+The final status must be exactly one of:
+
+- **Ready for developer manual testing**
+- **Ready for commit approval**
+- **Ready for push approval**
+- **Ready for PR review**
+- **Not ready to commit**
+- **Not ready to merge**
+- **Needs developer decision**
+
+Use **Not ready to merge** when required status checks are pending or
+failing (Section 15.18), or when required code-owner review is missing
+(Section 15.19).
+
+### 15.17 Branch protection alignment gate
+
+AI agent rules must mirror the repository branch protection expectations
+documented in `docs/repository-governance.md` and enforced on `develop`.
+
+Before declaring a PR ready, the agent must verify or document:
+
+- required status checks are passing or still pending;
+- unresolved review conversations are listed;
+- branch history is linear;
+- the PR branch is up to date with `origin/develop` by rebase, not merge;
+- no direct push was made to `develop`;
+- no force push was made to protected branches;
+- no merge commit was introduced.
+
+The agent must never suggest bypassing branch protection, disabling
+checks, reducing required reviews, or merging with failing checks unless
+the developer explicitly asks for repository administration guidance.
+
+### 15.18 Required status check gate
+
+If GitHub status checks exist for the PR, the agent must inspect and
+summarize them before PR readiness.
+
+The agent must report:
+
+- check name;
+- status;
+- failing job if any;
+- whether the failure is related to the current change;
+- next recommended fix.
+
+The agent must not say "CI is green" unless it has verified the current
+PR checks.
+
+If checks are **pending**, the final status must be:
+
+> Not ready to merge
+
+If checks are **failing**, the final status must be:
+
+> Not ready to merge
+
+### 15.19 CODEOWNERS and reviewer gate
+
+If [`.github/CODEOWNERS`](.github/CODEOWNERS) exists, the agent must
+inspect it when files are changed.
+
+Before PR readiness, the agent must list:
+
+- changed paths covered by CODEOWNERS;
+- required reviewers if identifiable;
+- whether review is still needed.
+
+The agent must not mark the PR as ready to merge when required
+code-owner review is missing.
+
+### 15.20 Explicit staging gate
+
+The agent must never stage everything blindly.
+
+Forbidden by default:
+
+```bash
+git add -A
+git add .
+git add --all
+```
+
+Allowed staging pattern:
+
+- stage only intentional files by explicit path;
+- show staged diff before commit approval;
+- confirm no unrelated files are staged.
+
+Before asking **Approve commit?**, the agent must run:
+
+```bash
+git diff --stat
+git diff --check
+git diff --cached --stat
+git diff --cached --check
+```
+
+If nothing is staged yet, the agent must say so and show the exact files
+it plans to stage.
+
+### 15.21 Scratch space gate
+
+Temporary agent work must go into a git-ignored scratch directory.
+
+Recommended directory: `agent_space/`
+
+Rules:
+
+- use `agent_space/` for temporary scripts, investigation notes, raw
+  outputs, prompt drafts, and experiments;
+- do not commit files from `agent_space/`;
+- do not store secrets in `agent_space/`;
+- delete or leave scratch files untracked according to developer
+  preference;
+- never stage scratch files unless explicitly requested.
+
+If `agent_space/` is missing from `.gitignore`, propose adding it in a
+follow-up documentation or tooling commit.
+
+### 15.22 Tool version and environment gate
+
+Before changing build, dependency, generated, or packaging files, the
+agent must record the relevant tool versions.
+
+For Habitv, report when relevant:
+
+```bash
+java -version
+mvn -v
+git --version
+gh --version   # if GitHub CLI is used
+```
+
+Also report: operating system, active branch, Maven module touched.
+
+If generated files or lock-like files are changed, the agent must
+document which tool version generated them.
+
+The agent must avoid regenerating files with a different tool version
+when that would create unrelated diff noise.
+
+### 15.23 Artifact exclusion gate
+
+The agent must not stage or commit build outputs, local IDE files,
+downloaded tools, installers, archives, logs, or generated binaries
+unless explicitly requested.
+
+Forbidden by default:
+
+- `target/`, `*.class`
+- `*.jar` produced by local build
+- `.zip`, `.exe`, `.dll`, `*.log`
+- downloaded ffmpeg, yt-dlp, aria2, curl, rtmpdump binaries
+- IDE caches
+- temporary screenshots, local reports, coverage outputs
+
+If such files appear in `git status`, the agent must leave them
+unstaged and mention them separately.
+
+### 15.24 Network and live-service gate
+
+For Habitv provider/plugin work, the agent must distinguish between:
+
+- offline unit tests;
+- live/network tests;
+- manual real-application tests.
+
+The agent must not rely only on live provider behavior as proof of
+correctness.
+
+When changing plugins or replay providers, the agent should prefer:
+
+- offline fixtures;
+- deterministic parser tests;
+- focused module tests;
+- manual live verification only as an additional check.
+
+If live tests are skipped because of network instability, geoblocking,
+authentication, DRM, or provider rate limits, the agent must say so
+clearly.
+
+### 15.25 PR comment action gate
+
+Posting GitHub comments changes remote state.
+
+The agent must ask for explicit approval before:
+
+- replying to a PR comment;
+- replying to Copilot;
+- marking a conversation resolved;
+- requesting review;
+- re-requesting review;
+- adding labels;
+- editing PR title or body.
+
+Before any PR comment action, the agent must show the exact English
+comment it plans to post.
+
+Review reply template when handled:
+
+```text
+Handled in commit <commit-sha or pending>. Summary: <short explanation>. Validation: <command/result or not applicable>.
+```
+
+When rejected:
+
+```text
+Not applied. Reason: <clear reason>. Risk/scope: <why it should not be changed in this PR>. Developer decision needed: <yes/no>.
+```
+
+See also Section 15.7 for resolution criteria.
+
+### 15.26 Issue and follow-up gate
+
+If the agent finds useful work outside the current PR scope, it must not
+implement it silently.
+
+Instead, list it under:
+
+```markdown
+## Follow-up candidates
+
+* Title:
+* Reason:
+* Risk:
+* Suggested branch:
+* Suggested commit type:
+```
+
+The agent must not create GitHub issues unless explicitly approved.
+
+### 15.27 No silent auto-fix gate
+
+The agent must not silently fix unrelated warnings, formatting, imports,
+lint issues, or IDE suggestions.
+
+If an auto-fix tool changes unrelated files, the agent must revert those
+unrelated changes or ask the developer.
+
+For Habitv, avoid mixing in one PR:
+
+- provider behavior changes;
+- Java migration changes;
+- dependency changes;
+- packaging changes;
+- CI changes;
+- documentation-only changes.
+
+Each category should normally be a separate PR.
+
+### 15.28 Commit content gate
+
+Each commit must be coherent and reviewable.
+
+Before commit approval, the agent must classify the commit as exactly one:
+
+- docs-only;
+- test-only;
+- code behavior;
+- refactor-only;
+- build/CI;
+- packaging;
+- dependency update;
+- generated files;
+- mixed with explicit approval.
+
+If the commit is **mixed**, the agent must explain why it cannot be split
+safely.
+
+---
+
+## ⚡ 16. Fast safe modernization workflow
+
+These rules help agents move faster **without** reducing safety. Manual
+approval gates (Section 14) and Java 8 compatibility (Section 2) remain
+mandatory unless a dedicated migration task says otherwise.
+
+Detailed companion docs: [`docs/dev-workflow.md`](docs/dev-workflow.md),
+[`docs/dependency-policy.md`](docs/dependency-policy.md),
+[`docs/security-policy.md`](docs/security-policy.md).
+
+### 16.1 Fast progress gate
+
+Optimize for small, reviewable, fast-to-merge PRs.
+
+Default rules:
+
+- one topic per branch;
+- one coherent commit unless the developer asks for a split;
+- no mixed PR combining code behavior, docs, dependency updates, CI,
+  packaging, and refactoring;
+- prefer incremental modernization over big-bang rewrites;
+- keep every PR buildable on Java 8 unless it is a dedicated Java
+  migration PR.
+
+Recommended PR size:
+
+| Size | Files changed | Rule |
+|------|---------------|------|
+| small | under 10 | preferred default |
+| medium | 10–25 | acceptable with clear scope |
+| large | over 25 | requires explicit developer approval before continuing |
+
+If a task becomes larger than expected, stop and propose a split plan.
+
+### 16.2 Speed-first task classification
+
+Before editing, classify the task as exactly one:
+
+- quick fix;
+- provider/plugin fix;
+- dependency/security update;
+- CI/workflow update;
+- IDE/tooling update;
+- docs-only;
+- refactor-only;
+- packaging;
+- migration preparation;
+- investigation only.
+
+Then apply the matching validation plan from Sections 6, 14.2, and 16.11.
+
+### 16.3 Dependency update policy
+
+Dependency updates must be handled in focused PRs. See
+[`docs/dependency-policy.md`](docs/dependency-policy.md).
+
+Allowed categories: security patch; patch update; minor update; major
+update; plugin/tooling update; GitHub Actions update; Maven plugin update.
+
+Rules:
+
+- do not batch unrelated dependency updates unless explicitly requested;
+- do not mix dependency updates with feature work;
+- preserve Java 8 compatibility unless a dedicated migration task says
+  otherwise;
+- document old version, new version, reason, risk, and validation;
+- check release notes or changelog when the update is non-trivial;
+- run full Maven validation after any dependency change.
+
+Before commit approval on dependency PRs, provide:
+
+```markdown
+## Dependency update report
+
+* Dependency:
+* Old version:
+* New version:
+* Update type:
+* Reason:
+* Java 8 compatibility:
+* Release notes/changelog checked:
+* Security impact:
+* Validation commands:
+* Known risks:
+```
+
+### 16.4 Security update policy
+
+Security fixes have priority over cosmetic cleanup. See
+[`docs/security-policy.md`](docs/security-policy.md) and [`SECURITY.md`](SECURITY.md).
+
+When a security alert, Dependabot PR, CodeQL alert, dependency review
+issue, or OWASP warning exists, the agent must:
+
+- identify whether it affects runtime, test-only, plugin-only,
+  build-only, or transitive scope;
+- avoid suppressing alerts without explanation;
+- prefer upgrading to a safe compatible version;
+- document if no Java 8-compatible fix exists;
+- avoid disabling security checks just to make CI green.
+
+The agent must **not**: ignore security alerts; silence CodeQL without
+justification; disable Dependabot; remove dependency review; weaken branch
+protection; add broad workflow permissions.
+
+### 16.5 Dependabot rule
+
+Inspect [`.github/dependabot.yml`](.github/dependabot.yml) before
+dependency work.
+
+Current configuration targets `develop`, limits open PRs, groups Maven
+minor/patch and GitHub Actions updates, and ignores major JAXB/mail bumps
+that would violate Java 8 / no-jakarta rules.
+
+Rules:
+
+- group low-risk patch updates only when useful;
+- keep security updates separate when possible;
+- never enable auto-merge for dependency updates unless the developer
+  explicitly asks;
+- if Dependabot config needs changes, use a dedicated CI/tooling PR.
+
+### 16.6 Dependency Review workflow rule
+
+For dependency-changing PRs, require dependency review when available.
+Current workflow: [`.github/workflows/dependency-review.yml`](.github/workflows/dependency-review.yml)
+(fails on high severity).
+
+The workflow should fail or warn when a new vulnerable dependency is
+introduced or a dependency diff is suspicious.
+
+If Dependency Review is not available for the repository plan, document
+that limitation instead of pretending it is enforced.
+
+### 16.7 CodeQL rule
+
+CodeQL should remain enabled for Java and GitHub Actions when possible.
+See `docs/required-checks-roadmap.md` for rollout status.
+
+Rules:
+
+- do not remove CodeQL workflows without explicit approval;
+- do not suppress CodeQL alerts without a clear reason;
+- for Java/Maven, ensure CodeQL build mode matches project reality;
+- if CodeQL fails because the Maven project requires Java 8, document
+  JDK setup and fix the workflow instead of disabling analysis;
+- use least required permissions.
+
+### 16.8 GitHub Actions security rule
+
+All GitHub Actions workflows must use least-privilege permissions.
+
+Default:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Only add write permissions when the job really needs them.
+
+Rules:
+
+- avoid `pull_request_target` unless explicitly justified;
+- pin actions to trusted major versions at minimum;
+- prefer official actions for checkout, setup-java, cache, CodeQL,
+  dependency-review;
+- do not expose secrets to PRs from forks;
+- do not echo secrets, tokens, cookies, or headers;
+- do not add workflow steps that execute untrusted PR text as shell
+  commands.
+
+Before changing workflows, provide:
+
+```markdown
+## Workflow safety checklist
+
+* Workflow changed:
+* Trigger changed:
+* Permissions before:
+* Permissions after:
+* Secrets used:
+* Third-party actions added:
+* Java version used:
+* Maven command used:
+* Security risk:
+```
+
+### 16.9 CI speed rule
+
+CI should be fast but meaningful. Current primary workflow:
+[`.github/workflows/ci-maven.yml`](.github/workflows/ci-maven.yml).
+
+Recommended split when adding workflows:
+
+| Workflow | Purpose |
+|----------|---------|
+| validate | Maven validate / compile / tests on Java 8 |
+| security | CodeQL, dependency review, OWASP if stable |
+| docs | Markdown/docs checks if useful |
+| package | packaging only when packaging changes or manual trigger |
+
+Rules:
+
+- avoid heavy packaging on every small PR unless needed;
+- use path filters where useful;
+- cache Maven dependencies safely;
+- never cache corrupted security databases if they cause recurring failures;
+- keep a full validation path available before merge.
+
+### 16.10 Java compatibility roadmap rule
+
+Habitv currently preserves Java 8 compatibility.
+
+Rules:
+
+- default source/target remains Java 8 unless a dedicated migration PR
+  changes it;
+- modern Java migration work must be split into preparation PRs;
+- do not introduce APIs unavailable in Java 8;
+- do not upgrade Maven plugins to versions requiring a newer JDK unless
+  the PR is explicitly a migration step;
+- document compatibility impact for every build plugin or dependency
+  update.
+
+Migration roadmap categories: Java 8 stabilization; JavaFX packaging
+clarification; Java 11 preparation; Java 17 preparation; Java 21/25 future
+migration.
+
+Do not claim Java 11/17/21/25 support until CI proves it. Use wording:
+**current support**, **planned migration**, **experimental**, or **not
+yet validated**.
+
+### 16.11 Maven quality gate
+
+For Maven changes, prefer explicit validation.
+
+Default commands:
+
+```bash
+mvn -B -ntp validate
+mvn -B -ntp -DskipTests clean package
+mvn -B -ntp test
+mvn -B -ntp -pl <module> -am test   # when module-specific
+```
+
+For dependency analysis:
+
+```bash
+mvn -B -ntp dependency:tree
+mvn -B -ntp versions:display-dependency-updates
+mvn -B -ntp versions:display-plugin-updates
+```
+
+Do not commit POM changes without explaining why the dependency or
+plugin change is needed.
+
+### 16.12 Maven Enforcer rule
+
+If Maven Enforcer is present, inspect and improve it carefully in a
+dedicated build-quality PR.
+
+If missing, propose Enforcer only in that dedicated PR — not mixed with
+feature work.
+
+Potential rules: require Java 8; require Maven minimum version; ban
+duplicate dependencies; require plugin versions; dependency convergence
+only if it does not create excessive noise.
+
+### 16.13 Cursor IDE rules
+
+Cursor configuration must help agents work faster and consistently.
+
+Project-level:
+
+- store repository rules in `.cursor/rules/`;
+- keep `AGENTS.md` as canonical source of truth;
+- Cursor rules must not contradict `AGENTS.md`;
+- split rules by topic (git, Maven, Java 8, PR, dependencies, workflows,
+  plugins).
+
+User-level Cursor settings are for personal preferences only. Never rely
+on user settings for repository-critical behavior.
+
+The agent must inspect repository rules first; never assume local Cursor
+settings are correct.
+
+### 16.14 Cursor recommended extensions gate
+
+Maintain [`.vscode/extensions.json`](.vscode/extensions.json) with
+recommended extensions. Do not force installation.
+
+Suggested categories: Java, Maven, Java test/debug, GitHub PRs, GitHub
+Actions, Copilot (if used), YAML, EditorConfig, Markdown.
+
+### 16.15 Cursor workspace settings gate
+
+Do not commit machine-specific Java paths.
+
+Forbidden in committed workspace settings: personal absolute paths; local
+username paths; machine-specific `JAVA_HOME`; tokens; private tool paths.
+
+Allowed: [`.vscode/settings.example.json`](.vscode/settings.example.json)
+with documented examples; safe editor settings; format-on-save only if it
+does not create massive unrelated diffs.
+
+Prefer documenting local Java 8 setup in [`docs/dev-workflow.md`](docs/dev-workflow.md).
+Keep machine-specific settings local and gitignored.
+
+### 16.16 Cursor task commands
+
+Add [`.vscode/tasks.json`](.vscode/tasks.json) only in a dedicated tooling
+PR.
+
+Recommended tasks: Maven validate; clean package (skip tests); test;
+targeted module test; git status; git diff — **never** tasks that commit,
+push, force-push, merge, or resolve PR comments.
+
+### 16.17 Agent startup checklist
+
+At the start of each task, report:
+
+```markdown
+## Agent startup checklist
+
+* Instruction files loaded:
+* Current branch:
+* Base branch:
+* Task classification:
+* Expected files to touch:
+* Validation plan:
+* Risk level:
+* Needs web/release-note lookup: yes/no
+* Needs developer decision: yes/no
+```
+
+See also Section 15.1 (instruction loading).
+
+### 16.18 Decision speed rule
+
+Move fast with safe defaults when scope is clear, change is low risk,
+validation can prove correctness, and no remote state change is needed.
+
+The agent **must ask** before: commit; push; force-with-lease push; PR
+creation; PR merge; resolving comments; dependency major updates; Java
+version migration; destructive commands; security suppression; workflow
+permission broadening.
+
+### 16.19 PR queue prioritization rule
+
+When multiple tasks exist, prioritize:
+
+1. build is broken
+2. security alert or vulnerable dependency
+3. CI/workflow failure blocking merges
+4. PR comments blocking review
+5. dependency patch/minor updates
+6. provider/plugin fixes
+7. tests and fixtures
+8. packaging
+9. docs cleanup
+10. refactor
+11. future Java migration preparation
+
+### 16.20 Provider/plugin update rule
+
+For replay provider work:
+
+- prefer deterministic parser tests with offline fixtures;
+- avoid relying only on live network tests;
+- document authentication, cookies, DRM, geoblocking, or browser session
+  requirements;
+- do not bypass DRM;
+- do not commit cookies, tokens, or browser profiles;
+- use yt-dlp behavior as integration inspiration only when legally and
+  technically appropriate;
+- keep each provider change isolated.
+
+See also Section 15.24 and [`plugins/AGENTS.md`](plugins/AGENTS.md).
+
+### 16.21 Documentation freshness rule
+
+When documentation mentions versions, Java support, workflow behavior,
+packaging, or external tools, verify the statement matches current
+repository state.
+
+Do not document future support as already available.
+
+### 16.22 Release notes and changelog gate
+
+Before non-trivial updates, inspect release notes or changelogs when
+available (Maven plugins, GitHub Actions, JavaFX/OpenJFX, yt-dlp,
+security tools, dependency major/minor updates, packaging tools).
+
+If release notes were not checked, say so explicitly.
+
+### 16.23 Auto-formatting gate
+
+Do not enable broad auto-formatting that changes many legacy files.
+Formatting must be explicit, scoped, and preferably a dedicated formatting
+PR separate from behavior changes.
+
+### 16.24 Branch naming for fast work
+
+Use predictable branch names: `fix/`, `feat/`, `docs/`, `test/`, `ci/`,
+`chore/`, `build/`, `refactor/` + short topic.
+
+Avoid: `claude/*`, `cursor/*`, random generated names, ticket/style IDs,
+vague names like `update-stuff`. See Section 4.
+
+### 16.25 Final task report
+
+Every completed task must end with:
+
+```markdown
+## Final report
+
+* Task classification:
+* Branch:
+* Files changed:
+* Summary:
+* Validation:
+* Manual tests requested:
+* Security impact:
+* Dependency impact:
+* Java 8 compatibility:
+* Copilot/GitHub comments:
+* Follow-up candidates:
+* Proposed commit:
+* Next action requiring approval:
+```
+
+---
+
+## 🔄 17. Evolutionary rules governance
+
+AI rules must evolve with project needs, repository maturity, tooling,
+security requirements, dependency updates, and developer feedback. Rules
+must be easy to update, version, audit, simplify, and retire.
+
+Companion docs: [`docs/agent-rules-changelog.md`](docs/agent-rules-changelog.md),
+[`docs/agent-rules-backlog.md`](docs/agent-rules-backlog.md).
+
+Section 13 governs **hard-rule** ADR changes. This section governs **AI
+workflow rule** evolution.
+
+### 17.1 Evolutionary rules governance
+
+`AGENTS.md` remains the canonical source of truth.
+
+All other AI instruction files must reference, summarize, or extend
+`AGENTS.md` — never contradict it.
+
+AI rules evolve through **normal pull requests** dedicated to rule changes
+or clearly scoped docs PRs. Do not silently change rules during unrelated
+feature, fix, dependency, or provider work.
+
+Rule changes must be explicit, reviewable, and recorded in the changelog.
+
+### 17.2 Rule lifecycle states
+
+Classify important rules as one of:
+
+| State | Meaning |
+|-------|---------|
+| **mandatory** | must follow unless developer explicitly overrides |
+| **recommended** | default best practice; adapt with justification |
+| **experimental** | being tested; review after a few PRs |
+| **deprecated** | temporary; remove soon |
+| **removed** | inactive; history in changelog only |
+
+Do not keep obsolete **mandatory** rules indefinitely.
+
+### 17.3 Rule review cadence
+
+Review rules:
+
+- after **5 merged PRs** touching agent workflow or CI;
+- after any **repeated agent mistake**;
+- after any **failed or polluted PR** caused by AI behavior;
+- after dependency/security workflow changes;
+- after Java compatibility milestones;
+- before large migrations;
+- before enabling new automation.
+
+Suggest a rule update when the same problem happens **twice**.
+
+### 17.4 Rule improvement trigger
+
+Propose a rule update when:
+
+- commit/push happened too early;
+- merge commits appeared on a PR branch;
+- Copilot comments resolved without handling;
+- validation skipped without clear status;
+- PR mixed unrelated changes;
+- dependency updates bundled badly;
+- CI failed from missing workflow rule;
+- security alert ignored or suppressed badly;
+- Java 8 compatibility broken accidentally;
+- generated files or binaries committed;
+- branch/PR naming conventions violated.
+
+Use:
+
+```markdown
+## Suggested rule improvement
+
+* Problem observed:
+* Proposed rule:
+* Files to update:
+* Risk if not added:
+* Suggested commit:
+```
+
+Add to [`docs/agent-rules-backlog.md`](docs/agent-rules-backlog.md) if not
+implemented immediately.
+
+### 17.5 Rule simplification gate
+
+When updating rules, check for: duplication; contradiction; obsolete text;
+too many examples; vague unverifiable rules; rules that slow simple tasks.
+
+If too long, split into:
+
+- mandatory short rule in `AGENTS.md`;
+- detailed explanation in `docs/dev-workflow.md`;
+- path-specific detail in nested `AGENTS.md` or
+  `.github/instructions/*.instructions.md`.
+
+### 17.6 Rule drift audit
+
+Before finishing any AI-rule update, audit:
+
+- `AGENTS.md`
+- `.cursor/rules/*`
+- `.github/copilot-instructions.md`
+- `.github/instructions/*.instructions.md`
+- `CLAUDE.md`, `GEMINI.md`
+- `docs/dev-workflow.md`
+- `docs/agent-rules-changelog.md`
+
+Report:
+
+```markdown
+## Rule drift audit
+
+* Files checked:
+* Conflicts found:
+* Conflicts resolved:
+* Files intentionally left unchanged:
+* Reason:
+```
+
+### 17.7 Cursor rule evolution
+
+Cursor rules must be modular. See [`.cursor/rules/README.md`](.cursor/rules/README.md).
+
+Each `.mdc` file must include: purpose; when it applies; mandatory rules;
+examples only if useful; reference to `AGENTS.md`.
+
+Cursor rules must **not** contain unique critical policy missing from
+`AGENTS.md`.
+
+Recommended numbered modules (current names in parentheses):
+
+| Module | Topic |
+|--------|-------|
+| `00-canonical-source.mdc` | canonical pointer |
+| `10-git-safety.mdc` | (`git-safety.mdc`) |
+| `20-validation.mdc` | (`maven-validation.mdc`) |
+| `30-java8-maven.mdc` | (`java8-compatibility.mdc`) |
+| `40-pr-review.mdc` | (`pr-review.mdc`) |
+| `50-dependencies-security.mdc` | (`dependencies.mdc`) |
+| `60-workflows-ci.mdc` | (`workflows.mdc`) |
+| `70-provider-plugins.mdc` | (`plugins/AGENTS.md`) |
+| `90-rule-evolution.mdc` | evolution and audit |
+
+### 17.8 GitHub Copilot instruction evolution
+
+Repository-wide: `.github/copilot-instructions.md`.
+
+Path-specific: `.github/instructions/*.instructions.md` — create only when
+they reduce noise or improve accuracy.
+
+Each path-specific file must state: files it applies to; how it extends
+`AGENTS.md`; validation expected; what not to change.
+
+### 17.9 Rule retirement policy
+
+Remove or downgrade rules when:
+
+- the problem no longer occurs;
+- CI or branch protection now enforces it;
+- it duplicates a stronger rule;
+- it slows work without preventing real issues;
+- it was temporary for a completed migration.
+
+Document retirement in `docs/agent-rules-changelog.md`.
+
+### 17.10 Automation maturity levels
+
+| Level | Name | Description |
+|-------|------|-------------|
+| 0 | Manual only | agent proposes; developer approves all remote actions |
+| 1 | Assisted | agent validates locally; developer approves commit/push/PR |
+| 2 | Guarded automation | selected automation only when CI + protection reliable |
+| 3 | Trusted automation | low-risk repetitive tasks only; explicit decision |
+
+**Current Habitv default: Level 1 — Assisted.**
+
+Do not move to a higher level without a dedicated PR and developer
+approval.
+
+### 17.11 Rule scoring
+
+Before adding a new **mandatory** rule, score it:
+
+```markdown
+## Rule score
+
+* Prevents real recurring problem: yes/no
+* Easy to verify: yes/no
+* Low maintenance cost: yes/no
+* Does not slow simple tasks too much: yes/no
+* Belongs in AGENTS.md instead of docs: yes/no
+```
+
+Add as mandatory only when most answers are **yes**. Otherwise use
+recommended, experimental, or backlog.
+
+### 17.12 Experimental rules
+
+Experimental rules must document:
+
+- start date; reason; success criteria; review date; owner; rollback
+  condition.
+
+Example template in [`docs/agent-rules-backlog.md`](docs/agent-rules-backlog.md).
+
+### 17.13 Progress-aware rules
+
+Identify the current project phase before major work (full list: Section
+18.1). See [`docs/dev-plan.md`](docs/dev-plan.md).
+
+### 17.14 Agent rules update report
+
+Every AI-rule update must end with:
+
+```markdown
+## Agent rules update report
+
+* Rule version before:
+* Rule version after:
+* Files updated:
+* Rules added:
+* Rules changed:
+* Rules removed:
+* Rules deprecated:
+* Drift audit:
+* Backlog updated:
+* Changelog updated:
+* Validation:
+* Next review trigger:
+```
+
+---
+
+## 📺 18. Habitv-specific modernization rules
+
+Habitv-specific rules for providers, dependencies, security tooling, CI,
+IDE setup, packaging, and Java compatibility. Companion docs:
+[`docs/provider-policy.md`](docs/provider-policy.md),
+[`docs/release-policy.md`](docs/release-policy.md),
+[`docs/modernization-backlog.md`](docs/modernization-backlog.md),
+[`docs/obsolescence-register.md`](docs/obsolescence-register.md).
+
+General gates in Sections 14–17 still apply.
+
+### 18.1 Habitv project phase gate
+
+Before making changes, identify the current work **phase** (exactly one):
+
+- stabilization;
+- provider/plugin restoration;
+- metadata enrichment;
+- dependency/security update;
+- CI hardening;
+- IDE/tooling setup;
+- packaging;
+- release preparation;
+- Java migration preparation;
+- Java migration execution.
+
+Each task must declare: **phase**; **risk level**; **expected files**;
+**validation plan**; whether **Java 8 compatibility** is affected.
+
+### 18.2 Provider status matrix rule
+
+Replay providers/plugins must have a clear status in
+[`docs/provider-inventory.md`](docs/provider-inventory.md) and/or
+[`docs/obsolescence-register.md`](docs/obsolescence-register.md).
+
+| Status | Meaning |
+|--------|---------|
+| **working** | validated with tests and real behavior when possible |
+| **degraded** | partial function; known metadata or endpoint gaps |
+| **protected** | auth, cookies, DRM, geoblocking, or anti-bot |
+| **obsolete** | dead or replaced endpoint/platform |
+| **removed** | intentionally removed from active UI/plugin list |
+| **unknown** | not recently validated |
+
+When changing a provider, update or propose updating status documentation.
+
+### 18.3 Provider data quality contract
+
+Preserve or improve metadata extraction when feasible. Desired fields:
+channel; program title; episode title; broadcast date; duration; summary;
+thumbnail; season/episode numbers when available; replay URL; download URL
+or delegated downloader command; availability/end date when available.
+
+If metadata is unavailable, document whether it is: not exposed; auth-protected;
+JavaScript/API-only; or out of scope for the PR.
+
+Do **not** claim metadata support without validation.
+
+### 18.4 Provider testing rule
+
+Prefer deterministic offline tests: fixtures; parser tests; URL extraction;
+command-building; targeted `mvn -pl plugins/<module> -am test`.
+
+Live/network checks are supplementary — not the only proof. If skipped, state
+why (network, geoblocking, auth, DRM, rate limits, downtime).
+
+Do not bypass DRM. Do not commit cookies, browser profiles, sessions, tokens,
+or auth headers. See also Section 15.24.
+
+### 18.5 External tools policy
+
+External tools include yt-dlp, ffmpeg, aria2, rclone, curl, rtmpdump.
+
+Rules:
+
+- do not silently replace or upgrade tools;
+- dedicated PRs for tool updates;
+- document source URL, version, reason, compatibility, checksum when possible;
+- do not commit downloaded binaries unless explicitly requested;
+- do not mix tool updates with provider behavior changes;
+- validate command-building with tests when possible.
+
+See [`docs/external-tools-recommendations.md`](docs/external-tools-recommendations.md).
+
+Before commit approval on tool updates, provide **External tool update
+report** (template in [`docs/provider-policy.md`](docs/provider-policy.md)).
+
+### 18.6 Java 8 compatibility rule
+
+Remain Java 8-compatible by default. Do not introduce Java 9+ APIs or
+language features, Maven plugins requiring newer JDK (unless dedicated
+migration PR), or dependencies dropping Java 8 without approval.
+
+Split migration work: Java 8 stabilization → 11/17/21/25 preparation →
+runtime migration. Do not claim newer Java support until CI validates it.
+
+See [`docs/java-runtime-policy.md`](docs/java-runtime-policy.md) and
+`.cursor/rules/java8-compatibility.mdc`.
+
+### 18.7 JavaFX compatibility rule
+
+Distinguish:
+
+- historical JDK 8 with bundled JavaFX (`jfxrt`);
+- modern Java 8 distributions that **may** bundle JavaFX (selected Zulu,
+  Liberica);
+- newer Java where JavaFX is typically separate (OpenJFX / packaging).
+
+Do **not** write that JavaFX is always bundled with Java. Document validated
+local setup and future migration plan separately when changing JavaFX docs.
+
+### 18.8 Dependency/security modernization lane
+
+Focused PRs only. Priority order:
+
+1. vulnerable dependencies;
+2. broken CI/security workflows;
+3. outdated GitHub Actions;
+4. Maven plugin updates;
+5. low-risk patches;
+6. minors;
+7. majors (dedicated review).
+
+Do not mix with feature work. Check release notes. Preserve Java 8. Run full
+Maven validation. Use **Dependency update report** (Section 16.3).
+
+See [`docs/dependency-policy.md`](docs/dependency-policy.md).
+
+### 18.9 SBOM rule
+
+SBOM generation (e.g. CycloneDX Maven plugin) belongs in a **dedicated
+security/tooling PR** — not unrelated work.
+
+Document where SBOM is generated. Do not commit generated SBOM files unless
+required. Prefer CI artifact upload.
+
+### 18.10 OWASP Dependency-Check rule
+
+If OWASP Dependency-Check is used:
+
+- do not disable it to green CI;
+- do not cache corrupted vulnerability databases;
+- use stable cache strategy;
+- NVD API key only via GitHub secrets — never hard-coded;
+- document suppressions with reason and expiry/review date.
+
+Suppression template in [`docs/security-policy.md`](docs/security-policy.md).
+
+### 18.11 CodeQL rule
+
+Do not remove CodeQL without approval. Do not suppress without explanation.
+Minimal permissions. Match Java/Maven build to Habitv reality. Fix Java 8 setup
+instead of disabling. See Section 16.7 and `docs/security-policy.md`.
+
+### 18.12 OpenSSF Scorecard rule
+
+Propose Scorecard in a **dedicated security PR** only. Document permissions,
+schedule, Security tab usage, expected noise, and follow-ups.
+
+### 18.13 GitHub Actions workflow tiers
+
+| Tier | Purpose |
+|------|---------|
+| PR fast validation | compile/tests on Java 8 |
+| targeted module | path-filtered module tests |
+| security | CodeQL, dependency review, OWASP, SBOM |
+| packaging | packaging changes or manual trigger |
+| scheduled maintenance | dependency/security scans |
+
+Avoid heavy packaging on every PR. Stable CI names for branch protection.
+Least privilege. No `pull_request_target` unless justified. No secrets to fork
+PRs. See Section 16.9 and `.cursor/rules/workflows.mdc`.
+
+### 18.14 IDE and Cursor project setup rule
+
+Repository-critical IDE setup lives in the repo:
+
+- `.vscode/extensions.json`, `.vscode/settings.example.json`;
+- `docs/dev-workflow.md`;
+- `.cursor/rules/README.md`.
+
+Recommend extensions; do not force. No machine-specific Java paths. Document
+Java 8 setup, Maven commands, Java project reload, and known Cursor Java
+pitfalls. See Section 16.13–16.16.
+
+### 18.15 Runtime diagnostics rule
+
+For runtime changes: avoid full stack traces for known provider endpoint
+failures; log short root-cause messages for expected failures; keep debug
+detail where useful; do not hide unexpected exceptions silently.
+
+### 18.16 Obsolescence register rule
+
+Maintain [`docs/obsolescence-register.md`](docs/obsolescence-register.md):
+obsolete provider; old endpoint; replacement; status; removal plan; risk; PR.
+
+Do not delete legacy providers silently — mark, replace, deprecate, or remove
+in focused PRs.
+
+### 18.17 Release readiness rule
+
+Before release/packaging work, verify full build, tests, provider status,
+dependency/security status, external tool versions, Java/JavaFX assumptions,
+packaging scripts, changelog, and known limitations.
+
+Provide **Release readiness report** (template in
+[`docs/release-policy.md`](docs/release-policy.md)).
+
+### 18.18 Fast modernization backlog
+
+Track future work in [`docs/modernization-backlog.md`](docs/modernization-backlog.md)
+instead of bloating `AGENTS.md`. Categories: build blockers; security;
+dependencies; CI; providers; metadata; external tools; packaging; Java
+migration; documentation; cleanup/removal.
+
+### 18.19 Habitv task final report
+
+Every completed Habitv task must end with:
+
+```markdown
+## Final report
+
+* Phase:
+* Task classification:
+* Branch:
+* Files changed:
+* Provider impact:
+* Dependency impact:
+* Security impact:
+* Java 8 compatibility:
+* JavaFX impact:
+* External tool impact:
+* Validation:
+* Manual tests requested:
+* Known limitations:
+* Follow-up candidates:
+* Proposed commit:
+* Next action requiring approval:
+```
+
+Section 16.25 is the generic minimum; Section 18.19 adds Habitv-specific
+fields; Section 19.25 adds maintainability fields.
+
+---
+
+## 🛠️ 19. Habitv maintainability guardrails
+
+Second-level rules for long-term maintainability, reproducible builds,
+dependency safety, configuration compatibility, test reliability, and
+decision tracking. Companion: [`docs/maintainability-policy.md`](docs/maintainability-policy.md).
+
+Sections 14–18 still apply.
+
+### 19.1 Decision record rule
+
+Document architectural, workflow, dependency, Java compatibility,
+packaging, or provider strategy decisions.
+
+- **Existing ADRs:** [`docs/decision-log.md`](docs/decision-log.md) (append-only).
+- **New ADR files:** [`docs/adr/`](docs/adr/) with template in
+  [`docs/adr/README.md`](docs/adr/README.md).
+
+Do not hide durable decisions only in PR comments. Supersede old ADRs;
+do not contradict silently.
+
+### 19.2 Definition of Done rule
+
+Declare **Definition of Done** before implementation:
+
+- code change complete;
+- relevant tests added or updated;
+- Maven validation run;
+- manual real-app test requested;
+- Java 8 compatibility preserved;
+- no unrelated files changed;
+- no secrets or binaries staged;
+- Copilot/GitHub comments handled when applicable;
+- final report written;
+- developer approval requested before commit/push.
+
+If DoD cannot be met: **Not ready to commit**.
+
+### 19.3 Reproducible build rule
+
+Improve reproducibility gradually:
+
+- no timestamps, local paths, random ordering, or machine-specific outputs
+  in generated artifacts;
+- avoid committing machine-varying generated files;
+- document tool versions when build output changes;
+- prefer deterministic packaging when in scope;
+- no reproducible-build tooling in unrelated PRs.
+
+For Maven/build PRs, consider: `project.build.outputTimestamp`; pinned
+plugin versions; Maven Toolchains; pinned CI JDK; checksum/provenance.
+
+### 19.4 Maven Toolchains rule
+
+For Java compatibility work, prefer Maven Toolchains or documented JDK
+setup — not developer machine defaults.
+
+- no hard-coded local JDK paths in committed files;
+- document Java 8 separately from 11/17/21/25 experiments;
+- toolchains only in dedicated build/tooling PRs;
+- CI and local docs must agree;
+- do not claim multi-JDK support without CI validation.
+
+### 19.5 Renovate and Dependabot strategy rule
+
+Dependency automation must reduce noise, not create it.
+
+**Current:** [`.github/dependabot.yml`](.github/dependabot.yml) — Maven +
+GitHub Actions, targets `develop`, limited open PRs.
+
+Allowed: Dependabot only; Renovate only; both with separated responsibility.
+Renovate requires dedicated PR; no automerge by default. Never auto-merge
+dependencies without explicit developer approval.
+
+See [`docs/dependency-policy.md`](docs/dependency-policy.md).
+
+### 19.6 Dependency provenance rule
+
+Document provenance for dependencies and external tools:
+
+name; ecosystem; source repo/site; license; old/new version; Java 8
+compatibility; security reason; release notes checked; migration notes;
+validation performed.
+
+No random mirrors or untrusted binaries. Template in
+[`docs/maintainability-policy.md`](docs/maintainability-policy.md).
+
+### 19.7 EditorConfig and formatting rule
+
+Style is repository-defined, not IDE-specific.
+
+If [`.editorconfig`](.editorconfig) exists: follow it; do not contradict
+in Cursor/VS Code settings. If missing: propose in dedicated tooling PR
+only.
+
+No broad legacy reformatting mixed with behavior changes (Section 16.23).
+
+### 19.8 Test reliability and flaky test rule
+
+Classify test failures: related; unrelated existing; flaky; environment/
+network; skipped by design; needs investigation.
+
+Do not ignore failures. For flaky tests: document command, frequency,
+cause, commit blocker status, fix/quarantine plan. Do not disable tests
+without developer approval.
+
+### 19.9 Network test rule
+
+Provider tests must not depend only on live network (see Section 18.4).
+
+Live tests clearly labeled; CI must not fail randomly on provider downtime,
+geoblocking, DRM, auth, or rate limits. Prefer offline fixtures; live
+checks optional, manual, or scheduled.
+
+### 19.10 XML configuration compatibility rule
+
+Protect legacy XML config compatibility when changing config classes,
+schema, JAXB models, or defaults:
+
+- document backward compatibility impact;
+- preserve existing user configs when possible;
+- add migration logic and old-config tests if needed;
+- do not remove fields or change defaults silently.
+
+If uncertain: **Needs developer decision**.
+
+### 19.11 User data safety rule
+
+Do not risk user data loss when changing download paths, config storage,
+plugin updates, or cleanup:
+
+- do not delete user files or overwrite downloads;
+- do not change default directories silently;
+- document migration; request manual real-app testing.
+
+### 19.12 External downloader command safety rule
+
+For yt-dlp, ffmpeg, aria2, curl, rclone commands:
+
+- log safely without secrets;
+- never print cookies, tokens, auth headers, or session paths;
+- quote Windows paths; preserve cross-platform behavior;
+- test command construction where possible;
+- document manual testing.
+
+### 19.13 Windows-first validation rule
+
+Primary development is on Windows. For launch, packaging, paths, scripts,
+process execution, or external tools:
+
+- validate Windows explicitly;
+- quote paths with spaces;
+- test with local Java 8 when possible;
+- keep PowerShell/Bash consistent;
+- do not assume Linux-only paths.
+
+### 19.14 Cross-platform script parity rule
+
+When both `.sh` and `.ps1` exist: update both or explain why not; align
+arguments and output; validate syntax; document platform differences.
+See [`scripts/AGENTS.md`](scripts/AGENTS.md).
+
+### 19.15 Manual test evidence rule
+
+Before commit approval on behavior changes, request or record manual
+test evidence. Template in [`docs/maintainability-policy.md`](docs/maintainability-policy.md).
+
+If manual testing not done: **Ready for developer manual testing** — not
+**Ready for commit approval**.
+
+### 19.16 PR risk label rule
+
+Classify risk: **low** (docs/narrow fix); **medium** (provider, Maven, CI,
+dep patch/minor); **high** (dep major, Java migration, packaging, config
+migration, external tools); **critical** (security, release, destructive
+migration, DRM/auth/cookies).
+
+Validation scales with risk (Section 19.2, 14.2).
+
+### 19.17 Rollback plan rule
+
+For medium/high/critical changes, provide rollback plan: files to revert;
+PR strategy; user impact; data compatibility; post-release safety.
+
+### 19.18 Feature flag and config default rule
+
+Conservative defaults: risky behavior off unless requested; document flags;
+backward compatible; test enabled/disabled; no silent user-visible changes.
+
+### 19.19 Logging policy rule
+
+Concise warnings for expected provider failures; debug detail for
+unexpected errors; never log secrets unnecessarily. See Section 18.15.
+
+### 19.20 Performance and timeout rule
+
+For downloaders, scans, startup, tool preflight: avoid overly short
+timeouts; document rationale; account for slow Windows startup; avoid
+blocking UI threads.
+
+### 19.21 UI behavior rule
+
+JavaFX/UI: Java 8/JavaFX compatibility; no modern JavaFX APIs; manual UI
+testing; do not mix UI with provider/backend unless necessary.
+
+### 19.22 Error message quality rule
+
+User-facing errors: what failed; likely cause; retry usefulness;
+obsolete/protected status; user action; log location. No raw stack traces
+for expected failures.
+
+### 19.23 Worktree rule
+
+For parallel PR work, prefer Git worktrees over dirty branch switching.
+
+One branch per worktree; no shared uncommitted files; document path in
+handoff; delete obsolete worktrees only with approval.
+
+### 19.24 Maintenance dashboard rule
+
+Maintain [`docs/maintenance-dashboard.md`](docs/maintenance-dashboard.md).
+Update in dedicated docs/planning PRs or when directly relevant.
+
+### 19.25 Maintainability report extension
+
+Extend the final report (Section 18.19) with:
+
+```markdown
+## Maintainability report
+
+* Rule impact:
+* Reproducibility impact:
+* Config compatibility:
+* User data safety:
+* Test reliability:
+* Rollback plan:
+* Manual evidence needed:
+* Maintenance dashboard update needed:
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ complement, but do not replace, the human review process.
 
 ## Agent rules metadata
 
-* **Version:** 1.3.0
+* **Version:** 1.4.0
 * **Last updated:** 2026-05-28
 * **Maintainer:** repository maintainer
 * **Scope:** Habitv AI-assisted development workflow
@@ -18,7 +18,8 @@ complement, but do not replace, the human review process.
   `docs/agent-rules-changelog.md`, `docs/agent-rules-backlog.md`,
   `docs/modernization-backlog.md`, `docs/obsolescence-register.md`,
   `docs/maintainability-policy.md`, `docs/maintenance-dashboard.md`,
-  `docs/adr/`, `docs/decision-log.md`
+  `docs/adr/`, `docs/decision-log.md`, `docs/agent-rule-profiles.md`,
+  `docs/archived-agent-rules.md`
 
 When rules change, update **Version** and **Last updated**, and add an
 entry to [`docs/agent-rules-changelog.md`](docs/agent-rules-changelog.md).
@@ -101,6 +102,9 @@ conflict with `AGENTS.md`, `AGENTS.md` wins.
 | [`docs/agent-rules-changelog.md`](docs/agent-rules-changelog.md) | AI rules version history |
 | [`docs/agent-rules-backlog.md`](docs/agent-rules-backlog.md) | Future rule improvements |
 | [`.github/instructions/docs.instructions.md`](.github/instructions/docs.instructions.md) | Path-specific Copilot rules for docs |
+| [`.cursor/rules/agent-productivity.mdc`](.cursor/rules/agent-productivity.mdc) | Anti-bloat, profiles, speed/deep mode |
+| [`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md) | Rule profiles and validation matrix |
+| [`docs/archived-agent-rules.md`](docs/archived-agent-rules.md) | Retired agent rules |
 
 ### AI agent workflow index
 
@@ -124,6 +128,7 @@ Use this map to find the canonical rule for each workflow area:
 | Evolutionary rules governance | §17 |
 | Habitv-specific modernization | §18 |
 | Habitv maintainability guardrails | §19 |
+| Productivity and anti-bloat | §20 |
 | Documentation sync | §12 |
 | Hard-rule ADR lifecycle | §13 |
 
@@ -1756,7 +1761,8 @@ Before editing, classify the task as exactly one:
 - migration preparation;
 - investigation only.
 
-Then apply the matching validation plan from Sections 6, 14.2, and 16.11.
+Then apply the matching **rule profile** (Section 20.2) and validation
+plan from Sections 6, 14.2, and 16.11.
 
 ### 16.3 Dependency update policy
 
@@ -2858,3 +2864,91 @@ Extend the final report (Section 18.19) with:
 * Manual evidence needed:
 * Maintenance dashboard update needed:
 ```
+
+---
+
+## ⚡ 20. Productivity and anti-bloat guardrails
+
+Keep AI rules **useful, fast, and maintainable**. Detail:
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md).
+
+Sections 14–19 still apply; this section controls **how much** applies per task.
+
+### 20.1 Minimum viable ruleset rule
+
+`AGENTS.md` = mandatory safety, workflow, validation commands, Java/Maven,
+Git/PR gates, and links — not long examples or edge cases. See file list in
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#minimum-viable-ruleset).
+
+### 20.2 Rule profile system
+
+Pick one profile at task start (extends Section 16.2). Profiles, validation,
+risk, allowed files, and report sections:
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#profile-matrix).
+
+Do not apply release or migration rules to docs-only tasks.
+
+### 20.3 Lightweight path for docs-only changes
+
+No Maven unless build/runtime docs change; verify Markdown and scope; drift
+audit if AI rules changed (Section 17.6). May reach **Ready for commit
+approval** after review. Details:
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#docs-only-lightweight-path).
+
+### 20.4 Heavy gate only when needed
+
+Heavy validation for code, build, providers, packaging, tools, Java/JavaFX,
+config/XML/JAXB, and security — not unrelated docs. Scope list in
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#heavy-gate-scope).
+
+### 20.5 Rule conflict resolver
+
+Precedence order in
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#conflict-precedence).
+If unresolved: **Needs developer decision**.
+
+### 20.6 Rule budget
+
+Before adding a mandatory rule: replace, merge, or simplify an existing one.
+Avoid duplicates and unverifiable rules. Prefer one short rule + linked doc +
+backlog item. Checklist in
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#rule-budget).
+
+### 20.7 Rule archive policy
+
+Retire inactive rules to changelog, backlog, or
+[`docs/archived-agent-rules.md`](docs/archived-agent-rules.md) — not active
+mandatory sections.
+
+### 20.8 Agent speed mode
+
+Low-risk docs-only, typo, narrow test fix, isolated config documentation.
+Still: `git status`, changed-files summary, final report, **Approve commit?**,
+approval gates. Skips heavy Maven/release/dep/provider/packaging checks.
+Details: [`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#speed-mode-vs-deep-mode).
+
+### 20.9 Deep mode
+
+Provider/dependency/Maven/CI/packaging/migration/release/downloaders/config
+work. Requires full validation plan, risk, rollback, manual testing, and
+impact reports. Details: same link as 20.8.
+
+### 20.10 Stop condition rule
+
+Do not add mandatory rules that duplicate CI, document one-time issues, or
+slow common tasks. When unsure, use
+[`docs/agent-rules-backlog.md`](docs/agent-rules-backlog.md). Criteria in
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#stop-conditions).
+
+### 20.11 Rule cleanup PR cadence
+
+Every ~10 merged PRs, propose `docs/cleanup-agent-rules` with
+`docs(ai-rules): clean up obsolete agent guidance`. See
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md#rule-cleanup-cadence).
+
+### 20.12 Enforcement over expansion
+
+Prefer enforcing rules via branch protection, CI, CODEOWNERS, Dependabot,
+Dependency Review, CodeQL, Maven validation, small PRs, and provider tests —
+not endless mandatory text. Track gaps in
+[`docs/agent-rules-backlog.md`](docs/agent-rules-backlog.md#enforcement-over-expansion-section-2012).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,28 @@
+# Gemini instructions for Habitv
+
+`AGENTS.md` is the canonical source of truth for repository-wide AI
+agent behavior.
+
+Before making changes, read and follow `AGENTS.md`. At task start, report
+the **Instruction files loaded** checklist (`AGENTS.md` Section 15.1).
+
+Tool-specific mirrors:
+
+- `.cursor/rules/git-safety.mdc`
+- `.cursor/rules/maven-validation.mdc`
+- `.cursor/rules/pr-review.mdc`
+- `.cursor/rules/java8-compatibility.mdc`
+- `.github/copilot-instructions.md`
+- `.github/instructions/*.instructions.md`
+- `docs/agent-rules-changelog.md`
+
+AI rule changes: drift audit (Section 17.6), changelog, version bump.
+
+Never commit, push, create PRs, merge PRs, or resolve review threads
+without explicit developer approval in the current conversation.
+
+Never chain approval-gated commands (Section 15.8). Inspect diffs for
+secrets (Section 15.9). No AI attribution (Section 15.10).
+
+Use English for code comments, commit messages, PR text, and
+documentation.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,6 +22,9 @@ changes (Markdown, tracker JSON mirrors, ADRs, audit baselines).
   `docs/maintainability-policy.md` for Habitv-specific agent topics
   (Sections 18–19).
 - AI rule changes require version bump and changelog entry (Section 17).
+- For docs-only AI-rule work, use speed mode (Section 20.8); run drift
+  audit when rules change (Section 17.6).
+- Prefer backlog over new mandatory rules (Section 20.10).
 - Do not use deprecated `hbtv-*` or `HBTV*` IDs in new headings or
   active tracker slugs.
 - No runtime behavior claims without citing source code or tracker items.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,46 @@
+# Documentation agent instructions
+
+Extends the root [`AGENTS.md`](../AGENTS.md). When they conflict, the
+root file wins.
+
+## Scope
+
+This file applies to work under `docs/` and other documentation-only
+changes (Markdown, tracker JSON mirrors, ADRs, audit baselines).
+
+## Path-specific rules
+
+- Update `docs/dev-tracker.md` AND `docs/dev-tracker.json` together when
+  tracker state changes (root `AGENTS.md` Section 12).
+- Keep slug ids aligned between `.md` and `.json` tracker mirrors.
+- Append-only for `docs/risk-register.md` and `docs/decision-log.md`;
+  supersede rather than rewrite ADRs.
+- English only for all new documentation.
+- Verify version/Java/workflow claims match repository state (Section 16.21).
+- Link to `docs/provider-policy.md`, `docs/release-policy.md`,
+  `docs/modernization-backlog.md`, `docs/obsolescence-register.md`, and
+  `docs/maintainability-policy.md` for Habitv-specific agent topics
+  (Sections 18–19).
+- AI rule changes require version bump and changelog entry (Section 17).
+- Do not use deprecated `hbtv-*` or `HBTV*` IDs in new headings or
+  active tracker slugs.
+- No runtime behavior claims without citing source code or tracker items.
+- No AI attribution in documentation (root `AGENTS.md` Section 15.10).
+
+## Validation (docs-only)
+
+When only documentation changes:
+
+- verify Markdown formatting manually;
+- verify no contradictory duplicate AI rules;
+- verify instruction files still point to the same workflow;
+- confirm no Java source, POM, dependency, workflow, or runtime file
+  changed.
+
+Maven is not required unless build files changed. Set repo health status
+per root `AGENTS.md` Section 15.4.
+
+## Instruction loading
+
+At task start, report **Instruction files loaded** including this file
+and root `AGENTS.md` Section 15.1.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,57 @@
+# Architecture Decision Records (ADR)
+
+Habitv uses ADR-style decision records for durable architectural and
+process decisions.
+
+## Where ADRs live
+
+| Location | Use |
+|----------|-----|
+| [`docs/decision-log.md`](../decision-log.md) | **Primary** append-only log with dashboard (existing ADRs) |
+| `docs/adr/<slug>.md` | Optional standalone ADR files for large decisions |
+
+New standalone files should be linked from the dashboard in
+`decision-log.md` in the same PR.
+
+## When to write an ADR
+
+- Java baseline or migration strategy
+- Provider/platform strategy
+- Packaging or release approach
+- Dependency automation (Dependabot/Renovate)
+- CI/security workflow changes
+- AI workflow policy changes (see also Section 13 meta-rules)
+- Config migration or breaking user-facing defaults
+
+Do **not** use ADRs for temporary implementation notes or PR-only rationale.
+
+## ADR template
+
+```markdown
+# Title
+
+| | |
+|---|---|
+| **Status** | proposed \| accepted \| superseded \| rejected |
+| **Date** | YYYY-MM-DD |
+| **Related PRs** | #123 |
+
+## Context
+
+## Decision
+
+## Consequences
+
+## Alternatives considered
+
+## Follow-up
+```
+
+## Status workflow
+
+- **proposed** — under review
+- **accepted** — in force
+- **superseded** — replaced; link to successor ADR
+- **rejected** — explicitly not adopted
+
+Supersede rather than rewrite. Canonical rule: `AGENTS.md` Section 19.1.

--- a/docs/agent-rule-profiles.md
+++ b/docs/agent-rule-profiles.md
@@ -28,7 +28,7 @@ Long explanations, examples, and templates belong in:
 | dependency/security | medium–high | full | §16.3–16.4, §19.5–19.6 | dependency + security |
 | CI/workflow | medium | validate | §15, workflows | CI impact |
 | IDE/tooling | low–medium | skip unless POM touched | §16.16 | tooling notes |
-| packaging | high | package when in scope | §18.12, §19.3 | release + rollback |
+| packaging | high | package when in scope | §18.13, §19.3, `release-policy.md` | release + rollback |
 | Java migration | critical | dedicated plan | §2, §18.7, §19.4 | migration report |
 | release preparation | high–critical | full + manual | §18.13, §19 | release readiness |
 | investigation only | low | skip | — | findings only |

--- a/docs/agent-rule-profiles.md
+++ b/docs/agent-rule-profiles.md
@@ -1,0 +1,161 @@
+# Agent rule profiles
+
+Canonical summary: [`AGENTS.md`](../AGENTS.md) Section 20.
+
+Agents must pick **one profile** at task start (extends Section 16.2).
+Do not apply heavy release or migration rules to docs-only work.
+
+## Minimum viable ruleset
+
+`AGENTS.md` holds only mandatory safety, workflow, validation commands,
+Java/Maven compatibility, Git/PR approval gates, and links.
+
+Long explanations, examples, and templates belong in:
+
+- [`docs/dev-workflow.md`](dev-workflow.md)
+- [`docs/agent-rules-changelog.md`](agent-rules-changelog.md)
+- [`docs/agent-rules-backlog.md`](agent-rules-backlog.md)
+- path-specific `AGENTS.md` files
+- [`.github/instructions/`](../.github/instructions/)
+
+## Profile matrix
+
+| Profile | Risk | Maven | Deep sections | Final report extras |
+|---------|:----:|:-----:|---------------|---------------------|
+| docs-only | low | skip* | — | minimal |
+| quick fix | low–medium | validate | — | standard |
+| provider/plugin | medium–high | validate + module tests | §18, §19 | Habitv + maintainability |
+| dependency/security | medium–high | full | §16.3–16.4, §19.5–19.6 | dependency + security |
+| CI/workflow | medium | validate | §15, workflows | CI impact |
+| IDE/tooling | low–medium | skip unless POM touched | §16.16 | tooling notes |
+| packaging | high | package when in scope | §18.12, §19.3 | release + rollback |
+| Java migration | critical | dedicated plan | §2, §18.7, §19.4 | migration report |
+| release preparation | high–critical | full + manual | §18.13, §19 | release readiness |
+| investigation only | low | skip | — | findings only |
+
+\* Skip Maven unless docs change build/runtime instructions or AI rules
+that affect validation policy (run drift audit instead).
+
+Profile names: docs-only; quick fix; provider/plugin; dependency/security;
+CI/workflow; IDE/tooling; packaging; Java migration; release preparation;
+investigation only.
+
+## Docs-only lightweight path
+
+For docs-only work:
+
+- no Maven unless docs affect build/runtime instructions;
+- verify Markdown manually;
+- verify no code, POM, workflow, dependency, or runtime file changed;
+- run rule drift audit if AI rules changed (Section 17.6);
+- status may be **Ready for commit approval** after manual review.
+
+Do not run full Maven for pure text-only docs unless requested.
+
+## Heavy gate scope
+
+Heavy validation required for:
+
+- Java source changes;
+- POM/dependency changes;
+- workflow changes;
+- provider/plugin behavior changes;
+- packaging changes;
+- external tool changes;
+- Java/JavaFX compatibility changes;
+- config/XML/JAXB changes;
+- security-sensitive changes.
+
+Do not apply heavy validation to unrelated documentation or planning.
+
+## Speed mode vs deep mode
+
+**Speed mode** (Section 20.8): docs-only, narrow test fix, typo, isolated
+config documentation; no remote state, dependency, or Java behavior change.
+
+Still required: `git status`, changed-files summary, final report,
+**Approve commit?**; no commit/push without approval.
+
+Skipped in speed mode: full Maven build, release checklist, dependency/
+security checklist, provider live validation, packaging checks.
+
+**Deep mode** (Section 20.9): provider behavior, dependency/security,
+Maven/POM, workflow/CI, packaging, Java migration, release prep, external
+downloaders, XML/config compatibility.
+
+Required: full validation plan, risk assessment, rollback plan (medium+),
+manual real-app testing request, security/dependency impact, Java 8 report.
+
+## Allowed files (scope creep guard)
+
+| Profile | Typical allowed paths |
+|---------|----------------------|
+| docs-only | `docs/**`, `*.md`, tracker JSON mirrors |
+| quick fix | single module or narrow path per task |
+| provider/plugin | `plugins/<name>/**`, related tests |
+| dependency/security | `pom.xml`, `**/pom.xml`, lockfiles if any |
+| CI/workflow | `.github/**` |
+| IDE/tooling | `.vscode/**`, `.cursor/**`, `docs/**` |
+| packaging | `packaging/**`, `scripts/stage-package.*` |
+| investigation only | read-only; no commits unless approved |
+
+Cross-profile changes require explicit developer approval.
+
+## Conflict precedence
+
+When rules conflict (Section 20.5):
+
+1. explicit developer instruction (current conversation)
+2. safety/security rule
+3. manual approval gate
+4. branch protection / repository policy
+5. root `AGENTS.md`
+6. nested `AGENTS.md`
+7. `.cursor/rules`
+8. `.github/copilot-instructions.md`
+9. `.github/instructions/*.instructions.md`
+10. docs guidance
+11. older comments or historical notes
+
+If still unresolved: **Needs developer decision**.
+
+## Rule budget
+
+Before adding a mandatory rule, check whether it replaces, merges, or
+simplifies an existing one.
+
+**Avoid:** duplicate wording; multiple rules saying the same thing; long
+examples for obvious rules; unverifiable rules; one-incident rules unlikely
+to recur.
+
+**Prefer:** one short mandatory rule; one linked detailed doc; one checklist
+item; one backlog item if not urgent.
+
+## Stop conditions
+
+Stop adding mandatory rules when:
+
+- the rule duplicates an existing gate;
+- CI or branch protection already enforces it;
+- it documents a one-time issue only;
+- it would slow common tasks more than it prevents real mistakes;
+- it belongs in backlog, not active instructions.
+
+When unsure: add to [`docs/agent-rules-backlog.md`](agent-rules-backlog.md).
+
+## Rule cleanup cadence
+
+Every ~10 merged PRs, propose branch `docs/cleanup-agent-rules` with commit
+`docs(ai-rules): clean up obsolete agent guidance` (Section 20.11): remove
+duplicates; downgrade over-strict rules; archive obsolete rules; align
+instruction files; keep `AGENTS.md` short.
+
+Archive retired rules in [`archived-agent-rules.md`](archived-agent-rules.md).
+
+## Enforcement over expansion
+
+Prefer enforcing rules through branch protection, required CI checks,
+CODEOWNERS, Dependabot, Dependency Review, CodeQL, Maven validation, small
+PR workflow, provider tests, and workspace docs — not endless mandatory text.
+
+Track gaps in [`docs/agent-rules-backlog.md`](agent-rules-backlog.md).

--- a/docs/agent-rules-backlog.md
+++ b/docs/agent-rules-backlog.md
@@ -1,0 +1,67 @@
+# Agent rules backlog
+
+Future AI rule improvements. Do not bloat `AGENTS.md` — track candidates
+here. Canonical source: [`AGENTS.md`](../AGENTS.md) Section 17.
+
+## Candidate rules
+
+### Numbered Cursor rule module rename
+
+* **Problem:** Legacy Cursor rule filenames (`git-safety.mdc`, etc.) differ
+  from recommended numbered modules (`10-git-safety.mdc`).
+* **Proposed rule:** Rename modules in a dedicated PR; keep README mapping
+  until complete.
+* **Priority:** P3
+* **Target file:** `.cursor/rules/`
+* **Trigger:** dedicated tooling PR
+* **Status:** proposed
+
+### VS Code tasks.json safe Maven/git tasks
+
+* **Problem:** No shared tasks for validate/test without commit/push actions.
+* **Proposed rule:** Add `.vscode/tasks.json` per Section 16.16 in tooling PR.
+* **Priority:** P3
+* **Target file:** `.vscode/tasks.json`
+* **Trigger:** developer request or tooling PR
+* **Status:** proposed
+
+### CodeQL workflow for Java 8 Maven
+
+* **Problem:** CodeQL referenced in governance docs but workflow may not
+  exist yet.
+* **Proposed rule:** Add CodeQL workflow with Java 8 build mode; document in
+  `security-policy.md`.
+* **Priority:** P2
+* **Target file:** `.github/workflows/`
+* **Trigger:** CI hardening phase
+* **Status:** proposed
+
+## Experimental rules
+
+### Targeted provider fixture requirement
+
+* **Start date:** (not started)
+* **Reason:** reduce live-network-only validation for plugin PRs
+* **Success criteria:** plugin PRs include offline fixture tests when parser
+  logic changes
+* **Review after:** 5 plugin PRs
+* **Owner:** repository maintainer
+* **Rollback condition:** fixtures add more noise than value
+
+## Deprecated rules to remove later
+
+*(none yet)*
+
+### Propose root `.editorconfig`
+
+* **Problem:** No repository-wide EditorConfig; IDE formatting may drift.
+* **Proposed rule:** Add `.editorconfig` in dedicated tooling PR (19.7).
+* **Priority:** P3
+* **Target file:** `.editorconfig`
+* **Trigger:** tooling PR
+* **Status:** proposed
+
+## Recently completed
+
+* v1.3.0 maintainability guardrails — see changelog
+* v1.1.0 evolutionary governance — see [`agent-rules-changelog.md`](agent-rules-changelog.md)

--- a/docs/agent-rules-backlog.md
+++ b/docs/agent-rules-backlog.md
@@ -1,7 +1,23 @@
 # Agent rules backlog
 
 Future AI rule improvements. Do not bloat `AGENTS.md` — track candidates
-here. Canonical source: [`AGENTS.md`](../AGENTS.md) Section 17.
+here. Canonical source: [`AGENTS.md`](../AGENTS.md) Sections 17 and 20.
+
+When unsure about a new rule, add here instead of making it mandatory
+(Section 20.10).
+
+## Enforcement over expansion (Section 20.12)
+
+Prefer implementing guardrails through tooling rather than new text:
+
+| Gap | Enforcement target | Status |
+|-----|-------------------|--------|
+| Commit/push without approval | branch protection, human review | partial |
+| Maven validate on code PRs | CI required check | exists |
+| Dependency security | Dependabot + Dependency Review | exists |
+| CodeQL Java 8 | workflow (see candidate below) | proposed |
+| Small PR size | review convention | partial |
+| Provider offline fixtures | CI policy (future) | proposed |
 
 ## Candidate rules
 
@@ -63,5 +79,6 @@ here. Canonical source: [`AGENTS.md`](../AGENTS.md) Section 17.
 
 ## Recently completed
 
+* v1.4.0 productivity and anti-bloat guardrails — see changelog
 * v1.3.0 maintainability guardrails — see changelog
 * v1.1.0 evolutionary governance — see [`agent-rules-changelog.md`](agent-rules-changelog.md)

--- a/docs/agent-rules-changelog.md
+++ b/docs/agent-rules-changelog.md
@@ -153,7 +153,8 @@ Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AG
 * Companion docs: `dev-workflow.md`, `dependency-policy.md`,
   `security-policy.md`.
 * VS Code extension recommendations and `settings.example.json`.
-* `agent_space/` gitignore entry.
+* Guidance to propose `agent_space/` gitignore entry in a tooling PR (not
+  committed in the initial rules rollout).
 
 ### Changed
 

--- a/docs/agent-rules-changelog.md
+++ b/docs/agent-rules-changelog.md
@@ -1,0 +1,141 @@
+# Agent rules changelog
+
+Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AGENTS.md).
+
+## 2026-05-28 — v1.3.0
+
+### Added
+
+* Section 19 — Habitv maintainability guardrails (ADR/decisions, DoD,
+  reproducible builds, toolchains, Renovate/Dependabot strategy, dependency
+  provenance, EditorConfig, flaky/network tests, XML config, user data,
+  downloader safety, Windows-first, script parity, manual test evidence,
+  risk levels, rollback, feature flags, logging, performance, UI, errors,
+  worktrees, maintenance dashboard, maintainability report).
+* `docs/maintainability-policy.md`, `docs/maintenance-dashboard.md`,
+  `docs/adr/README.md`.
+* `.cursor/rules/habitv-maintainability.mdc`.
+
+### Changed
+
+* `docs/dependency-policy.md` — provenance and Renovate/Dependabot notes.
+* `scripts/AGENTS.md` — cross-platform and Windows-first rules.
+
+### Removed
+
+* None.
+
+### Reason
+
+* Second-level rules needed for reproducibility, config compatibility, test
+  reliability, and decision tracking without bloating Section 18.
+
+### Follow-up
+
+* Propose `.editorconfig` in dedicated tooling PR (backlog).
+* Populate `maintenance-dashboard.md` during planning reviews.
+
+---
+
+## 2026-05-28 — v1.2.0
+
+### Added
+
+* Section 18 — Habitv-specific modernization (phases, provider status matrix,
+  metadata contract, provider testing, external tools, Java/JavaFX, security
+  tooling lanes, workflow tiers, IDE setup, runtime diagnostics, obsolescence
+  register, release readiness, modernization backlog, Habitv final report).
+* `docs/provider-policy.md`, `docs/release-policy.md`,
+  `docs/obsolescence-register.md`, `docs/modernization-backlog.md`.
+* `.cursor/rules/habitv-providers.mdc`.
+
+### Changed
+
+* Section 17.13 phases now reference Section 18.1 canonical list.
+* `docs/security-policy.md` — SBOM, OWASP, Scorecard, workflow tiers.
+* `plugins/AGENTS.md`, `plugins.instructions.md` — Section 18 alignment.
+
+### Removed
+
+* None.
+
+### Reason
+
+* Habitv needs project-specific rules for providers, external tools, JavaFX
+  wording, security tooling maturity, and release readiness — without
+  duplicating generic gates in Sections 14–17.
+
+### Follow-up
+
+* Populate `obsolescence-register.md` from `provider-inventory.md` audits.
+* Execute modernization backlog items in focused PRs.
+
+---
+
+## 2026-05-28 — v1.1.0
+
+### Added
+
+* Section 17 — evolutionary rules governance (lifecycle states, review
+  cadence, improvement triggers, simplification, drift audit, retirement,
+  automation maturity levels, rule scoring, experimental rules,
+  progress-aware phases).
+* Agent rules metadata block in `AGENTS.md` (version, last updated,
+  related files).
+* `docs/agent-rules-changelog.md` and `docs/agent-rules-backlog.md`.
+* `.cursor/rules/README.md`, `00-canonical-source.mdc`, `90-rule-evolution.mdc`.
+* `.github/instructions/docs.instructions.md`.
+
+### Changed
+
+* Workflow index extended with Section 17 and hard-rule ADR distinction
+  (Section 13 vs Section 17).
+* Cursor rules documentation maps legacy filenames to recommended numbered
+  modules.
+
+### Removed
+
+* None.
+
+### Reason
+
+* Rules accumulated across multiple instruction files during modernization;
+  governance was needed so rules evolve through reviewable PRs, stay
+  auditable, and can be simplified or retired without silent drift.
+
+### Follow-up
+
+* Consider numbered Cursor rule renames (`10-git-safety.mdc`, etc.) in a
+  dedicated tooling PR.
+* Review experimental backlog items after 5 merged agent-rules PRs.
+
+---
+
+## 2026-05-28 — v1.0.0
+
+### Added
+
+* Initial consolidated AI agent rules: Sections 14–16 (manual validation
+  gates, instruction governance, fast safe modernization).
+* Cursor rules, Copilot instructions, nested `AGENTS.md` files.
+* Companion docs: `dev-workflow.md`, `dependency-policy.md`,
+  `security-policy.md`.
+* VS Code extension recommendations and `settings.example.json`.
+* `agent_space/` gitignore entry.
+
+### Changed
+
+* Tool-specific files aligned to reference `AGENTS.md` as canonical source.
+
+### Removed
+
+* None (first versioned baseline).
+
+### Reason
+
+* Replace ad hoc agent behavior with explicit, enforceable workflow gates
+  while preserving manual commit/push/PR approval and Java 8 compatibility.
+
+### Follow-up
+
+* Add evolutionary governance (completed in v1.1.0).

--- a/docs/agent-rules-changelog.md
+++ b/docs/agent-rules-changelog.md
@@ -2,6 +2,38 @@
 
 Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AGENTS.md).
 
+## 2026-05-28 — v1.4.0
+
+### Added
+
+* Section 20 — Productivity and anti-bloat guardrails (minimum viable
+  ruleset, rule profiles, docs-only lightweight path, heavy-gate scope,
+  conflict precedence, rule budget, archive policy, speed/deep mode, stop
+  condition, cleanup cadence, enforcement-over-expansion).
+* `docs/agent-rule-profiles.md` — profile matrix and speed/deep mode detail.
+* `docs/archived-agent-rules.md` — retired rules archive.
+* `.cursor/rules/agent-productivity.mdc` — always-on profile guidance.
+
+### Changed
+
+* Section 16.2 — cross-reference to rule profiles (Section 20.2).
+
+### Removed
+
+* None (anti-bloat policy defers demotion to future cleanup PRs).
+
+### Reason
+
+* Rule surface grew across Sections 14–19; agents need scope control so
+  docs-only work stays fast and detail stays in companion docs.
+
+### Follow-up
+
+* Propose `docs/cleanup-agent-rules` after ~10 merged PRs (Section 20.11).
+* Shift effort to enforcement (CI, branch protection) per Section 20.12.
+
+---
+
 ## 2026-05-28 — v1.3.0
 
 ### Added

--- a/docs/archived-agent-rules.md
+++ b/docs/archived-agent-rules.md
@@ -1,0 +1,21 @@
+# Archived agent rules
+
+Retired or superseded AI agent rules. Active rules live in [`AGENTS.md`](../AGENTS.md).
+
+Do not delete history — move entries here when cleanup PRs downgrade or
+remove mandatory wording (Section 20.7).
+
+## Archive template
+
+```markdown
+### Rule title (archived YYYY-MM-DD)
+
+* **Former location:** AGENTS.md §X.Y
+* **Reason:** superseded by … / enforced by CI / duplicate of …
+* **Replacement:** link or "none — behavior now in branch protection"
+* **Changelog:** vX.Y.Z entry
+```
+
+---
+
+*(no archived rules yet)*

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -1,0 +1,94 @@
+# Dependency update policy
+
+Canonical source: [`AGENTS.md`](../AGENTS.md) Section 16.3 and Section 2
+hard rules.
+
+## Scope
+
+This policy applies to Maven dependencies, Maven plugins, GitHub Actions,
+and tooling dependencies managed through the repository.
+
+## Principles
+
+- **Focused PRs** — one dependency topic per PR when possible.
+- **No mixing** — do not combine dependency updates with feature work.
+- **Java 8 first** — preserve Java 8 compatibility unless a dedicated
+  migration task and ADR authorize otherwise.
+- **Full validation** — run full Maven validation after any dependency
+  change.
+
+## Update categories
+
+| Category | Example | Typical risk |
+|----------|---------|--------------|
+| security patch | CVE fix | high priority |
+| patch update | bugfix release | low |
+| minor update | new features, compatible API | medium |
+| major update | breaking API | high — needs release notes |
+| plugin/tooling update | Maven plugin bump | medium–high |
+| GitHub Actions update | `actions/checkout@vN` | medium |
+
+## Dependabot
+
+Configuration: [`.github/dependabot.yml`](../.github/dependabot.yml)
+
+- targets `develop`
+- limits open PRs to reduce noise
+- groups Maven minor/patch and GitHub Actions updates
+- ignores major JAXB/mail bumps that would violate Java 8 / no-jakarta rules
+- **no auto-merge** unless developer explicitly enables it
+
+Inspect Dependabot config before changing dependency automation.
+
+## Required report
+
+Before commit approval on dependency PRs, provide the **Dependency update
+report** (Section 16.3):
+
+- dependency name, old/new version, update type, reason
+- Java 8 compatibility assessment
+- release notes/changelog checked (yes/no)
+- security impact
+- validation commands with exact results
+- known risks
+
+## Analysis commands
+
+```bash
+mvn -B -ntp dependency:tree
+mvn -B -ntp versions:display-dependency-updates
+mvn -B -ntp versions:display-plugin-updates
+mvn -B -ntp -DskipTests clean package
+mvn -B -ntp test
+```
+
+## Forbidden without tracker + ADR
+
+See `AGENTS.md` Section 2: reactor restructure, Java baseline bump,
+JavaFX migration, JAXB regeneration, youtube-dl → yt-dlp behavior
+replacement, and similar high-blast-radius changes.
+
+## Dependency Review
+
+PRs that change dependencies should pass
+[`.github/workflows/dependency-review.yml`](../.github/workflows/dependency-review.yml)
+when available (fails on high severity).
+
+If Dependency Review is unavailable on the repository plan, document that
+limitation in the PR body.
+
+## Dependency provenance (Section 19.6)
+
+Document name, ecosystem, source, license, versions, Java 8 compatibility,
+security reason, release notes, migration notes, validation. Template in
+[`docs/maintainability-policy.md`](maintainability-policy.md).
+
+## Renovate vs Dependabot (Section 19.5)
+
+Current: Dependabot only (`.github/dependabot.yml`). Renovate requires a
+dedicated PR. Never auto-merge without explicit approval.
+
+## Plugin versioning
+
+Plugin module version bumps must follow `plugin-versioning-policy` in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -14,8 +14,9 @@ and tooling dependencies managed through the repository.
 - **No mixing** — do not combine dependency updates with feature work.
 - **Java 8 first** — preserve Java 8 compatibility unless a dedicated
   migration task and ADR authorize otherwise.
-- **Full validation** — run full Maven validation after any dependency
-  change.
+- **Tiered validation** — run the Section 14.2 tier for the change scope;
+  full root `clean package` only for packaging/release/full-app work when
+  the environment supports it.
 
 ## Update categories
 
@@ -58,8 +59,9 @@ report** (Section 16.3):
 mvn -B -ntp dependency:tree
 mvn -B -ntp versions:display-dependency-updates
 mvn -B -ntp versions:display-plugin-updates
-mvn -B -ntp -DskipTests clean package
-mvn -B -ntp test
+mvn -B -ntp validate
+mvn -B -ntp -pl <module> -am test   # standard dependency scope
+mvn -B -ntp test                    # risky or wide dependency impact
 ```
 
 ## Forbidden without tracker + ADR

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -33,7 +33,7 @@ refactor, packaging, migration preparation, or investigation only.
 1. Create a work branch from latest `origin/develop` (never work on
    `develop` directly).
 2. Use conventional branch prefixes: `fix/`, `feat/`, `docs/`, `test/`,
-   `ci/`, `chore/`, `build/`, `refactor/`.
+   `ci/`, `chore/`, `refactor/`.
 3. Keep PRs small when possible (under 10 files preferred).
 4. Rebase on `origin/develop` to update; never merge `develop` into the
    PR branch.
@@ -41,16 +41,30 @@ refactor, packaging, migration preparation, or investigation only.
 
 ## Validation
 
-**Code changes** (pre-commit):
+Validation tiers (`AGENTS.md` Section 14.2):
+
+**Docs-only:** `git diff --check`; Maven may be skipped with a clear note.
+
+**Standard code changes:**
 
 ```bash
-mvn -B -ntp -DskipTests clean package
-mvn -B -ntp test
+mvn -B -ntp validate
 mvn -B -ntp -pl <module> -am test   # when module-specific
 ```
 
-**Docs-only changes:** `git diff --check`; no Maven unless POM/workflow
-files changed.
+**Risky / code-wide changes:**
+
+```bash
+mvn -B -ntp validate
+mvn -B -ntp test
+```
+
+**Packaging / release / full-app** (when in scope and JavaFX/`jdk.home`
+environment supports it):
+
+```bash
+mvn -B -ntp -DskipTests clean package
+```
 
 Provide exact command output — not vague "build ok" claims (Section 15.15).
 
@@ -70,8 +84,9 @@ Recommended extensions: [`.vscode/extensions.json`](../.vscode/extensions.json).
 Repository rules live in `.cursor/rules/` and `AGENTS.md`. User-level
 Cursor settings are personal preferences only.
 
-Use `agent_space/` for temporary agent scratch work (gitignored per
-`.gitignore`).
+Use `agent_space/` for temporary agent scratch work. If `agent_space/` is
+missing from `.gitignore`, propose adding it in a dedicated tooling PR
+(per `AGENTS.md` Section 15.21).
 
 ## CI overview
 

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -19,6 +19,11 @@ on Habitv modernization.
 At task start, agents report the **Agent startup checklist** (Section
 16.17) and **Instruction files loaded** (Section 15.1).
 
+Pick a **rule profile** before editing (Sections 16.2 and **20.2**). Use
+**speed mode** for docs-only and other low-risk work (Section 20.8); use
+**deep mode** for provider, dependency, packaging, and migration work
+(Section 20.9).
+
 Classify work before editing (Section 16.2 and **18.1** for Habitv phases):
 quick fix, provider/plugin, dependency/security, CI, IDE/tooling, docs-only,
 refactor, packaging, migration preparation, or investigation only.
@@ -86,6 +91,8 @@ for required checks and branch protection.
 - [`docs/modernization-backlog.md`](modernization-backlog.md) — fast modernization queue
 - [`docs/maintenance-dashboard.md`](maintenance-dashboard.md) — planning dashboard
 - [`docs/maintainability-policy.md`](maintainability-policy.md) — DoD, tests, config
+- [`docs/agent-rule-profiles.md`](agent-rule-profiles.md) — profiles, speed/deep mode
+- [`docs/archived-agent-rules.md`](archived-agent-rules.md) — retired rules
 - [`docs/adr/README.md`](adr/README.md) — ADR workflow (see also `decision-log.md`)
 - [`docs/dependency-policy.md`](dependency-policy.md) — dependency updates
 - [`docs/security-policy.md`](security-policy.md) — security fixes
@@ -98,4 +105,4 @@ for required checks and branch protection.
 
 Agents end tasks with the **Final report** (Sections 16.25, **18.19**, and
 **19.25** for maintainability fields) and ask **Approve commit?** before
-any commit.
+any commit. Apply Section 20 profiles for validation scope.

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -1,0 +1,101 @@
+# Habitv developer and agent workflow
+
+Canonical AI agent policy: [`AGENTS.md`](../AGENTS.md) (especially
+Sections 14–16).
+
+This guide summarizes practical workflow for humans and agents working
+on Habitv modernization.
+
+## Principles
+
+- **Fast but safe** — small, focused PRs; one topic per branch.
+- **Java 8 default** — unless a dedicated migration PR says otherwise.
+- **Manual approval** — agents never commit, push, or open PRs without
+  explicit developer approval in the current conversation.
+- **Incremental modernization** — prefer focused changes over rewrites.
+
+## Task startup
+
+At task start, agents report the **Agent startup checklist** (Section
+16.17) and **Instruction files loaded** (Section 15.1).
+
+Classify work before editing (Section 16.2 and **18.1** for Habitv phases):
+quick fix, provider/plugin, dependency/security, CI, IDE/tooling, docs-only,
+refactor, packaging, migration preparation, or investigation only.
+
+## Branch and PR workflow
+
+1. Create a work branch from latest `origin/develop` (never work on
+   `develop` directly).
+2. Use conventional branch prefixes: `fix/`, `feat/`, `docs/`, `test/`,
+   `ci/`, `chore/`, `build/`, `refactor/`.
+3. Keep PRs small when possible (under 10 files preferred).
+4. Rebase on `origin/develop` to update; never merge `develop` into the
+   PR branch.
+5. Target PRs at `Mika3578/habitv` → `develop`.
+
+## Validation
+
+**Code changes** (pre-commit):
+
+```bash
+mvn -B -ntp -DskipTests clean package
+mvn -B -ntp test
+mvn -B -ntp -pl <module> -am test   # when module-specific
+```
+
+**Docs-only changes:** `git diff --check`; no Maven unless POM/workflow
+files changed.
+
+Provide exact command output — not vague "build ok" claims (Section 15.15).
+
+## Local Java 8 setup
+
+Habitv targets Java 8. For GUI/packaging work, use a **JavaFX-capable
+JDK 8** (e.g. Liberica Full JDK 8).
+
+Do **not** commit machine-specific paths in workspace settings. Use
+[`.vscode/settings.example.json`](../.vscode/settings.example.json) as a
+reference; keep actual `JAVA_HOME` and paths in local untracked settings.
+
+## Cursor / VS Code
+
+Recommended extensions: [`.vscode/extensions.json`](../.vscode/extensions.json).
+
+Repository rules live in `.cursor/rules/` and `AGENTS.md`. User-level
+Cursor settings are personal preferences only.
+
+Use `agent_space/` for temporary agent scratch work (gitignored per
+`.gitignore`).
+
+## CI overview
+
+| Workflow | File | Role |
+|----------|------|------|
+| Maven CI | `.github/workflows/ci-maven.yml` | Java 8 validate/test/package |
+| Dependency Review | `.github/workflows/dependency-review.yml` | High-severity dependency gate |
+| Build | `.github/workflows/build.yml` | Additional build diagnostics |
+
+See [`docs/ci.md`](ci.md) and [`docs/repository-governance.md`](repository-governance.md)
+for required checks and branch protection.
+
+## Related policies
+
+- [`docs/provider-policy.md`](provider-policy.md) — providers and external tools
+- [`docs/release-policy.md`](release-policy.md) — release readiness
+- [`docs/modernization-backlog.md`](modernization-backlog.md) — fast modernization queue
+- [`docs/maintenance-dashboard.md`](maintenance-dashboard.md) — planning dashboard
+- [`docs/maintainability-policy.md`](maintainability-policy.md) — DoD, tests, config
+- [`docs/adr/README.md`](adr/README.md) — ADR workflow (see also `decision-log.md`)
+- [`docs/dependency-policy.md`](dependency-policy.md) — dependency updates
+- [`docs/security-policy.md`](security-policy.md) — security fixes
+- [`docs/java-runtime-policy.md`](java-runtime-policy.md) — Java 8 and JavaFX
+- [`docs/agent-rules-changelog.md`](agent-rules-changelog.md) — rule versions
+- [`docs/agent-rules-backlog.md`](agent-rules-backlog.md) — future rule work
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — commit and PR policy
+
+## Final report
+
+Agents end tasks with the **Final report** (Sections 16.25, **18.19**, and
+**19.25** for maintainability fields) and ask **Approve commit?** before
+any commit.

--- a/docs/maintainability-policy.md
+++ b/docs/maintainability-policy.md
@@ -1,0 +1,83 @@
+# Habitv maintainability policy
+
+Canonical source: [`AGENTS.md`](../AGENTS.md) Section 19.
+
+## Definition of Done
+
+Declare before implementation (Section 19.2). If any item cannot be met,
+status is **Not ready to commit**.
+
+## Dependency provenance
+
+Required when adding or updating dependencies or external tools:
+
+| Field | Required |
+|-------|:--------:|
+| name | yes |
+| ecosystem (Maven, npm, binary) | yes |
+| source repository or official site | yes |
+| license | yes |
+| old version | if update |
+| new version | if update |
+| Java 8 compatibility | yes |
+| security reason | if applicable |
+| release notes checked | yes/no |
+| known migration notes | if any |
+| validation performed | yes |
+
+No random mirrors or untrusted binary downloads.
+
+## Manual test evidence
+
+Before commit approval on behavior changes:
+
+```markdown
+* Scenario tested:
+* Command or UI path:
+* Input:
+* Expected result:
+* Actual result:
+* Screenshot/log needed: yes/no
+* Remaining uncertainty:
+```
+
+If not done: **Ready for developer manual testing** (not commit approval).
+
+## PR risk levels
+
+| Level | Examples | Validation |
+|-------|----------|------------|
+| low | docs, narrow isolated fix | focused validation |
+| medium | provider, Maven config, CI, dep patch/minor | targeted + full Maven |
+| high | dep major, Java migration, packaging, config migration | full + manual + review |
+| critical | security, release, DRM/auth, destructive migration | dedicated plan + decision |
+
+## Rollback plan (medium+)
+
+```markdown
+* Files to revert:
+* Command or PR strategy:
+* User impact:
+* Data compatibility concerns:
+* Safe after release: yes/no
+```
+
+## Test failure classification
+
+- related to current change
+- unrelated existing failure
+- flaky
+- environment/network-dependent
+- skipped by design
+- needs investigation
+
+Do not disable tests without developer approval.
+
+## XML / user config
+
+See Section 19.10–19.11. Preserve backward compatibility; test old config
+files; document default changes.
+
+## Scripts
+
+Windows-first validation (19.13); cross-platform `.sh`/`.ps1` parity (19.14).

--- a/docs/maintenance-dashboard.md
+++ b/docs/maintenance-dashboard.md
@@ -1,0 +1,72 @@
+# Habitv maintenance dashboard
+
+Lightweight planning view. Update in dedicated docs/planning PRs or when
+directly relevant (Section 19.24).
+
+**Sources:** [`dev-tracker.md`](dev-tracker.md), [`risk-register.md`](risk-register.md),
+[`provider-inventory.md`](provider-inventory.md), [`modernization-backlog.md`](modernization-backlog.md).
+
+---
+
+## Current phase
+
+*(e.g. stabilization, provider restoration, CI hardening — see AGENTS.md §18.1)*
+
+## Open PR priorities
+
+| Priority | Scope | Branch/PR | Status |
+|----------|-------|-----------|--------|
+| — | — | — | — |
+
+## Security alerts
+
+| Alert | Scope | Action | PR |
+|-------|-------|--------|-----|
+| — | — | — | — |
+
+## Dependency updates
+
+| Dependency | Type | Status | PR |
+|------------|------|--------|-----|
+| — | — | — | — |
+
+## Providers
+
+| Provider | Status | Notes |
+|----------|--------|-------|
+| *(see provider-inventory.md)* | | |
+
+### Broken / degraded summary
+
+- **Broken:** —
+- **Degraded:** —
+- **Obsolete:** see [`obsolescence-register.md`](obsolescence-register.md)
+
+## CI issues
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Maven CI (Java 8) | — | |
+| Dependency review | — | |
+
+## Packaging status
+
+*(Java 8 + JavaFX assumptions; blockers — see release-policy.md)*
+
+## Java migration status
+
+**Current support:** Java 8 only ([`java-runtime-policy.md`](java-runtime-policy.md))
+
+**Preparation:** —
+
+## Next 5 recommended PRs
+
+1. —
+2. —
+3. —
+4. —
+5. —
+
+---
+
+Last reviewed: *(YYYY-MM-DD)*

--- a/docs/modernization-backlog.md
+++ b/docs/modernization-backlog.md
@@ -1,0 +1,78 @@
+# Habitv modernization backlog
+
+Fast-moving modernization work tracked here instead of bloating `AGENTS.md`.
+Canonical rule: [`AGENTS.md`](../AGENTS.md) Section 18.18.
+
+Also see [`dev-tracker.md`](dev-tracker.md) for formal tracker items.
+
+## Categories
+
+- build blockers
+- security
+- dependencies
+- CI
+- providers
+- metadata enrichment
+- external tools
+- packaging
+- Java migration
+- documentation
+- cleanup/removal
+
+## Item template
+
+### \<title\>
+
+* **Priority:** P0 / P1 / P2 / P3
+* **Risk:** low / medium / high
+* **Estimated scope:** small / medium / large
+* **Suggested branch:** `fix/...`, `feat/...`, etc.
+* **Validation required:** Maven commands, manual tests
+* **Blocked by:** tracker item, CI, or dependency
+* **Target phase:** see Section 18.1
+
+## Active candidates
+
+### Provider metadata enrichment pass
+
+* **Priority:** P2
+* **Risk:** medium
+* **Estimated scope:** medium (per provider)
+* **Suggested branch:** `feat/provider-<name>-metadata`
+* **Validation required:** offline fixtures + targeted module tests
+* **Blocked by:** provider status unknown in inventory
+* **Target phase:** metadata enrichment
+
+### CodeQL workflow for Java 8 Maven
+
+* **Priority:** P2
+* **Risk:** low
+* **Estimated scope:** small
+* **Suggested branch:** `ci/codeql-java8`
+* **Validation required:** workflow run on PR
+* **Blocked by:** `docs/required-checks-roadmap.md` phase
+* **Target phase:** CI hardening
+
+### CycloneDX SBOM in CI
+
+* **Priority:** P3
+* **Risk:** low
+* **Estimated scope:** small
+* **Suggested branch:** `ci/sbom-cyclonedx`
+* **Validation required:** dedicated security PR; no SBOM committed
+* **Blocked by:** explicit security modernization scope
+* **Target phase:** dependency/security update
+
+### OpenSSF Scorecard evaluation
+
+* **Priority:** P3
+* **Risk:** low
+* **Estimated scope:** small
+* **Suggested branch:** `ci/scorecard`
+* **Validation required:** dedicated security PR
+* **Blocked by:** maintainer decision
+* **Target phase:** CI hardening
+
+## Completed
+
+*(move items here with PR reference when done)*

--- a/docs/obsolescence-register.md
+++ b/docs/obsolescence-register.md
@@ -1,0 +1,40 @@
+# Habitv obsolescence register
+
+Track obsolete providers, endpoints, and features deliberately. Canonical
+rule: [`AGENTS.md`](../AGENTS.md) Section 18.16.
+
+**Related inventory:** [`provider-inventory.md`](provider-inventory.md) —
+current provider status table.
+
+Do not delete legacy providers silently. Mark, replace, deprecate, or remove
+in focused PRs.
+
+## Register template
+
+| Provider / feature | Old endpoint or behavior | Replacement | Status | Removal plan | Risk | Related PR |
+|--------------------|--------------------------|-------------|--------|--------------|------|------------|
+| *(example)* | *(dead URL)* | *(new service)* | obsolete | *(tracker/PR)* | low | — |
+
+### Status values
+
+Use the provider status matrix from [`provider-policy.md`](provider-policy.md):
+working, degraded, protected, obsolete, removed, unknown.
+
+## When to add an entry
+
+- endpoint confirmed dead or replaced;
+- provider removed from active list;
+- external tool replaced (see [`external-tools-recommendations.md`](external-tools-recommendations.md));
+- platform DRM/auth change makes prior approach obsolete.
+
+## When to update
+
+- provider restored or degraded status changes;
+- replacement service validated;
+- removal completed — move to **removed** with PR reference.
+
+## Initial notes
+
+Populate from [`provider-inventory.md`](provider-inventory.md) and tracker
+items as providers are validated. This register is the **removal/obsolete
+planning** view; inventory is the **current status** view.

--- a/docs/provider-policy.md
+++ b/docs/provider-policy.md
@@ -1,0 +1,72 @@
+# Habitv provider policy
+
+Canonical source: [`AGENTS.md`](../AGENTS.md) Section 18 and Section 15.24.
+
+Related: [`provider-inventory.md`](provider-inventory.md),
+[`obsolescence-register.md`](obsolescence-register.md),
+[`external-tools-recommendations.md`](external-tools-recommendations.md),
+[`plugins/AGENTS.md`](../plugins/AGENTS.md).
+
+## Project phase
+
+Declare phase, risk, expected files, validation plan, and Java 8 impact
+before provider work (Section 18.1).
+
+## Provider status matrix
+
+Update [`provider-inventory.md`](provider-inventory.md) and/or
+[`obsolescence-register.md`](obsolescence-register.md) when status changes.
+
+| Status | When to use |
+|--------|-------------|
+| working | tests + real behavior validated when feasible |
+| degraded | partial function or known gaps |
+| protected | auth, cookies, DRM, geoblocking, anti-bot |
+| obsolete | dead/replaced endpoint |
+| removed | intentionally delisted |
+| unknown | not recently validated |
+
+## Metadata quality contract
+
+Target fields when the provider exposes them: channel, program title,
+episode title, broadcast date, duration, summary, thumbnail, season/episode
+numbers, replay URL, download URL or downloader command, availability end.
+
+Document why metadata is missing. Do not claim support without validation.
+
+## Testing
+
+**Preferred:** offline fixtures, parser tests, URL extraction, command-building,
+`mvn -B -ntp -pl plugins/<module> -am test`.
+
+**Live checks:** supplementary only. If skipped, document reason.
+
+**Never:** bypass DRM; commit cookies, sessions, tokens, browser profiles.
+
+## External tools
+
+Tools: yt-dlp, ffmpeg, aria2, rclone, curl, rtmpdump.
+
+Dedicated PRs for tool updates. No binaries in git unless requested. No mixing
+with provider behavior changes.
+
+### External tool update report
+
+```markdown
+## External tool update report
+
+* Tool:
+* Old version:
+* New version:
+* Source:
+* Checksum:
+* Reason:
+* Compatibility:
+* Validation:
+* Risk:
+```
+
+## Runtime diagnostics
+
+Short root-cause messages for expected provider failures; avoid noisy stack
+traces; preserve debug detail where useful; never swallow unexpected errors.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,50 @@
+# Habitv release policy
+
+Canonical source: [`AGENTS.md`](../AGENTS.md) Section 18.17.
+
+Related: [`java-runtime-policy.md`](java-runtime-policy.md),
+[`provider-inventory.md`](provider-inventory.md),
+[`dependency-policy.md`](dependency-policy.md),
+[`security-policy.md`](security-policy.md).
+
+## Before release or packaging work
+
+Verify:
+
+- full Maven build and tests;
+- provider status summary (working / degraded / obsolete);
+- dependency and security check status;
+- external tool versions documented;
+- Java 8 and JavaFX runtime assumptions documented;
+- packaging scripts reviewed;
+- changelog updated;
+- known limitations listed.
+
+Use phase **release preparation** or **packaging** (Section 18.1).
+
+## Release readiness report
+
+```markdown
+## Release readiness report
+
+* Version:
+* Java runtime:
+* JavaFX strategy:
+* Maven validation:
+* Tests:
+* Providers working:
+* Providers degraded:
+* Providers obsolete:
+* Security checks:
+* External tools:
+* Packaging:
+* Known limitations:
+* Release blocker list:
+```
+
+## Packaging PR scope
+
+Keep packaging changes in dedicated PRs. Do not mix with provider refactors,
+dependency updates, or docs-only cleanup.
+
+See [`packaging/AGENTS.md`](../packaging/AGENTS.md) when present.

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -20,7 +20,7 @@ documented CVEs, the agent must:
    transitive.
 2. Prefer upgrading to a **Java 8-compatible** safe version.
 3. Document if no Java 8-compatible fix exists and propose alternatives.
-4. Run full Maven validation after the fix.
+4. Run the appropriate Maven validation tier (Section 14.2) after the fix.
 5. Avoid suppressing alerts without a clear written reason.
 
 ## Agent must not
@@ -80,12 +80,26 @@ Security PRs should be focused:
 ## SBOM (Section 18.9)
 
 Propose CycloneDX or equivalent in a **dedicated security/tooling PR**.
+Do not enable in unrelated PRs.
+
+**Prerequisites:**
+
+- a dedicated tracker item;
+- a dedicated security/tooling PR;
+- an ADR when the change affects repository policy or CI behavior.
+
+`AGENTS.md` Section 2 still forbids adding SBOM plugins without an
+explicit tracker item and ADR.
+
 Document generation location. Do not commit generated SBOM unless required.
 Prefer CI artifacts.
 
 ## OWASP Dependency-Check (Section 18.10)
 
-If used:
+If used, same prerequisites as SBOM (tracker item, dedicated security PR,
+ADR when policy/CI changes; no unrelated PR enablement; Section 2 hard rule).
+
+Operational rules:
 
 - do not disable to green CI;
 - stable cache; no corrupted DB cache;

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -1,0 +1,112 @@
+# Security update policy (agents and contributors)
+
+Canonical sources:
+
+- [`AGENTS.md`](../AGENTS.md) Section 16.4
+- [`SECURITY.md`](../SECURITY.md) — vulnerability reporting
+- [`docs/risk-register.md`](risk-register.md) — tracked risks
+
+## Priority
+
+Security fixes take priority over cosmetic cleanup, refactors, and
+non-blocking docs work (see Section 16.19 PR queue).
+
+## When an alert exists
+
+For Dependabot alerts, CodeQL findings, dependency review failures, or
+documented CVEs, the agent must:
+
+1. Identify scope: runtime, test-only, plugin-only, build-only, or
+   transitive.
+2. Prefer upgrading to a **Java 8-compatible** safe version.
+3. Document if no Java 8-compatible fix exists and propose alternatives.
+4. Run full Maven validation after the fix.
+5. Avoid suppressing alerts without a clear written reason.
+
+## Agent must not
+
+- ignore security alerts
+- silence CodeQL without justification
+- disable Dependabot or dependency review
+- weaken branch protection to make CI green
+- add broad `permissions:` to workflows
+- commit secrets, tokens, cookies, or credentials
+- disable analysis instead of fixing Java 8 / Maven workflow setup
+
+## Reporting vulnerabilities
+
+Do **not** open public issues for security vulnerabilities. Use GitHub
+private security advisories per [`SECURITY.md`](../SECURITY.md).
+
+## CodeQL
+
+CodeQL should remain enabled when possible. See
+[`docs/required-checks-roadmap.md`](required-checks-roadmap.md) for rollout
+status. Do not remove CodeQL workflows without explicit approval.
+
+If CodeQL fails on Java 8 Maven builds, fix JDK/workflow configuration
+rather than disabling analysis.
+
+## Dependency Review
+
+High-severity vulnerable dependencies introduced in PRs should fail
+dependency review (see `.github/workflows/dependency-review.yml`).
+
+## Workflow changes
+
+Before modifying security-related workflows, complete the **Workflow
+safety checklist** (Section 16.8):
+
+- document permission changes
+- avoid `pull_request_target` unless justified
+- pin trusted action versions
+- never expose secrets to fork PRs
+
+## Known sensitive areas
+
+See `SECURITY.md` and `docs/risk-register.md` for hardcoded credentials,
+legacy hosts, and other tracked risks. Do not extend or re-enable unsafe
+patterns.
+
+## Security update PR scope
+
+Security PRs should be focused:
+
+- dependency/security update classification
+- dependency update report when versions change
+- exact validation evidence
+- no unrelated refactors or formatting
+
+## SBOM (Section 18.9)
+
+Propose CycloneDX or equivalent in a **dedicated security/tooling PR**.
+Document generation location. Do not commit generated SBOM unless required.
+Prefer CI artifacts.
+
+## OWASP Dependency-Check (Section 18.10)
+
+If used:
+
+- do not disable to green CI;
+- stable cache; no corrupted DB cache;
+- NVD API key via GitHub secrets only;
+- document suppressions:
+
+```markdown
+* CVE:
+* Dependency:
+* Reason:
+* Scope:
+* Expiry/review date:
+* Link to upstream issue if available:
+```
+
+## OpenSSF Scorecard (Section 18.12)
+
+Dedicated security PR only. Document permissions, schedule, Security tab,
+noise, and follow-ups.
+
+## Workflow tiers (Section 18.13)
+
+See `AGENTS.md` Section 18.13 and `.cursor/rules/workflows.mdc` for PR fast,
+security, packaging, and scheduled tiers.

--- a/packaging/AGENTS.md
+++ b/packaging/AGENTS.md
@@ -1,0 +1,30 @@
+# Packaging agent instructions
+
+Extends the root [`AGENTS.md`](../AGENTS.md). When they conflict, the
+root file wins.
+
+## Scope
+
+Packaging, installers, platform bundling, and staging scripts that
+produce distributable artifacts.
+
+## Path-specific rules
+
+- No installer or binary scope creep unless explicitly requested.
+- No platform packaging unless the task requires it.
+- Do not add binaries (`.exe`, `.zip`, `.dll`, generated `.jar`) unless
+  explicitly requested and developer-approved before staging.
+- JavaFX packaging requires a Java 8 JDK with JavaFX; document
+  constraints in validation evidence.
+- Do not commit `target/` outputs, downloaded tools, or local logs.
+
+## Validation
+
+Document exact packaging commands, pass/fail results, and manual tests
+for the produced artifact. Follow root `AGENTS.md` Section 15.15.
+
+## Instruction loading
+
+At task start, report **Instruction files loaded** including this file,
+`.github/instructions/packaging.instructions.md`, and root `AGENTS.md`
+Section 15.1.

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -1,0 +1,47 @@
+# Plugin agent instructions
+
+Extends the root [`AGENTS.md`](../AGENTS.md). When they conflict, the
+root file wins.
+
+## Scope
+
+This file applies to work under `plugins/` — provider, downloader, and
+export plugins plus `plugin-tester`.
+
+Full policy: [`docs/provider-policy.md`](../docs/provider-policy.md) and
+`AGENTS.md` Section 18.
+
+## Path-specific rules
+
+- Declare Habitv **phase** before editing (Section 18.1).
+- Do not rewrite providers without a scoped tracker item and ADR.
+- Update provider **status** when changing behavior (Section 18.2).
+- Preserve/improve **metadata** when validated (Section 18.3).
+- Plugin version bumps must match `plugin-versioning-policy` triggers in
+  [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+- Internal reactor deps in a bumped plugin MUST use
+  `${project.parent.version}`, never `${project.version}`.
+- Prefer offline fixtures and opt-in network tests; do not add live
+  provider tests to the default lifecycle.
+- Do not rely on live-network-only validation as proof of correctness.
+- Distinguish offline unit tests, live/network tests, and manual tests
+  (Section 15.24).
+- If live tests are skipped (geoblocking, auth, DRM, rate limits), state
+  why clearly.
+- Keep changes scoped to one provider or plugin module when possible.
+- No secrets, binaries, or manual JAXB/XML generated-file edits unless
+  explicitly required (root `AGENTS.md` Sections 15.9, 15.12–15.13).
+
+## Validation
+
+When Java or POM files under `plugins/` change, run root `AGENTS.md`
+Section 14.2 validation plus targeted module tests:
+
+```bash
+mvn -B -ntp -pl plugins/<module> -am test
+```
+
+## Instruction loading
+
+At task start, report **Instruction files loaded** including this file
+and root `AGENTS.md` Section 15.1.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,39 @@
+# Scripts agent instructions
+
+Extends the root [`AGENTS.md`](../AGENTS.md). When they conflict, the
+root file wins.
+
+## Scope
+
+This file applies to work under `scripts/` — maintenance, packaging
+helpers, static-repo tooling, and security inventory scripts.
+
+## Path-specific rules
+
+- Do not commit secrets, tokens, local absolute paths, or credentials.
+- Prefer deterministic, documented commands; state OS assumptions
+  (PowerShell vs bash) in script headers or companion docs.
+- Do not re-enable runtime calls to legacy hosts (`dabiboo.free.fr`,
+  `ftpperso.free.fr`) without explicit tracker approval.
+- Keep script changes scoped; do not mix unrelated refactors.
+- No destructive scripts without explicit developer approval.
+- Maintain PowerShell/Bash parity when a script has both `.ps1` and
+  `.sh` variants.
+- When a script affects packaging or deployment layout, coordinate with
+  `packaging/AGENTS.md` and `.github/instructions/packaging.instructions.md`.
+- **Cross-platform parity:** if both `.sh` and `.ps1` exist, update both or
+  explain why not (Section 19.14).
+- **Windows-first:** quote paths with spaces; do not assume Linux-only
+  behavior (Section 19.13).
+
+## Validation
+
+- Shell/Python script changes: run the script in a safe dry-run or
+  document why execution was skipped.
+- If scripts invoke Maven or touch POMs indirectly, follow root
+  `AGENTS.md` Section 14.2.
+
+## Instruction loading
+
+At task start, report **Instruction files loaded** including this file
+and root `AGENTS.md` Section 15.1.


### PR DESCRIPTION
## Related issue

(none)

## Scope

ai-rules-workflow-and-productivity

## Summary

Centralize Habitv AI/dev agent workflow rules in three focused commits: manual validation gates, instruction governance, Habitv-specific guidance, maintainability guardrails, productivity/anti-bloat scope control, and Copilot review follow-ups.

## Changes

**Commit 1** (22461b6f) — centralized safe agent workflow rules:

* AGENTS.md Sections 14–19
* Companion docs (provider/release/security/dependency/maintainability policies, etc.)
* Cursor rules, Copilot instructions, nested AGENTS.md files
* .vscode/extensions.json, .vscode/settings.example.json

**Commit 2** (2faf9b41) — productivity and anti-bloat guardrails:

* AGENTS.md Section 20
* docs/agent-rule-profiles.md, docs/archived-agent-rules.md
* .cursor/rules/agent-productivity.mdc
* Cross-reference updates in changelog, backlog, Copilot, and Cursor rules

**Commit 3** (2a2e5b3d) — addressed Copilot review feedback:

* aligned SBOM/OWASP/security-tooling guidance with the existing tracker/ADR hard-rule requirement;
* replaced universal root clean package guidance with tiered validation;
* removed deprecated build/ branch-prefix references;
* fixed canonical AGENTS.md links and agent_space wording;
* updated packaging/profile references.

Documentation/rules-only scope. No Java source, POM, workflow, packaging, or runtime behavior changes.

## Review status

* Copilot generated 23 comments.
* All review threads are resolved.
* Latest Copilot review generated no new comments.

## Validation

* git diff --check — passed
* mvn validate — skipped, docs/rules-only
* GitHub Actions: Maven CI and Dependency Review green

Remaining follow-up files are intentionally excluded from this PR and preserved in stash:

* .gitignore
* CLAUDE.md
* CONTRIBUTING.md
* .cursor/rules/pr-style.mdc

## Risk / rollback

Low — documentation and AI instruction files only. Revert all commits to restore prior agent guidance.

## Notes

Three-commit split keeps §14–§19 foundation separate from §20 productivity rules, with a third commit for Copilot review follow-ups. Follow-up PRs may cover excluded files and .gitignore tooling updates.
