### PR TITLE
ci: add manual Maven CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  schedule:
+    - cron: "37 4 * * 1"
+
+permissions:
+  security-events: write
+  packages: read
+  actions: read
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  analyze-java:
+    name: Analyze Java
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Liberica JDK 8 with JavaFX
+        uses: ./.github/actions/setup-build-jdk
+        with:
+          distribution: liberica
+          java-version: "8"
+          java-package: jdk+fx
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      - name: Build Maven reactor
+        run: mvn -B -ntp -DskipTests verify
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -18,7 +18,7 @@
 | Maven CI | `.github/workflows/ci-maven.yml` | `develop` PR validation: validate, deterministic tests, package |
 | Build | `.github/workflows/build.yml` | Legacy `master` push/PR coverage only; not part of the `develop` merge baseline |
 | Dependency Review | `.github/workflows/dependency-review.yml` | Blocks new high/critical dependency issues on PRs |
-| CodeQL | (repository default setup) | Code scanning alerts |
+| CodeQL | `.github/workflows/codeql.yml` | Java static analysis via manual Maven reactor build (`build-mode: manual`) |
 | Labeler | `.github/workflows/labeler.yml` | Path-based PR labels (not required) |
 | Stale | `.github/workflows/stale.yml` | Inactivity labels (no auto-close) |
 
@@ -79,7 +79,12 @@ tests over time (`provider-inventory`, `live-tests-flaky` risk).
   update PRs; semver-major ignored; no auto-merge.
 - **Dependency Review** — fails PRs that introduce new high/critical vulns in
   dependencies.
-- **CodeQL** — separate from Maven CI.
+- **CodeQL** — `.github/workflows/codeql.yml`; triggers on `pull_request` and
+  `push` to `develop` plus a weekly schedule. Uses advanced setup with
+  `build-mode: manual` and `mvn -B -ntp -DskipTests verify` so extraction
+  follows the Maven reactor instead of default setup `build-mode: none`.
+  Separate from Maven CI; not a required merge check until the workflow is
+  green on a PR and on `develop` after merge.
 
 Details: [`repository-maintenance.md`](repository-maintenance.md).
 


### PR DESCRIPTION
## Summary
- Add an in-repository CodeQL workflow for Java analysis.
- Use advanced setup with manual Maven build mode.
- Build the full Maven reactor during CodeQL extraction so analysis follows the project build instead of default setup build-mode none.
- Document the CodeQL workflow and the current maintenance rule in `docs/ci.md`.

## Why
The current GitHub default setup reports Java extraction with build-mode none and a duplicate-class warning. Habitv is a Maven reactor, so manual build mode gives CodeQL the same source set Maven compiles and avoids relying on raw source scanning.

## Validation
- `git diff --check`
- CodeQL workflow content check
- `mvn -B -ntp -DskipTests verify`
- `yamllint .github/workflows/codeql.yml` if available

## Notes
- CodeQL should not be added as a required branch protection check until this workflow is green on the PR and then on `develop` after merge.
- GitHub default setup still includes `java-kotlin`, so Java may be scanned twice until default setup is adjusted after this PR proves green.
- The duplicate-class paths were not visible in the old default setup Actions log. Re-check diagnostics after the first manual-build CodeQL run.
