### PR TITLE
docs: document Lombok compiler warning

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -88,6 +88,46 @@ tests over time (`provider-inventory`, `live-tests-flaky` risk).
 
 Details: [`repository-maintenance.md`](repository-maintenance.md).
 
+## Accepted CodeQL build warnings (Lombok / final-field mutation)
+
+During the **CodeQL** manual Maven build (`Build Maven reactor` step), logs
+may emit warnings such as:
+
+```text
+WARNING: Final field fileManager in class javac_extend.com.sun.tools.javac.jvm.ClassWriter
+  has been mutated reflectively by class lombok.permit.Permit in unnamed module @…
+WARNING: Use --enable-final-field-mutation=ALL-UNNAMED to avoid a warning
+WARNING: Mutating final fields will be blocked in a future release unless
+  final field mutation is enabled
+```
+
+**Audit result:** Habitv does **not** declare or use Lombok. A full reactor
+`dependency:tree` filter for `org.projectlombok:lombok` is empty, and no
+module source uses Lombok annotations. The warning is **not** reproduced by
+local or Maven CI builds on Java 8 (for example `mvn -B -ntp -DskipTests
+verify` on Zulu/Liberica 8).
+
+**Root cause:** After `codeql database init --begin-tracing`, CodeQL wraps
+the manual Maven build with its Java extractor environment (`LD_PRELOAD`,
+`CODEQL_JAVA_HOME`, and related tracing variables). That toolchain uses
+Lombok’s `Permit` helper to patch `javac` internals for extraction. The
+warnings come from JDK **final-field mutation** restrictions (JEP 500 and
+related `--enable-final-field-mutation` guidance) interacting with CodeQL’s
+bundled tooling—not from Habitv application code or Maven dependencies.
+
+**Status today:** Non-blocking. CodeQL analysis completes successfully; Maven
+CI required jobs do not show this warning.
+
+**Why not suppressed:** Adding `--enable-final-field-mutation=ALL-UNNAMED` (or
+similar JVM flags) to Maven or CI would hide the message without removing the
+underlying CodeQL/JDK interaction and is out of scope for application POM
+changes. This PR does not modify `.github/workflows/codeql.yml`.
+
+**Follow-up:** Revisit when the Java baseline moves beyond Java 8 and CodeQL
+runner/JDK tooling is upgraded as part of the Java 21/25 modernization track
+(`java-runtime-policy`, `javafx-modernization`). A durable fix likely belongs
+in CodeQL workflow or extractor configuration, not in Habitv source.
+
 ## Local command parity
 
 Before opening a PR:

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -54,6 +54,15 @@ See [`pull-request-style-guide.md`](pull-request-style-guide.md).
 Live provider tests must not become required checks until replaced or reliably
 quarantined — see [`ci.md`](ci.md).
 
+### CodeQL-only compiler warnings (Lombok `Permit`)
+
+The Habitv reactor does not use Lombok. If CodeQL logs mention
+`lombok.permit.Permit` or `--enable-final-field-mutation` during the manual
+Maven verify step, treat that as an **accepted, CodeQL-tracer warning**—not a
+project dependency or compiler-plugin defect. Maven CI on Java 8 does not
+emit it. Do not add Maven `-q`, log filtering, or JVM flags in application POMs
+to silence it. See the audit notes in [`ci.md`](ci.md#accepted-codeql-build-warnings-lombok--final-field-mutation).
+
 ## Documentation sync
 
 When process, scope, or status changes, keep aligned in the **same commit**:


### PR DESCRIPTION
## Related issue

(none)

## Scope

lombok-compiler-warning-audit

## Summary

- Audited Lombok usage across the Maven reactor: Habitv does not declare or use Lombok.
- Confirmed the final-field mutation warning appears only in CodeQL manual Maven builds, not in Maven CI or local Java 8 verify.
- Documented the warning as accepted and non-blocking until Java/CodeQL modernization; no suppression flags added.

## Changes

- `docs/ci.md`: new section on accepted CodeQL Lombok/final-field-mutation warnings (root cause, status, follow-up).
- `docs/repository-maintenance.md`: pointer for maintainers not to treat this as a project defect.

## Validation

- `git diff --check`: pass
- `mvn -B -ntp -DskipTests verify`: pass (exit 0)
- Before grep (local verify): no matches for Lombok/final-field-mutation patterns
- After grep (local verify): no matches for Lombok/final-field-mutation patterns
- CodeQL evidence (develop run 26641040910): warnings present in Build Maven reactor step (documented, not fixed here)
- Commit attribution grep: pass

## Risk / rollback

Low risk docs-only change. Revert the commit to remove the documentation.

## Notes

- Does not modify `.github/workflows/codeql.yml`, Maven resource encoding, or Shade/JAXB/Activation warnings.
- No Lombok version upgrade attempted because Lombok is not a project dependency.