### PR TITLE
build: configure Maven resource encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<!-- Local Maven staging only; runtime uses FrameworkConf.UPDATE_URL (GitHub Pages). -->
 		<habitv.static.repo.path>${user.home}/dev/habitv-repo/repository</habitv.static.repo.path>
 	</properties>
@@ -146,6 +147,19 @@
 			</resource>			
 		</resources>	
 		<sourceDirectory>src</sourceDirectory>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.4.0</version>
+					<configuration>
+						<encoding>${project.build.sourceEncoding}</encoding>
+						<propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- Configure Maven resource/properties encoding explicitly.
- Keep encoding centralized in the parent Maven configuration.
- Remove the Maven Resources warning about filtered properties encoding.

## Why
Maven Resources warned that the encoding used to copy filtered properties files was not set. Setting it explicitly to the project UTF-8 encoding makes the build behavior deterministic across environments.

## Validation
- `git diff --check`
- `mvn -B -ntp -DskipTests verify`
- Before/after grep for the Maven Resources filtered-properties encoding warning
