### PR TITLE
test: remove live URL dependency from deterministic test

### DIFF
--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/TestUrl.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/TestUrl.java
@@ -1,15 +1,68 @@
 package com.dabi.habitv.framework.plugin.utils;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Offline coverage for {@link RetrieverUtils#getTitleByUrl(String)}.
+ * Does not call external websites (deterministic CI).
+ */
 public class TestUrl {
 
-	@Test
-	public void test() {
+	private static final String EXPECTED_TITLE = "Offline fixture title";
+	private static final String HTML = "<!DOCTYPE html><html><head><title>" + EXPECTED_TITLE
+			+ "</title></head><body></body></html>";
 
-		RetrieverUtils.getTitleByUrl("http://www.beinsports.fr");
-		// RetrieverUtils.getTitleByUrl("http%3A%2F%2Fwww.beinsports.fr%2Fvideos%2Ftitle%2FLiga%20%3A%20Barcelone%204-0%20Almeria%2Farticle%2F3kgv5a6r3li41xod5wm0znvz5");
-		// RetrieverUtils.getTitleByUrl("http://www.beinsports.fr/videos/title/Liga : Barcelone 4-0 Almeria/article/3kgv5a6r3li41xod5wm0znvz5");
+	private HttpServer server;
+	private String localUrl;
+
+	@Before
+	public void setUp() throws IOException {
+		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/", new HttpHandler() {
+			@Override
+			public void handle(final HttpExchange exchange) throws IOException {
+				final byte[] body = htmlBytes();
+				exchange.getResponseHeaders().set("Content-Type", "text/html; charset=UTF-8");
+				exchange.sendResponseHeaders(200, body.length);
+				final OutputStream out = exchange.getResponseBody();
+				out.write(body);
+				out.close();
+			}
+		});
+		server.start();
+		localUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
 	}
 
+	@After
+	public void tearDown() {
+		if (server != null) {
+			server.stop(0);
+		}
+	}
+
+	@Test
+	public void getTitleByUrl_extractsTitleFromLocalHtmlPage() {
+		assertEquals(EXPECTED_TITLE, RetrieverUtils.getTitleByUrl(localUrl));
+	}
+
+	private static byte[] htmlBytes() {
+		try {
+			return HTML.getBytes("UTF-8");
+		} catch (final UnsupportedEncodingException e) {
+			throw new AssertionError(e);
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Replace or quarantine the live BeIN Sports URL dependency in `TestUrl`.
- Keep deterministic Java 8 CI independent from external websites.

## Why
`deterministic-tests-java8` failed because `TestUrl` called a live BeIN Sports URL and received HTTP 403. A deterministic CI test should not depend on a live replay/provider website.

## Scope
quarantine-live-url-test

## Changes
- `TestUrl` serves fixed HTML from `127.0.0.1` via JDK `HttpServer` and asserts `RetrieverUtils.getTitleByUrl` extracts the title.

## Validation
- `mvn -B -ntp -pl fwk/framework -Dtest=TestUrl test`
- `mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am test`
- `mvn -B -ntp -DskipTests verify`
- `git diff --check`

## Risk / rollback
- Test-only change; revert the commit if title extraction regressions are suspected.

## Notes
- Test sources live under `fwk/framework/test/` (parent POM `testSourceDirectory`), not `src/test/java`.
