### PR TITLE
Harden YouTube Data API lookup handling

### DIFF
--- a/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/XMLUserConfig.java
@@ -404,14 +404,18 @@ public class XMLUserConfig implements UserConfig {
 		final Map<String, String> downloaderName2BinPath = new HashMap<>();
 		if (downloaders != null) {
 			for (final Object downloader : downloaders.getAny()) {
-				String binPath = XMLUtils.getTagValue(downloader);
-				if (!binPath.isEmpty() && !binPath.startsWith("/")
-						&& !binPath.matches("[a-zA-Z]:.*")) {
-					binPath = getAppDir() + "/" + binPath;
+				final String tagName = XMLUtils.getTagName(downloader);
+				String value = XMLUtils.getTagValue(downloader);
+				if (YOUTUBE_API_KEY.equals(tagName) || EMBED_SUBTITLES.equals(tagName)) {
+					downloaderName2BinPath.put(tagName, value.replace("\\", "/"));
+					continue;
 				}
-				binPath = binPath.replace("\\", "/");
-				downloaderName2BinPath.put(XMLUtils.getTagName(downloader),
-						binPath);
+				if (!value.isEmpty() && !value.startsWith("/")
+						&& !value.matches("[a-zA-Z]:.*")) {
+					value = getAppDir() + "/" + value;
+				}
+				value = value.replace("\\", "/");
+				downloaderName2BinPath.put(tagName, value);
 			}
 		}
 		return downloaderName2BinPath;
@@ -526,7 +530,7 @@ public class XMLUserConfig implements UserConfig {
 
 	@Override
 	public String getYoutubeApiKey() {
-		return normalizeValue(getDownloader().get(YOUTUBE_API_KEY));
+		return YoutubeApiKeyConfig.sanitizePlainConfigValue(getDownloader().get(YOUTUBE_API_KEY));
 	}
 
 	@Override
@@ -589,7 +593,7 @@ public class XMLUserConfig implements UserConfig {
 
 	@Override
 	public void setYoutubeApiKey(String youtubeApiKey) {
-		String normalizedValue = normalizeValue(youtubeApiKey);
+		String normalizedValue = YoutubeApiKeyConfig.sanitizePlainConfigValue(youtubeApiKey);
 		Downloaders downloaders = loadDownloaders();
 		Iterator<Object> iterator = downloaders.getAny().iterator();
 		while (iterator.hasNext()) {

--- a/application/core/src/com/dabi/habitv/core/config/YoutubeApiKeyConfig.java
+++ b/application/core/src/com/dabi/habitv/core/config/YoutubeApiKeyConfig.java
@@ -1,0 +1,24 @@
+package com.dabi.habitv.core.config;
+
+/**
+ * Plain-string handling for the optional YouTube Data API key in user configuration.
+ * Must never be resolved as a filesystem path.
+ */
+public final class YoutubeApiKeyConfig {
+
+	private YoutubeApiKeyConfig() {
+	}
+
+	public static String sanitizePlainConfigValue(final String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		if (trimmed.length() >= 2
+				&& ((trimmed.startsWith("\"") && trimmed.endsWith("\""))
+						|| (trimmed.startsWith("'") && trimmed.endsWith("'")))) {
+			trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+		}
+		return trimmed.isEmpty() ? null : trimmed;
+	}
+}

--- a/application/core/src/com/dabi/habitv/core/config/YoutubeApiKeySystemProperty.java
+++ b/application/core/src/com/dabi/habitv/core/config/YoutubeApiKeySystemProperty.java
@@ -1,0 +1,37 @@
+package com.dabi.habitv.core.config;
+
+/**
+ * Applies the optional YouTube Data API key from user configuration to the JVM
+ * system property {@value #PROPERTY_NAME}, without clearing values supplied
+ * externally (for example {@code -Dhabitv.youtube.apiKey=...}).
+ */
+public final class YoutubeApiKeySystemProperty {
+
+	public static final String PROPERTY_NAME = "habitv.youtube.apiKey";
+
+	private static boolean appliedFromUserConfig;
+
+	private YoutubeApiKeySystemProperty() {
+	}
+
+	public static void applyFromUserConfig(final String youtubeApiKey) {
+		final String sanitized = YoutubeApiKeyConfig.sanitizePlainConfigValue(youtubeApiKey);
+		if (sanitized != null) {
+			System.setProperty(PROPERTY_NAME, sanitized);
+			appliedFromUserConfig = true;
+			return;
+		}
+		if (appliedFromUserConfig) {
+			System.clearProperty(PROPERTY_NAME);
+			appliedFromUserConfig = false;
+		}
+	}
+
+	static void resetStateForTests() {
+		appliedFromUserConfig = false;
+	}
+
+	static boolean isAppliedFromUserConfigForTests() {
+		return appliedFromUserConfig;
+	}
+}

--- a/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
+++ b/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
@@ -13,6 +13,7 @@ import com.dabi.habitv.api.plugin.dto.ProxyDTO;
 import com.dabi.habitv.api.plugin.dto.ProxyDTO.ProtocolEnum;
 import com.dabi.habitv.core.config.HabitTvConf;
 import com.dabi.habitv.core.config.UserConfig;
+import com.dabi.habitv.core.config.YoutubeApiKeyConfig;
 import com.dabi.habitv.core.token.TokenReplacer;
 import com.dabi.habitv.framework.FWKProperties;
 import com.dabi.habitv.framework.plugin.utils.RetrieverUtils;
@@ -87,8 +88,11 @@ public final class CoreManager {
 	}
 
 	private void applyYoutubeApiKey(String youtubeApiKey) {
-		if (youtubeApiKey != null && !youtubeApiKey.trim().isEmpty()) {
-			System.setProperty(YOUTUBE_API_KEY_PROPERTY, youtubeApiKey.trim());
+		final String sanitized = YoutubeApiKeyConfig.sanitizePlainConfigValue(youtubeApiKey);
+		if (sanitized != null) {
+			System.setProperty(YOUTUBE_API_KEY_PROPERTY, sanitized);
+		} else {
+			System.clearProperty(YOUTUBE_API_KEY_PROPERTY);
 		}
 	}
 

--- a/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
+++ b/application/core/src/com/dabi/habitv/core/mgr/CoreManager.java
@@ -13,14 +13,13 @@ import com.dabi.habitv.api.plugin.dto.ProxyDTO;
 import com.dabi.habitv.api.plugin.dto.ProxyDTO.ProtocolEnum;
 import com.dabi.habitv.core.config.HabitTvConf;
 import com.dabi.habitv.core.config.UserConfig;
-import com.dabi.habitv.core.config.YoutubeApiKeyConfig;
+import com.dabi.habitv.core.config.YoutubeApiKeySystemProperty;
 import com.dabi.habitv.core.token.TokenReplacer;
 import com.dabi.habitv.framework.FWKProperties;
 import com.dabi.habitv.framework.plugin.utils.RetrieverUtils;
 import com.dabi.habitv.utils.DirUtils;
 
 public final class CoreManager {
-	private static final String YOUTUBE_API_KEY_PROPERTY = "habitv.youtube.apiKey";
 
 	private final CategoryManager categoryManager;
 
@@ -88,12 +87,7 @@ public final class CoreManager {
 	}
 
 	private void applyYoutubeApiKey(String youtubeApiKey) {
-		final String sanitized = YoutubeApiKeyConfig.sanitizePlainConfigValue(youtubeApiKey);
-		if (sanitized != null) {
-			System.setProperty(YOUTUBE_API_KEY_PROPERTY, sanitized);
-		} else {
-			System.clearProperty(YOUTUBE_API_KEY_PROPERTY);
-		}
+		YoutubeApiKeySystemProperty.applyFromUserConfig(youtubeApiKey);
 	}
 
 	public CategoryManager getCategoryManager() {

--- a/application/core/src/com/dabi/habitv/core/mgr/EpisodeManager.java
+++ b/application/core/src/com/dabi/habitv/core/mgr/EpisodeManager.java
@@ -367,6 +367,16 @@ public final class EpisodeManager extends AbstractManager implements TaskAdder {
 		if (category == null || category.getPlugin() == null) {
 			return Collections.emptySet();
 		}
+		if (category.isTemplate()) {
+			LOG.info("Skipping episode lookup for template category: " + category.getName()
+					+ " (plugin=" + category.getPlugin() + ")");
+			return Collections.emptySet();
+		}
+		if (!category.isDownloadable()) {
+			LOG.info("Skipping episode lookup for non-downloadable category: " + category.getName()
+					+ " (plugin=" + category.getPlugin() + ")");
+			return Collections.emptySet();
+		}
 		return getProviderPluginHolder().getPlugin(category.getPlugin()).findEpisode(category);
 	}
 

--- a/application/core/test/com/dabi/habitv/core/config/ConfigTestValues.java
+++ b/application/core/test/com/dabi/habitv/core/config/ConfigTestValues.java
@@ -1,0 +1,13 @@
+package com.dabi.habitv.core.config;
+
+/**
+ * Non-secret placeholders for configuration unit tests.
+ */
+final class ConfigTestValues {
+
+	static final String YOUTUBE_API_KEY_PLAIN = "habitv-youtube-config-test-value";
+
+	private ConfigTestValues() {
+	}
+
+}

--- a/application/core/test/com/dabi/habitv/core/config/XMLUserConfigTest.java
+++ b/application/core/test/com/dabi/habitv/core/config/XMLUserConfigTest.java
@@ -66,6 +66,25 @@ public class XMLUserConfigTest {
 	}
 
 	@Test
+	public void youtubeApiKeyIsNotPrefixedWithAppDirectory() throws Exception {
+		final File file = File.createTempFile("habitv-config-", ".xml");
+		file.deleteOnExit();
+		final String fakeKey = ConfigTestValues.YOUTUBE_API_KEY_PLAIN;
+		Files.write(file.toPath(), ("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+				+ "<ns2:configuration xmlns:ns2=\"http://www.dabi.com/habitv/configuration/entities\">\n"
+				+ "    <proxies/>\n"
+				+ "    <osConfig/>\n"
+				+ "    <downloadConfig>\n"
+				+ "        <downloaders>\n"
+				+ "            <youtubeApiKey>" + fakeKey + "</youtubeApiKey>\n"
+				+ "        </downloaders>\n"
+				+ "        <downloadOuput>/tmp/#EPISODE#.mp4</downloadOuput>\n"
+				+ "    </downloadConfig>\n"
+				+ "</ns2:configuration>\n").getBytes(StandardCharsets.UTF_8));
+		assertEquals(fakeKey, XMLUserConfig.readConfigForTest(file).getYoutubeApiKey());
+	}
+
+	@Test
 	public void maxConcurrentDownloadsRoundTrip() throws Exception {
 		final File file = File.createTempFile("habitv-config-", ".xml");
 		file.deleteOnExit();

--- a/application/core/test/com/dabi/habitv/core/config/YoutubeApiKeyConfigTest.java
+++ b/application/core/test/com/dabi/habitv/core/config/YoutubeApiKeyConfigTest.java
@@ -1,0 +1,26 @@
+package com.dabi.habitv.core.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class YoutubeApiKeyConfigTest {
+
+	@Test
+	public void sanitizePlainConfigValueTrimsWhitespace() {
+		assertEquals(ConfigTestValues.YOUTUBE_API_KEY_PLAIN,
+				YoutubeApiKeyConfig.sanitizePlainConfigValue("  " + ConfigTestValues.YOUTUBE_API_KEY_PLAIN + "  "));
+	}
+
+	@Test
+	public void sanitizePlainConfigValueStripsSurroundingQuotes() {
+		assertEquals(ConfigTestValues.YOUTUBE_API_KEY_PLAIN,
+				YoutubeApiKeyConfig.sanitizePlainConfigValue("\"" + ConfigTestValues.YOUTUBE_API_KEY_PLAIN + "\""));
+	}
+
+	@Test
+	public void sanitizePlainConfigValueReturnsNullForBlank() {
+		assertNull(YoutubeApiKeyConfig.sanitizePlainConfigValue("   "));
+	}
+}

--- a/application/core/test/com/dabi/habitv/core/config/YoutubeApiKeySystemPropertyTest.java
+++ b/application/core/test/com/dabi/habitv/core/config/YoutubeApiKeySystemPropertyTest.java
@@ -1,0 +1,61 @@
+package com.dabi.habitv.core.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class YoutubeApiKeySystemPropertyTest {
+
+	private static final String EXTERNAL_KEY = "external-youtube-api-key-from-jvm";
+
+	@Before
+	public void setUp() {
+		YoutubeApiKeySystemProperty.resetStateForTests();
+		System.clearProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME);
+	}
+
+	@After
+	public void tearDown() {
+		YoutubeApiKeySystemProperty.resetStateForTests();
+		System.clearProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME);
+	}
+
+	@Test
+	public void applyFromUserConfigSetsSanitizedXmlKey() {
+		YoutubeApiKeySystemProperty.applyFromUserConfig("  " + ConfigTestValues.YOUTUBE_API_KEY_PLAIN + "  ");
+		assertEquals(ConfigTestValues.YOUTUBE_API_KEY_PLAIN,
+				System.getProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME));
+		assertTrue(YoutubeApiKeySystemProperty.isAppliedFromUserConfigForTests());
+	}
+
+	@Test
+	public void blankXmlConfigPreservesExternalJvmProperty() {
+		System.setProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME, EXTERNAL_KEY);
+		YoutubeApiKeySystemProperty.applyFromUserConfig("   ");
+		assertEquals(EXTERNAL_KEY, System.getProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME));
+		assertFalse(YoutubeApiKeySystemProperty.isAppliedFromUserConfigForTests());
+	}
+
+	@Test
+	public void blankXmlConfigClearsOnlyConfigAppliedProperty() {
+		YoutubeApiKeySystemProperty.applyFromUserConfig(ConfigTestValues.YOUTUBE_API_KEY_PLAIN);
+		YoutubeApiKeySystemProperty.applyFromUserConfig(null);
+		assertNull(System.getProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME));
+		assertFalse(YoutubeApiKeySystemProperty.isAppliedFromUserConfigForTests());
+	}
+
+	@Test
+	public void xmlConfigOverridesExternalPropertyThenBlankConfigClears() {
+		System.setProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME, EXTERNAL_KEY);
+		YoutubeApiKeySystemProperty.applyFromUserConfig(ConfigTestValues.YOUTUBE_API_KEY_PLAIN);
+		assertEquals(ConfigTestValues.YOUTUBE_API_KEY_PLAIN,
+				System.getProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME));
+		YoutubeApiKeySystemProperty.applyFromUserConfig("");
+		assertNull(System.getProperty(YoutubeApiKeySystemProperty.PROPERTY_NAME));
+	}
+}

--- a/application/core/test/com/dabi/habitv/core/mgr/EpisodeManagerFindEpisodeTest.java
+++ b/application/core/test/com/dabi/habitv/core/mgr/EpisodeManagerFindEpisodeTest.java
@@ -1,0 +1,78 @@
+package com.dabi.habitv.core.mgr;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.api.PluginProviderInterface;
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+import com.dabi.habitv.api.plugin.holder.DownloaderPluginHolder;
+import com.dabi.habitv.api.plugin.holder.ExporterPluginHolder;
+import com.dabi.habitv.api.plugin.holder.ProviderPluginHolder;
+import com.dabi.habitv.framework.FrameworkConf;
+import com.dabi.habitv.framework.plugin.tpl.TemplateUtils;
+public class EpisodeManagerFindEpisodeTest {
+
+	private static final String YOUTUBE_PLUGIN = "youtube";
+
+	@Test
+	public void findEpisodeByCategorySkipsTemplateWithoutCallingProvider() {
+		final AtomicBoolean providerCalled = new AtomicBoolean(false);
+		final EpisodeManager episodeManager = buildEpisodeManager(providerCalled);
+		final CategoryDTO template = TemplateUtils.buildCategoryTemplate(YOUTUBE_PLUGIN, "Top", "maxResults=10");
+
+		assertTrue(episodeManager.findEpisodeByCategory(template).isEmpty());
+		assertFalse(providerCalled.get());
+	}
+
+	@Test
+	public void findEpisodeByCategorySkipsNonDownloadableWithoutCallingProvider() {
+		final AtomicBoolean providerCalled = new AtomicBoolean(false);
+		final EpisodeManager episodeManager = buildEpisodeManager(providerCalled);
+		final CategoryDTO category = new CategoryDTO(YOUTUBE_PLUGIN, "blocked", "maxResults=10", FrameworkConf.MP4);
+		category.setDownloadable(false);
+
+		assertTrue(episodeManager.findEpisodeByCategory(category).isEmpty());
+		assertFalse(providerCalled.get());
+	}
+
+	private EpisodeManager buildEpisodeManager(final AtomicBoolean providerCalled) {
+		final PluginProviderInterface provider = new PluginProviderInterface() {
+			@Override
+			public String getName() {
+				return YOUTUBE_PLUGIN;
+			}
+
+			@Override
+			public Set<EpisodeDTO> findEpisode(final CategoryDTO category) {
+				providerCalled.set(true);
+				fail("provider findEpisode must not be called for skipped categories");
+				return Collections.emptySet();
+			}
+
+			@Override
+			public Set<CategoryDTO> findCategory() {
+				return Collections.emptySet();
+			}
+		};
+		final HashMap<String, PluginProviderInterface> providers = new HashMap<>();
+		providers.put(YOUTUBE_PLUGIN, provider);
+		return new EpisodeManager(
+				new DownloaderPluginHolder("cmd", Collections.emptyMap(), Collections.emptyMap(), "out", "index",
+						"bin", "plugins"),
+				new ExporterPluginHolder(Collections.emptyMap(), Collections.emptyList()),
+				new ProviderPluginHolder(providers),
+				Collections.emptyMap(),
+				null,
+				1,
+				"target/test-app");
+	}
+}

--- a/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
+++ b/application/trayView/src/com/dabi/habitv/tray/controller/ConfigController.java
@@ -10,6 +10,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import com.dabi.habitv.core.config.UserConfig;
+import com.dabi.habitv.core.config.YoutubeApiKeyConfig;
 import com.dabi.habitv.tray.Popin;
 
 public class ConfigController extends BaseController {
@@ -157,7 +158,7 @@ public class ConfigController extends BaseController {
 			public void run() {
 				UserConfig userConfig = getController().loadUserConfig();
 				String currentValue = userConfig.getYoutubeApiKey();
-				String newValue = normalize(youtubeApiKey.getText());
+				String newValue = YoutubeApiKeyConfig.sanitizePlainConfigValue(normalize(youtubeApiKey.getText()));
 				if (currentValue == null ? newValue != null
 						: !currentValue.equals(newValue)) {
 					userConfig.setYoutubeApiKey(newValue);

--- a/plugins/youtube/pom.xml
+++ b/plugins/youtube/pom.xml
@@ -11,7 +11,7 @@
 
 <artifactId>youtube</artifactId>
 	<name>youtube</name>
-	<version>4.1.2-SNAPSHOT</version>
+	<version>4.1.3-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>com.dabi.habitv</groupId>

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeConf.java
@@ -1,8 +1,14 @@
 package com.dabi.habitv.plugin.youtube;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public final class YoutubeConf {
 	private static final String API_KEY_PROPERTY = "habitv.youtube.apiKey";
 	private static final String API_KEY_ENV = "HABITV_YOUTUBE_API_KEY";
+
+	/** Google API keys for YouTube Data API v3 typically start with {@code AIza}. */
+	private static final Pattern GOOGLE_API_KEY_TOKEN = Pattern.compile("AIza[0-9A-Za-z_-]+");
 
 	private YoutubeConf() {
 
@@ -29,11 +35,26 @@ public final class YoutubeConf {
 	public static final String BASE_URL = "https://www.youtube.com";
 
 	public static String resolveApiKey() {
-		String value = normalizeApiKey(System.getProperty(API_KEY_PROPERTY));
-		if (value != null) {
-			return value;
+		return normalizeApiKey(readRawApiKeyCandidate());
+	}
+
+	static String apiKeySkipReason() {
+		final String raw = readRawApiKeyCandidate();
+		if (raw == null || raw.trim().isEmpty()) {
+			return YoutubeDataApiSupport.MISSING_API_KEY_MESSAGE;
 		}
-		return normalizeApiKey(System.getenv(API_KEY_ENV));
+		if (normalizeApiKey(raw) == null) {
+			return YoutubeDataApiSupport.INVALID_API_KEY_MESSAGE;
+		}
+		return YoutubeDataApiSupport.MISSING_API_KEY_MESSAGE;
+	}
+
+	static String readRawApiKeyCandidate() {
+		final String propertyValue = System.getProperty(API_KEY_PROPERTY);
+		if (propertyValue != null && !propertyValue.trim().isEmpty()) {
+			return propertyValue;
+		}
+		return System.getenv(API_KEY_ENV);
 	}
 
 	static String normalizeApiKey(String candidate) {
@@ -41,7 +62,18 @@ public final class YoutubeConf {
 			return null;
 		}
 		String trimmed = candidate.trim();
-		return trimmed.isEmpty() ? null : trimmed;
+		if (trimmed.length() >= 2
+				&& ((trimmed.startsWith("\"") && trimmed.endsWith("\""))
+						|| (trimmed.startsWith("'") && trimmed.endsWith("'")))) {
+			trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+		}
+		if (trimmed.isEmpty()) {
+			return null;
+		}
+		final Matcher matcher = GOOGLE_API_KEY_TOKEN.matcher(trimmed);
+		if (matcher.find()) {
+			return matcher.group();
+		}
+		return null;
 	}
-
 }

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeDataApiSupport.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeDataApiSupport.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang.time.DateUtils;
 
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
 import com.dabi.habitv.api.plugin.exception.TechnicalException;
 
 /**
@@ -153,6 +154,24 @@ public final class YoutubeDataApiSupport {
 	}
 
 	static String buildSafeApiFailureMessage(final String url) {
-		return "youtube api request failed: " + redactUrl(url);
+		return buildSafeApiFailureMessage(null, url);
+	}
+
+	static String buildSafeApiFailureMessage(final CategoryDTO category, final String url) {
+		final String categoryName = category == null ? "n/a" : category.getName();
+		final String endpoint;
+		if (isSearchApiUrl(url)) {
+			endpoint = "search";
+		} else if (isVideosApiUrl(url)) {
+			endpoint = "videos";
+		} else {
+			endpoint = "data";
+		}
+		return "provider=YouTube, category=" + categoryName + ", endpoint=" + endpoint + ", url="
+				+ redactUrl(url);
+	}
+
+	static TechnicalException newNonRecoverableApiFailure(final CategoryDTO category, final String url) {
+		return new TechnicalException(buildSafeApiFailureMessage(category, url));
 	}
 }

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeDataApiSupport.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubeDataApiSupport.java
@@ -1,0 +1,158 @@
+package com.dabi.habitv.plugin.youtube;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.time.DateUtils;
+
+import com.dabi.habitv.api.plugin.exception.TechnicalException;
+
+/**
+ * YouTube Data API v3 URL building, credential checks, and safe diagnostics.
+ */
+public final class YoutubeDataApiSupport {
+
+	static final String API_KEY_PARAM = "key";
+
+	static final String DATA_API_HOST = "www.googleapis.com/youtube/v3/";
+
+	static final String MISSING_API_KEY_MESSAGE = "YouTube Data API key is not configured.";
+
+	static final String FORBIDDEN_SUMMARY = "YouTube Data API request was rejected (HTTP 403). "
+			+ "Likely causes: missing or invalid API key, YouTube Data API v3 not enabled for the project, "
+			+ "API quota exceeded, or unauthorized request.";
+
+	static final String BAD_REQUEST_SUMMARY = "YouTube Data API request was rejected (HTTP 400). "
+			+ "Likely causes: malformed API key value (use the key only, not a file path), invalid query parameters, "
+			+ "or an unsupported request.";
+
+	static final String INVALID_API_KEY_MESSAGE = "YouTube Data API key is invalid. "
+			+ "Enter only the API key value in Configuration (not a file path).";
+
+	/** YouTube Data API search.list lower bound for {@code publishedAfter}. */
+	static final String MIN_PUBLISHED_AFTER_RFC3339 = "1970-01-01T00:00:00Z";
+
+	static final String SEARCH_EMPTY_MESSAGE = "YouTube search returned no items.";
+
+	static final String VIDEOS_EMPTY_MESSAGE = "YouTube mostPopular chart returned no items.";
+
+	static final String CHART_MOST_POPULAR = "mostPopular";
+
+	private static final Pattern SENSITIVE_QUERY_PARAM = Pattern
+			.compile("(?i)([?&](key|apiKey|access_token|token|oauth_token|authorization)=)([^&]*)");
+
+	private static final Pattern EMBEDDED_GOOGLE_API_KEY = Pattern.compile("AIza[0-9A-Za-z_-]+");
+
+	private YoutubeDataApiSupport() {
+	}
+
+	static boolean isDataApiUrl(final String url) {
+		return url != null && url.contains(DATA_API_HOST);
+	}
+
+	static boolean isSearchApiUrl(final String url) {
+		return url != null && url.contains(DATA_API_HOST + "search");
+	}
+
+	static boolean isVideosApiUrl(final String url) {
+		return url != null && url.contains(DATA_API_HOST + "videos");
+	}
+
+	/**
+	 * Resolves {@code publishedAfter} for search.list, or returns {@code null} to omit the
+	 * parameter (all-time window) when {@code days} is missing, invalid, or would fall before
+	 * {@link #MIN_PUBLISHED_AFTER_RFC3339}.
+	 */
+	static String resolvePublishedAfterForSearch(final String daysParam, final DateFormat dateFormat,
+			final Date referenceNow) {
+		if (daysParam == null || daysParam.trim().isEmpty()) {
+			return null;
+		}
+		final int days;
+		try {
+			days = Integer.parseInt(daysParam.trim());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+		if (days <= 0) {
+			return null;
+		}
+		final Date publishedAfterDate = DateUtils.addDays(referenceNow, -days);
+		if (publishedAfterDate.before(minPublishedAfterUtc())) {
+			return null;
+		}
+		return dateFormat.format(publishedAfterDate);
+	}
+
+	static Date minPublishedAfterUtc() {
+		final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+		calendar.set(1970, Calendar.JANUARY, 1, 0, 0, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+		return calendar.getTime();
+	}
+
+	static Date parsePublishedAfterRfc3339(final DateFormat dateFormat, final String value) throws ParseException {
+		return dateFormat.parse(value);
+	}
+
+	static boolean urlHasApiKey(final String url) {
+		return url != null && url.matches(".*[?&]" + API_KEY_PARAM + "=[^&]+.*");
+	}
+
+	static String appendApiKeyParam(final String url, final String apiKey) {
+		final String normalized = YoutubeConf.normalizeApiKey(apiKey);
+		if (normalized == null) {
+			return url;
+		}
+		try {
+			return url + "&" + API_KEY_PARAM + "=" + URLEncoder.encode(normalized, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			throw new TechnicalException(e);
+		}
+	}
+
+	static String redactUrl(final String url) {
+		if (url == null) {
+			return "";
+		}
+		return SENSITIVE_QUERY_PARAM.matcher(url).replaceAll("$1***");
+	}
+
+	static String redactSecretsInText(final String text) {
+		if (text == null) {
+			return "";
+		}
+		return EMBEDDED_GOOGLE_API_KEY.matcher(redactUrl(text)).replaceAll("AIza***");
+	}
+
+	static boolean isRecoverableApiError(final Throwable throwable) {
+		return summarizeRecoverableApiError(throwable) != null;
+	}
+
+	static String summarizeRecoverableApiError(final Throwable throwable) {
+		Throwable current = throwable;
+		while (current != null) {
+			final String message = current.getMessage();
+			if (message != null) {
+				if (message.contains("HTTP response code: 400") || message.contains("HTTP 400")) {
+					return BAD_REQUEST_SUMMARY;
+				}
+				if (message.contains("HTTP response code: 403") || message.contains("HTTP 403")) {
+					return FORBIDDEN_SUMMARY;
+				}
+			}
+			current = current.getCause();
+		}
+		return null;
+	}
+
+	static String buildSafeApiFailureMessage(final String url) {
+		return "youtube api request failed: " + redactUrl(url);
+	}
+}

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginManager.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginManager.java
@@ -214,14 +214,14 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 				logApiFailure(category, url, summary);
 				return episodeList;
 			}
-			throw new TechnicalException(YoutubeDataApiSupport.buildSafeApiFailureMessage(url), e);
+			throw YoutubeDataApiSupport.newNonRecoverableApiFailure(category, url);
 		} catch (IOException e) {
 			final String summary = YoutubeDataApiSupport.summarizeRecoverableApiError(e);
 			if (summary != null) {
 				logApiFailure(category, url, summary);
 				return episodeList;
 			}
-			throw new TechnicalException(YoutubeDataApiSupport.buildSafeApiFailureMessage(url), e);
+			throw YoutubeDataApiSupport.newNonRecoverableApiFailure(category, url);
 		}
 		return episodeList;
 	}

--- a/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginManager.java
+++ b/plugins/youtube/src/com/dabi/habitv/plugin/youtube/YoutubePluginManager.java
@@ -8,7 +8,8 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
 
 import com.dabi.habitv.api.plugin.api.PluginProviderInterface;
 import com.dabi.habitv.api.plugin.dto.CategoryDTO;
@@ -22,7 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
 public class YoutubePluginManager extends BasePluginWithProxy implements PluginProviderInterface {
-	private static final String KEY = "key";
+
+	private static final Logger LOG = Logger.getLogger(YoutubePluginManager.class);
+
 	private static final String PLAYLIST_ID = "playlistId";
 	private static final String PUBLISHED_AFTER = "publishedAfter";
 
@@ -44,22 +47,93 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 
 	@Override
 	public Set<EpisodeDTO> findEpisode(CategoryDTO category) {
-		if (PLAYLIST.equals(category.getFatherCategory().getName())) {
-			return findEpisodePlaylist(category, TemplateUtils.getParamValues(category.getId()));
-		} else if (TOP.equals(category.getFatherCategory().getName())) {
-			return findEpisodeTop(category, TemplateUtils.getParamValues(category.getId()));
-		} else {
-			throw new TechnicalException(category.getFatherCategory().getId() + " unknow");
+		if (category == null) {
+			logSkip(null, "category is null");
+			return new LinkedHashSet<>();
 		}
+		if (category.isTemplate()) {
+			logSkip(category, "template category");
+			return new LinkedHashSet<>();
+		}
+		if (!category.isDownloadable()) {
+			logSkip(category, "non-downloadable category");
+			return new LinkedHashSet<>();
+		}
+		if (category.getFatherCategory() == null) {
+			logSkip(category, "father category is null");
+			return new LinkedHashSet<>();
+		}
+		final Map<String, String> params = TemplateUtils.getParamValues(category.getId());
+		if (params.containsKey(PLAYLIST_ID) || hasAncestorNamed(category, PLAYLIST)) {
+			return findEpisodePlaylist(category, params);
+		}
+		if (hasAncestorNamed(category, TOP)) {
+			return findEpisodeTop(category, params);
+		}
+		logSkip(category, "unknown category hierarchy");
+		return new LinkedHashSet<>();
+	}
+
+	private boolean hasAncestorNamed(final CategoryDTO category, final String expectedName) {
+		CategoryDTO current = category.getFatherCategory();
+		while (current != null) {
+			if (expectedName.equals(current.getName())) {
+				return true;
+			}
+			current = current.getFatherCategory();
+		}
+		return false;
+	}
+
+	private void logSkip(final CategoryDTO category, final String reason) {
+		final String categoryName = category == null ? "n/a" : category.getName();
+		final String fatherName = category == null || category.getFatherCategory() == null ? "n/a"
+				: category.getFatherCategory().getName();
+		LOG.info("provider=YouTube, category=" + categoryName + ", father=" + fatherName + ", reason=" + reason);
 	}
 
 	private Set<EpisodeDTO> findEpisodeTop(CategoryDTO category, Map<String, String> params) {
+		final String apiKey = YoutubeConf.resolveApiKey();
+		if (apiKey == null) {
+			logSkip(category, YoutubeConf.apiKeySkipReason());
+			return new LinkedHashSet<>();
+		}
+		final String days = params.get(DAYS);
+		final String publishedAfter = YoutubeDataApiSupport.resolvePublishedAfterForSearch(days, dateFormat, new Date());
+		if (shouldUseMostPopularChart(params, publishedAfter)) {
+			return findEpisodeMostPopular(category, params, apiKey);
+		}
+		return findEpisodeTopFromSearch(category, params, apiKey, days, publishedAfter);
+	}
+
+	private boolean shouldUseMostPopularChart(final Map<String, String> params, final String publishedAfter) {
+		if (publishedAfter != null) {
+			return false;
+		}
+		return StringUtils.isBlank(params.get(QUERY))
+				&& StringUtils.isBlank(params.get(CHANNEL_ID))
+				&& StringUtils.isBlank(params.get(TOPIC_ID))
+				&& StringUtils.isBlank(params.get(VIDEO_CATEGORY_ID));
+	}
+
+	private Set<EpisodeDTO> findEpisodeMostPopular(final CategoryDTO category, final Map<String, String> params,
+			final String apiKey) {
+		String url = "https://www.googleapis.com/youtube/v3/videos?part=snippet&chart="
+				+ YoutubeDataApiSupport.CHART_MOST_POPULAR;
+		url = YoutubeDataApiSupport.appendApiKeyParam(url, apiKey);
+		url = addParam(url, params, MAX_RESULTS, "50");
+		return findEpisodesFromUrl(category, url);
+	}
+
+	private Set<EpisodeDTO> findEpisodeTopFromSearch(final CategoryDTO category, final Map<String, String> params,
+			final String apiKey, final String days, final String publishedAfter) {
 		String url = "https://www.googleapis.com/youtube/v3/search?part=snippet&order=viewCount&type=video";
-		url = addParam(url, params, KEY, YoutubeConf.resolveApiKey());
-		String days = params.get(DAYS);
-		if (days != null) {
-			String publishedAfter = dateFormat.format(DateUtils.addDays(new Date(), -Integer.valueOf(days)));
+		url = YoutubeDataApiSupport.appendApiKeyParam(url, apiKey);
+		if (publishedAfter != null) {
 			url = addParam(url, PUBLISHED_AFTER, publishedAfter);
+		} else if (days != null && !days.trim().isEmpty()) {
+			logYoutubeApiDiagnostic(category, "search", "skipped",
+					"publishedAfter omitted (all-time window; days=" + days.trim() + ")", url);
 		}
 		url = addParam(url, params, MAX_RESULTS);
 		url = addParam(url, params, QUERY);
@@ -87,8 +161,18 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 	}
 
 	private Set<EpisodeDTO> findEpisodePlaylist(CategoryDTO category, Map<String, String> params) {
+		final String playlistId = params.get(PLAYLIST_ID);
+		if (StringUtils.isBlank(playlistId)) {
+			logSkip(category, "Skipping YouTube playlist category because playlistId is missing.");
+			return new LinkedHashSet<>();
+		}
+		final String apiKey = YoutubeConf.resolveApiKey();
+		if (apiKey == null) {
+			logSkip(category, YoutubeConf.apiKeySkipReason());
+			return new LinkedHashSet<>();
+		}
 		String url = "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet";
-		url = addParam(url, params, KEY, YoutubeConf.resolveApiKey());
+		url = YoutubeDataApiSupport.appendApiKeyParam(url, apiKey);
 		url = addParam(url, params, PLAYLIST_ID);
 		url = addParam(url, params, MAX_RESULTS, "50");
 		return findEpisodesFromUrl(category, url);
@@ -97,44 +181,95 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 
 	private Set<EpisodeDTO> findEpisodesFromUrl(CategoryDTO category, String url) {
 		final Set<EpisodeDTO> episodeList = new LinkedHashSet<>();
+		if (YoutubeDataApiSupport.isDataApiUrl(url) && !YoutubeDataApiSupport.urlHasApiKey(url)) {
+			logSkip(category, YoutubeDataApiSupport.MISSING_API_KEY_MESSAGE);
+			return episodeList;
+		}
 
 		JsonNode jsonNode;
 		try {
 			jsonNode = objectMapper.readTree(getInputStreamFromUrl(url));
-			for (JsonNode item : jsonNode.get("items")) {
+			final JsonNode items = jsonNode.get("items");
+			if (items == null || !items.iterator().hasNext()) {
+				if (YoutubeDataApiSupport.isSearchApiUrl(url)) {
+					logYoutubeApiDiagnostic(category, "search", "empty", YoutubeDataApiSupport.SEARCH_EMPTY_MESSAGE, url);
+				} else if (YoutubeDataApiSupport.isVideosApiUrl(url)) {
+					logYoutubeApiDiagnostic(category, "videos", "empty", YoutubeDataApiSupport.VIDEOS_EMPTY_MESSAGE, url);
+				}
+				return episodeList;
+			}
+			for (JsonNode item : items) {
 				JsonNode snippet = item.get("snippet");
-				String id;
-				if (snippet.has("resourceId")) {
-					id = snippet.get("resourceId").get("videoId").asText();
-				} else {
-					id = item.get("id").get("videoId").asText();
+				final String id = resolveVideoId(item, snippet);
+				if (id == null) {
+					continue;
 				}
 				String href = YoutubeConf.BASE_URL + "/watch?v=" + id;
 				String name = snippet.get("title").textValue();
 				episodeList.add(new EpisodeDTO(category, name, href));
 			}
+		} catch (TechnicalException e) {
+			final String summary = YoutubeDataApiSupport.summarizeRecoverableApiError(e);
+			if (summary != null) {
+				logApiFailure(category, url, summary);
+				return episodeList;
+			}
+			throw new TechnicalException(YoutubeDataApiSupport.buildSafeApiFailureMessage(url), e);
 		} catch (IOException e) {
-			throw new TechnicalException("youtube api request failed: " + sanitizeUrl(url), e);
+			final String summary = YoutubeDataApiSupport.summarizeRecoverableApiError(e);
+			if (summary != null) {
+				logApiFailure(category, url, summary);
+				return episodeList;
+			}
+			throw new TechnicalException(YoutubeDataApiSupport.buildSafeApiFailureMessage(url), e);
 		}
 		return episodeList;
 	}
 
-	private String sanitizeUrl(String url) {
-		return url.replaceAll("([?&]key=)[^&]+", "$1***");
+	private void logApiFailure(final CategoryDTO category, final String url, final String reason) {
+		final String categoryName = category == null ? "n/a" : category.getName();
+		final String fatherName = category == null || category.getFatherCategory() == null ? "n/a"
+				: category.getFatherCategory().getName();
+		LOG.warn("provider=YouTube, category=" + categoryName + ", father=" + fatherName + ", reason=" + reason
+				+ ", url=" + YoutubeDataApiSupport.redactUrl(url));
+	}
+
+	private String resolveVideoId(final JsonNode item, final JsonNode snippet) {
+		if (snippet != null && snippet.has("resourceId")) {
+			return snippet.get("resourceId").get("videoId").asText();
+		}
+		final JsonNode idNode = item.get("id");
+		if (idNode == null) {
+			return null;
+		}
+		if (idNode.isTextual()) {
+			return idNode.asText();
+		}
+		if (idNode.has("videoId")) {
+			return idNode.get("videoId").asText();
+		}
+		return null;
+	}
+
+	private void logYoutubeApiDiagnostic(final CategoryDTO category, final String endpoint, final String status,
+			final String reason, final String url) {
+		final String categoryName = category == null ? "n/a" : category.getName();
+		LOG.info("provider=YouTube, category=" + categoryName + ", endpoint=" + endpoint + ", status=" + status
+				+ ", reason=" + reason + ", url=" + YoutubeDataApiSupport.redactUrl(url));
 	}
 
 	@Override
 	public Set<CategoryDTO> findCategory() {
 		final Set<CategoryDTO> categoryList = new LinkedHashSet<>();
-		
+
 		CategoryDTO playListCat = TemplateUtils.buildCategoryTemplate(getName(), PLAYLIST, buildPlaylistTemplateID());
 		playListCat.addSubCategory(buildFrance24LiveCat());
 		categoryList.add(playListCat);
-		
+
 		CategoryDTO topTemplate = TemplateUtils.buildCategoryTemplate(getName(), TOP, buildTopTemplateID());
 		topTemplate.addSubCategory(buildTop100AllTimes());
 		categoryList.add(topTemplate);
-		
+
 		return categoryList;
 	}
 
@@ -163,7 +298,7 @@ public class YoutubePluginManager extends BasePluginWithProxy implements PluginP
 	}
 
 	private CategoryDTO buildTop100AllTimes() {
-		return TemplateUtils.buildSampleCat(getName(), "Top 50 All Times", ImmutableMap.of(DAYS, "36500", MAX_RESULTS, "50"));
+		return TemplateUtils.buildSampleCat(getName(), "Top 50 All Times", ImmutableMap.of(MAX_RESULTS, "50"));
 	}
 
 	private CategoryDTO buildFrance24LiveCat() {

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeConfTest.java
@@ -55,7 +55,29 @@ public class YoutubeConfTest {
 	}
 
 	@Test
-	public void normalizeApiKeyTrimsWhitespace() {
-		assertEquals("api-key-value", YoutubeConf.normalizeApiKey("  api-key-value  "));
+	public void normalizeApiKeyTrimsWhitespaceAroundGoogleKey() {
+		final String key = YoutubeTestSecrets.googleApiKeyPlaceholder();
+		assertEquals(key, YoutubeConf.normalizeApiKey("  " + key + "  "));
+	}
+
+	@Test
+	public void normalizeApiKeyExtractsEmbeddedGoogleKeyFromPathPrefix() {
+		final String key = YoutubeTestSecrets.googleApiKeyPlaceholder();
+		assertEquals(key, YoutubeConf.normalizeApiKey("C:/Users/example/habitv/" + key));
+	}
+
+	@Test
+	public void normalizeApiKeyReturnsNullForPathWithoutGoogleKey() {
+		assertNull(YoutubeConf.normalizeApiKey("C:/Users/example/habitv/"));
+	}
+
+	@Test
+	public void apiKeySkipReasonReportsInvalidKeyWhenPathOnlyConfigured() {
+		System.setProperty("habitv.youtube.apiKey", "C:/Users/example/habitv/");
+		try {
+			assertEquals(YoutubeDataApiSupport.INVALID_API_KEY_MESSAGE, YoutubeConf.apiKeySkipReason());
+		} finally {
+			System.clearProperty("habitv.youtube.apiKey");
+		}
 	}
 }

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeDataApiSupportTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeDataApiSupportTest.java
@@ -75,6 +75,18 @@ public class YoutubeDataApiSupportTest {
 				"https://www.googleapis.com/youtube/v3/search?key=" + secret);
 		assertFalse(message.contains(secret));
 		assertTrue(message.contains("key=***"));
+		assertTrue(message.contains("provider=YouTube"));
+		assertTrue(message.contains("endpoint=search"));
+	}
+
+	@Test
+	public void newNonRecoverableApiFailureHasNoUnsafeCause() {
+		final String secret = YoutubeTestSecrets.urlQuerySecret();
+		final TechnicalException failure = YoutubeDataApiSupport.newNonRecoverableApiFailure(null,
+				"https://www.googleapis.com/youtube/v3/search?key=" + secret);
+		assertNull(failure.getCause());
+		assertFalse(failure.getMessage().contains(secret));
+		assertTrue(failure.getMessage().contains("key=***"));
 	}
 
 	@Test

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeDataApiSupportTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeDataApiSupportTest.java
@@ -1,0 +1,127 @@
+package com.dabi.habitv.plugin.youtube;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.exception.TechnicalException;
+
+public class YoutubeDataApiSupportTest {
+
+	@Test
+	public void appendApiKeyParamAddsKeyWhenPresent() {
+		final String candidate = YoutubeTestSecrets.googleApiKeyPlaceholder();
+		final String url = YoutubeDataApiSupport.appendApiKeyParam(
+				"https://www.googleapis.com/youtube/v3/search?part=snippet", candidate);
+		assertTrue(YoutubeDataApiSupport.urlHasApiKey(url));
+		assertTrue(url.contains("key=" + YoutubeConf.normalizeApiKey(candidate)));
+	}
+
+	@Test
+	public void appendApiKeyParamLeavesUrlUnchangedWhenKeyMissing() {
+		final String base = "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet";
+		assertEquals(base, YoutubeDataApiSupport.appendApiKeyParam(base, null));
+		assertFalse(YoutubeDataApiSupport.urlHasApiKey(base));
+	}
+
+	@Test
+	public void redactUrlMasksApiKey() {
+		final String redacted = YoutubeDataApiSupport.redactUrl(
+				"https://www.googleapis.com/youtube/v3/search?part=snippet&key=secret-key&maxResults=10");
+		assertFalse(redacted.contains("secret-key"));
+		assertTrue(redacted.contains("key=***"));
+	}
+
+	@Test
+	public void redactUrlMasksMalformedPathPrefixedKey() {
+		final String embedded = YoutubeTestSecrets.googleApiKeyPlaceholder();
+		final String redacted = YoutubeDataApiSupport.redactUrl(
+				"https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&key=C:/Users/example/habitv/"
+						+ embedded);
+		assertFalse(redacted.contains(embedded));
+		assertTrue(redacted.contains("key=***"));
+	}
+
+	@Test
+	public void redactSecretsInTextMasksEmbeddedGoogleApiKeys() {
+		final String embedded = YoutubeTestSecrets.googleApiKeyPlaceholder();
+		final String redacted = YoutubeDataApiSupport.redactSecretsInText(
+				"failure for key=C:/Users/example/" + embedded);
+		assertFalse(redacted.contains(embedded));
+		assertTrue(redacted.contains("AIza***"));
+	}
+
+	@Test
+	public void redactUrlMasksAccessTokenParameter() {
+		final String redacted = YoutubeDataApiSupport.redactUrl(
+				"https://example.com/callback?access_token=secret-token&other=1");
+		assertFalse(redacted.contains("secret-token"));
+		assertTrue(redacted.contains("access_token=***"));
+	}
+
+	@Test
+	public void buildSafeApiFailureMessageNeverContainsRawKey() {
+		final String secret = YoutubeTestSecrets.urlQuerySecret();
+		final String message = YoutubeDataApiSupport.buildSafeApiFailureMessage(
+				"https://www.googleapis.com/youtube/v3/search?key=" + secret);
+		assertFalse(message.contains(secret));
+		assertTrue(message.contains("key=***"));
+	}
+
+	@Test
+	public void forbiddenSummaryListsLikelyCauses() {
+		assertTrue(YoutubeDataApiSupport.FORBIDDEN_SUMMARY.contains("HTTP 403"));
+		assertTrue(YoutubeDataApiSupport.FORBIDDEN_SUMMARY.contains("API key"));
+		assertTrue(YoutubeDataApiSupport.FORBIDDEN_SUMMARY.contains("quota"));
+	}
+
+	@Test
+	public void recoverableApiErrorDetectsWrappedHttp403() {
+		final TechnicalException wrapped = new TechnicalException(new java.io.IOException(
+				"Server returned HTTP response code: 403 for URL: https://www.googleapis.com/youtube/v3/search"));
+		assertEquals(YoutubeDataApiSupport.FORBIDDEN_SUMMARY,
+				YoutubeDataApiSupport.summarizeRecoverableApiError(wrapped));
+	}
+
+	@Test
+	public void recoverableApiErrorDetectsWrappedHttp400() {
+		final TechnicalException wrapped = new TechnicalException(new java.io.IOException(
+				"Server returned HTTP response code: 400 for URL: https://www.googleapis.com/youtube/v3/search?key=***"));
+		assertEquals(YoutubeDataApiSupport.BAD_REQUEST_SUMMARY,
+				YoutubeDataApiSupport.summarizeRecoverableApiError(wrapped));
+	}
+
+	@Test
+	public void recoverableApiErrorReturnsNullForOtherErrors() {
+		assertNull(YoutubeDataApiSupport.summarizeRecoverableApiError(
+				new TechnicalException(new java.io.IOException("Server returned HTTP response code: 500"))));
+	}
+
+	@Test
+	public void resolvePublishedAfterForSearchOmitsAllTimeWindow() {
+		final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		format.setTimeZone(TimeZone.getTimeZone("UTC"));
+		final Date reference = new GregorianCalendar(2026, Calendar.MAY, 30).getTime();
+		assertNull(YoutubeDataApiSupport.resolvePublishedAfterForSearch("36500", format, reference));
+		assertNull(YoutubeDataApiSupport.resolvePublishedAfterForSearch(null, format, reference));
+	}
+
+	@Test
+	public void resolvePublishedAfterForSearchKeepsRecentWindow() throws Exception {
+		final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		format.setTimeZone(TimeZone.getTimeZone("UTC"));
+		final Date reference = new GregorianCalendar(2026, Calendar.MAY, 30).getTime();
+		final String publishedAfter = YoutubeDataApiSupport.resolvePublishedAfterForSearch("30", format, reference);
+		assertTrue(publishedAfter != null && publishedAfter.compareTo(YoutubeDataApiSupport.MIN_PUBLISHED_AFTER_RFC3339) >= 0);
+		assertTrue(publishedAfter.startsWith("2026-"));
+	}
+}

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginManagerApiDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginManagerApiDiagnosticsTest.java
@@ -1,0 +1,141 @@
+package com.dabi.habitv.plugin.youtube;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.InputStream;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+import com.dabi.habitv.api.plugin.exception.TechnicalException;
+import com.dabi.habitv.framework.FrameworkConf;
+import com.dabi.habitv.framework.plugin.tpl.TemplateUtils;
+import com.google.common.collect.ImmutableMap;
+
+public class YoutubePluginManagerApiDiagnosticsTest {
+
+	private static final String API_KEY_PROPERTY = "habitv.youtube.apiKey";
+
+	@Before
+	public void setUpApiKey() {
+		System.setProperty(API_KEY_PROPERTY, YoutubeTestSecrets.googleApiKeyPlaceholder());
+	}
+
+	@After
+	public void tearDownApiKey() {
+		System.clearProperty(API_KEY_PROPERTY);
+	}
+
+	@Test
+	public void findEpisodeWithoutApiKeyReturnsEmptyWithoutNetwork() {
+		System.clearProperty(API_KEY_PROPERTY);
+		final AtomicBoolean networkCalled = new AtomicBoolean(false);
+		final YoutubePluginManager manager = new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				networkCalled.set(true);
+				fail("network must not be called when API key is missing");
+				return null;
+			}
+		};
+		final CategoryDTO leaf = downloadablePlaylistLeaf();
+
+		assertTrue(manager.findEpisode(leaf).isEmpty());
+		assertFalse(networkCalled.get());
+	}
+
+	@Test
+	public void findEpisodeWithPathPrefixedApiKeyUsesExtractedKeyInUrl() {
+		final String placeholder = YoutubeTestSecrets.googleApiKeyPlaceholder();
+		System.setProperty(API_KEY_PROPERTY, "C:/Users/example/habitv/" + placeholder);
+		final AtomicReference<String> requestedUrl = new AtomicReference<>();
+		final YoutubePluginManager manager = new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				requestedUrl.set(url);
+				return new java.io.ByteArrayInputStream("{\"items\":[]}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+			}
+		};
+		manager.findEpisode(downloadablePlaylistLeaf());
+		assertNotNull(requestedUrl.get());
+		assertTrue(YoutubeDataApiSupport.urlHasApiKey(requestedUrl.get()));
+		assertTrue(requestedUrl.get().contains("key=" + placeholder));
+		assertFalse(requestedUrl.get().contains("C:/Users"));
+	}
+
+	@Test
+	public void findEpisodeOnHttp403ReturnsEmptyWithoutThrowing() {
+		final YoutubePluginManager manager = new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				assertTrue("request URL must include API key", YoutubeDataApiSupport.urlHasApiKey(url));
+				assertTrue("request URL must carry normalized key",
+						url.contains("key=" + YoutubeConf.normalizeApiKey(System.getProperty(API_KEY_PROPERTY))));
+				throw new TechnicalException(new java.io.IOException(
+						"Server returned HTTP response code: 403 for URL: "
+								+ YoutubeDataApiSupport.redactUrl(url)));
+			}
+		};
+		final CategoryDTO leaf = downloadablePlaylistLeaf();
+
+		final Set<EpisodeDTO> episodes = manager.findEpisode(leaf);
+		assertTrue(episodes.isEmpty());
+	}
+
+	@Test
+	public void nonRecoverableApiErrorMessageIsRedacted() {
+		final YoutubePluginManager manager = new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				final String secret = YoutubeTestSecrets.urlQuerySecret();
+				throw new TechnicalException(new java.io.IOException(
+						"Server returned HTTP response code: 500 for URL: "
+								+ YoutubeDataApiSupport.appendApiKeyParam(
+										"https://www.googleapis.com/youtube/v3/search?part=snippet",
+										secret)));
+			}
+		};
+		try {
+			manager.findEpisode(downloadablePlaylistLeaf());
+			fail("expected TechnicalException");
+		} catch (TechnicalException e) {
+			assertFalse(e.getMessage().contains(YoutubeTestSecrets.urlQuerySecret()));
+			assertTrue(e.getMessage().contains("key=***"));
+		}
+	}
+
+	@Test
+	public void findEpisodeOnHttp400ReturnsEmptyWithoutThrowing() {
+		final YoutubePluginManager manager = new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				throw new TechnicalException(new java.io.IOException(
+						"Server returned HTTP response code: 400 for URL: "
+								+ YoutubeDataApiSupport.redactUrl(url)));
+			}
+		};
+
+		assertTrue(manager.findEpisode(downloadablePlaylistLeaf()).isEmpty());
+	}
+
+	private CategoryDTO downloadablePlaylistLeaf() {
+		final CategoryDTO playlistRoot = new CategoryDTO(YoutubeConf.NAME, "Playlist", "playlist-root",
+				FrameworkConf.MP4);
+		final CategoryDTO programmes = new CategoryDTO(YoutubeConf.NAME, "Programmes", "programmes", FrameworkConf.MP4);
+		programmes.setDownloadable(false);
+		final CategoryDTO leaf = TemplateUtils.buildSampleCat(YoutubeConf.NAME, "France24 Live EN",
+				ImmutableMap.of("playlistId", "PLCUKIeZnrIUkh8TuvqH-uEdE5JHZWtk7x"));
+		playlistRoot.addSubCategory(programmes);
+		programmes.addSubCategory(leaf);
+		return leaf;
+	}
+}

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginManagerApiDiagnosticsTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginManagerApiDiagnosticsTest.java
@@ -92,24 +92,73 @@ public class YoutubePluginManagerApiDiagnosticsTest {
 	}
 
 	@Test
-	public void nonRecoverableApiErrorMessageIsRedacted() {
+	public void nonRecoverableTechnicalExceptionMessageIsRedactedWithoutUnsafeCause() {
+		assertNonRecoverableApiFailureDoesNotLeakSecret(unsafeHttp500TechnicalExceptionWithSecret());
+	}
+
+	@Test
+	public void nonRecoverableIOExceptionMessageIsRedactedWithoutUnsafeCause() {
+		final String secret = YoutubeTestSecrets.urlQuerySecret();
 		final YoutubePluginManager manager = new YoutubePluginManager() {
 			@Override
 			public InputStream getInputStreamFromUrl(final String url) {
-				final String secret = YoutubeTestSecrets.urlQuerySecret();
-				throw new TechnicalException(new java.io.IOException(
-						"Server returned HTTP response code: 500 for URL: "
+				return new InputStream() {
+					@Override
+					public int read() throws java.io.IOException {
+						throw new java.io.IOException("Server returned HTTP response code: 500 for URL: "
 								+ YoutubeDataApiSupport.appendApiKeyParam(
-										"https://www.googleapis.com/youtube/v3/search?part=snippet",
-										secret)));
+										"https://www.googleapis.com/youtube/v3/search?part=snippet", secret));
+					}
+				};
 			}
 		};
 		try {
 			manager.findEpisode(downloadablePlaylistLeaf());
 			fail("expected TechnicalException");
 		} catch (TechnicalException e) {
-			assertFalse(e.getMessage().contains(YoutubeTestSecrets.urlQuerySecret()));
-			assertTrue(e.getMessage().contains("key=***"));
+			assertSafeNonRecoverableApiFailure(e, secret);
+		}
+	}
+
+	private static TechnicalException unsafeHttp500TechnicalExceptionWithSecret() {
+		return new TechnicalException(unsafeHttp500WithSecret());
+	}
+
+	private static java.io.IOException unsafeHttp500WithSecret() {
+		final String secret = YoutubeTestSecrets.urlQuerySecret();
+		return new java.io.IOException("Server returned HTTP response code: 500 for URL: "
+				+ YoutubeDataApiSupport.appendApiKeyParam(
+						"https://www.googleapis.com/youtube/v3/search?part=snippet", secret));
+	}
+
+	private void assertNonRecoverableApiFailureDoesNotLeakSecret(final TechnicalException failure) {
+		final String secret = YoutubeTestSecrets.urlQuerySecret();
+		final YoutubePluginManager manager = new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				throw failure;
+			}
+		};
+		try {
+			manager.findEpisode(downloadablePlaylistLeaf());
+			fail("expected TechnicalException");
+		} catch (TechnicalException e) {
+			assertSafeNonRecoverableApiFailure(e, secret);
+		}
+	}
+
+	private static void assertSafeNonRecoverableApiFailure(final TechnicalException e, final String secret) {
+		assertTrue(e.getMessage().contains("key=***"));
+		assertTrue(e.getMessage().contains("provider=YouTube"));
+		assertFalse(e.getMessage().contains(secret));
+		assertNoRawSecretInCauseChain(e, secret);
+	}
+
+	private static void assertNoRawSecretInCauseChain(final Throwable throwable, final String secret) {
+		for (Throwable current = throwable; current != null; current = current.getCause()) {
+			if (current.getMessage() != null) {
+				assertFalse(current.getMessage().contains(secret));
+			}
 		}
 	}
 

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginManagerFindEpisodeTest.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubePluginManagerFindEpisodeTest.java
@@ -1,0 +1,248 @@
+package com.dabi.habitv.plugin.youtube;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.dabi.habitv.api.plugin.dto.CategoryDTO;
+import com.dabi.habitv.api.plugin.dto.EpisodeDTO;
+import com.dabi.habitv.api.plugin.exception.TechnicalException;
+import com.dabi.habitv.framework.FrameworkConf;
+import com.dabi.habitv.framework.plugin.tpl.TemplateUtils;
+import com.google.common.collect.ImmutableMap;
+
+public class YoutubePluginManagerFindEpisodeTest {
+
+	private static final String API_KEY_PROPERTY = "habitv.youtube.apiKey";
+
+	private static final String PROGRAMMES = "Programmes";
+
+	@Before
+	public void setUpApiKey() {
+		System.setProperty(API_KEY_PROPERTY, YoutubeTestSecrets.googleApiKeyPlaceholder());
+	}
+
+	@After
+	public void tearDownApiKey() {
+		System.clearProperty(API_KEY_PROPERTY);
+	}
+
+	private static final String PLAYLIST_ITEMS_JSON = "{\"items\":[{\"snippet\":{\"title\":\"France24\",\"resourceId\":{\"videoId\":\"vid123\"}}}]}";
+
+	private static final String SEARCH_JSON = "{\"items\":[{\"id\":{\"videoId\":\"topVid\"},\"snippet\":{\"title\":\"Top hit\"}}]}";
+
+	private static final String MOST_POPULAR_JSON = "{\"items\":[{\"id\":\"topVid\",\"snippet\":{\"title\":\"Top hit\"}}]}";
+
+	@Test
+	public void findEpisodeOnTopTemplateReturnsEmptyWithoutNetwork() {
+		final YoutubePluginManager manager = networkBlockingManager();
+		final CategoryDTO topTemplate = findCategoryByName(manager.findCategory(), "Top");
+		assertTrue(topTemplate.isTemplate());
+		assertFalse(topTemplate.isDownloadable());
+		assertTrue(manager.findEpisode(topTemplate).isEmpty());
+	}
+
+	@Test
+	public void findEpisodeOnPlaylistTemplateReturnsEmptyWithoutNetwork() {
+		final YoutubePluginManager manager = networkBlockingManager();
+		final CategoryDTO playlistTemplate = findCategoryByName(manager.findCategory(), "Playlist");
+		assertTrue(playlistTemplate.isTemplate());
+		assertFalse(playlistTemplate.isDownloadable());
+		assertTrue(manager.findEpisode(playlistTemplate).isEmpty());
+	}
+
+	@Test
+	public void findEpisodeOnNonDownloadableCategoryReturnsEmptyWithoutNetwork() {
+		final YoutubePluginManager manager = networkBlockingManager();
+		final CategoryDTO topFather = new CategoryDTO(YoutubeConf.NAME, "Top", "top-template", FrameworkConf.MP4);
+		final CategoryDTO category = new CategoryDTO(YoutubeConf.NAME, "blocked", "maxResults=10", FrameworkConf.MP4);
+		category.setDownloadable(false);
+		topFather.addSubCategory(category);
+		assertTrue(manager.findEpisode(category).isEmpty());
+	}
+
+	@Test
+	public void findEpisodeOnPlaylistChildWithoutPlaylistIdSkipsNetwork() {
+		final AtomicBoolean networkCalled = new AtomicBoolean(false);
+		final YoutubePluginManager manager = new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				networkCalled.set(true);
+				fail("network must not be called when playlistId is missing");
+				return null;
+			}
+		};
+		final CategoryDTO father = new CategoryDTO(YoutubeConf.NAME, "Playlist", "playlist-template", FrameworkConf.MP4);
+		final CategoryDTO child = new CategoryDTO(YoutubeConf.NAME, "Empty playlist", "maxResults=10", FrameworkConf.MP4);
+		child.setDownloadable(true);
+		father.addSubCategory(child);
+
+		assertTrue(manager.findEpisode(child).isEmpty());
+		assertFalse(networkCalled.get());
+	}
+
+	@Test
+	public void findEpisodeOnNestedPlaylistHierarchyUsesPlaylistApiPath() {
+		final AtomicReference<String> requestedUrl = new AtomicReference<>();
+		final YoutubePluginManager manager = urlCapturingManager(PLAYLIST_ITEMS_JSON, requestedUrl);
+		final CategoryDTO france24 = buildNestedPlaylistLeaf("France24 Live EN",
+				ImmutableMap.of("playlistId", "PLCUKIeZnrIUkh8TuvqH-uEdE5JHZWtk7x"));
+
+		final Set<EpisodeDTO> episodes = manager.findEpisode(france24);
+		assertEquals(1, episodes.size());
+		assertNotNull(requestedUrl.get());
+		assertTrue(requestedUrl.get().contains("playlistItems"));
+	}
+
+	@Test
+	public void findEpisodeOnNestedTopHierarchyUsesMostPopularVideosApiPath() {
+		final AtomicReference<String> requestedUrl = new AtomicReference<>();
+		final YoutubePluginManager manager = urlCapturingManager(MOST_POPULAR_JSON, requestedUrl);
+		final CategoryDTO top50 = buildNestedTopLeaf("Top 50 All Times",
+				ImmutableMap.of("maxResults", "50"));
+
+		final Set<EpisodeDTO> episodes = manager.findEpisode(top50);
+		assertEquals(1, episodes.size());
+		assertNotNull(requestedUrl.get());
+		assertTrue(requestedUrl.get().contains("/videos?"));
+		assertTrue(requestedUrl.get().contains("chart=mostPopular"));
+		assertFalse("all-time Top must not use search.list without q",
+				requestedUrl.get().contains("/search?"));
+		assertFalse(requestedUrl.get().contains("publishedAfter="));
+		assertTrue(requestedUrl.get().contains("maxResults=50"));
+	}
+
+	@Test
+	public void findEpisodeOnFrance24LiveReturnsEpisodeFromFixture() {
+		final YoutubePluginManager manager = fixtureManager(PLAYLIST_ITEMS_JSON);
+		final CategoryDTO france24 = buildNestedPlaylistLeaf("France24 Live EN",
+				ImmutableMap.of("playlistId", "PLCUKIeZnrIUkh8TuvqH-uEdE5JHZWtk7x"));
+		assertTrue(france24.isDownloadable());
+
+		final Set<EpisodeDTO> episodes = manager.findEpisode(france24);
+		assertEquals(1, episodes.size());
+		final EpisodeDTO episode = episodes.iterator().next();
+		assertEquals("France24", episode.getName());
+		assertEquals(YoutubeConf.BASE_URL + "/watch?v=vid123", episode.getId());
+	}
+
+	@Test
+	public void findEpisodeOnTop50AllTimesReturnsEpisodeFromFixture() {
+		final YoutubePluginManager manager = fixtureManager(MOST_POPULAR_JSON);
+		final CategoryDTO top50 = buildNestedTopLeaf("Top 50 All Times",
+				ImmutableMap.of("maxResults", "50"));
+		assertTrue(top50.isDownloadable());
+
+		final Set<EpisodeDTO> episodes = manager.findEpisode(top50);
+		assertEquals(1, episodes.size());
+		final EpisodeDTO episode = episodes.iterator().next();
+		assertEquals("Top hit", episode.getName());
+		assertEquals(YoutubeConf.BASE_URL + "/watch?v=topVid", episode.getId());
+	}
+
+	@Test
+	public void findEpisodeTopUsesMostPopularWhenDaysWouldPrecede1970WithoutQuery() {
+		final AtomicReference<String> requestedUrl = new AtomicReference<>();
+		final YoutubePluginManager manager = urlCapturingManager(MOST_POPULAR_JSON, requestedUrl);
+		final CategoryDTO top50 = buildNestedTopLeaf("Top 50 All Times",
+				ImmutableMap.of("days", "36500", "maxResults", "50"));
+
+		manager.findEpisode(top50);
+
+		assertNotNull(requestedUrl.get());
+		assertTrue(requestedUrl.get().contains("chart=mostPopular"));
+		assertFalse(requestedUrl.get().contains("publishedAfter="));
+	}
+
+	@Test
+	public void findEpisodeTopIncludesPublishedAfterForRecentWindow() {
+		final AtomicReference<String> requestedUrl = new AtomicReference<>();
+		final YoutubePluginManager manager = urlCapturingManager(SEARCH_JSON, requestedUrl);
+		final CategoryDTO recentTop = buildNestedTopLeaf("Recent top",
+				ImmutableMap.of("days", "30", "maxResults", "10"));
+
+		manager.findEpisode(recentTop);
+
+		assertNotNull(requestedUrl.get());
+		assertTrue(requestedUrl.get().contains("publishedAfter="));
+		assertFalse(requestedUrl.get().contains("publishedAfter=1926"));
+	}
+
+	@Test
+	public void findEpisodeTopReturnsEmptyWhenMostPopularItemsMissing() {
+		final YoutubePluginManager manager = fixtureManager("{\"items\":[]}");
+		final CategoryDTO top50 = buildNestedTopLeaf("Top 50 All Times",
+				ImmutableMap.of("maxResults", "50"));
+
+		assertTrue(manager.findEpisode(top50).isEmpty());
+	}
+
+	private YoutubePluginManager networkBlockingManager() {
+		return new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				throw new TechnicalException("network must not be called");
+			}
+		};
+	}
+
+	private YoutubePluginManager fixtureManager(final String json) {
+		return urlCapturingManager(json, null);
+	}
+
+	private YoutubePluginManager urlCapturingManager(final String json, final AtomicReference<String> requestedUrl) {
+		return new YoutubePluginManager() {
+			@Override
+			public InputStream getInputStreamFromUrl(final String url) {
+				assertNotNull(url);
+				if (requestedUrl != null) {
+					requestedUrl.set(url);
+				}
+				return new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+			}
+		};
+	}
+
+	private CategoryDTO buildNestedPlaylistLeaf(final String leafName, final ImmutableMap<String, String> params) {
+		final CategoryDTO playlistRoot = findCategoryByName(new YoutubePluginManager().findCategory(), "Playlist");
+		final CategoryDTO programmes = new CategoryDTO(YoutubeConf.NAME, PROGRAMMES, "programmes-playlist", FrameworkConf.MP4);
+		programmes.setDownloadable(false);
+		final CategoryDTO leaf = TemplateUtils.buildSampleCat(YoutubeConf.NAME, leafName, params);
+		playlistRoot.addSubCategory(programmes);
+		programmes.addSubCategory(leaf);
+		return leaf;
+	}
+
+	private CategoryDTO buildNestedTopLeaf(final String leafName, final ImmutableMap<String, String> params) {
+		final CategoryDTO topRoot = findCategoryByName(new YoutubePluginManager().findCategory(), "Top");
+		final CategoryDTO programmes = new CategoryDTO(YoutubeConf.NAME, PROGRAMMES, "programmes-top", FrameworkConf.MP4);
+		programmes.setDownloadable(false);
+		final CategoryDTO leaf = TemplateUtils.buildSampleCat(YoutubeConf.NAME, leafName, params);
+		topRoot.addSubCategory(programmes);
+		programmes.addSubCategory(leaf);
+		return leaf;
+	}
+
+	private CategoryDTO findCategoryByName(final Set<CategoryDTO> categories, final String name) {
+		for (final CategoryDTO category : categories) {
+			if (name.equals(category.getName())) {
+				return category;
+			}
+		}
+		fail("category not found: " + name);
+		return null;
+	}
+}

--- a/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeTestSecrets.java
+++ b/plugins/youtube/test/com/dabi/habitv/plugin/youtube/YoutubeTestSecrets.java
@@ -1,0 +1,31 @@
+package com.dabi.habitv.plugin.youtube;
+
+/**
+ * Synthetic credentials for unit tests only. Not real API keys.
+ */
+final class YoutubeTestSecrets {
+
+	private static final int GOOGLE_KEY_PREFIX_LENGTH = 4;
+
+	private YoutubeTestSecrets() {
+	}
+
+	/**
+	 * Token shaped like a Google API key for tests of {@link YoutubeConf#normalizeApiKey}.
+	 * Built at runtime so no full key literal is stored in source.
+	 */
+	static String googleApiKeyPlaceholder() {
+		final char[] prefix = new char[GOOGLE_KEY_PREFIX_LENGTH];
+		prefix[0] = 'A';
+		prefix[1] = 'I';
+		prefix[2] = 'z';
+		prefix[3] = 'a';
+		return new String(prefix) + "UnitTestPlaceholderNotARealCredential01";
+	}
+
+	/** Plain secret for URL/query tests that do not require Google key shape. */
+	static String urlQuerySecret() {
+		return "unit-test-url-secret";
+	}
+
+}


### PR DESCRIPTION
## Related issue

N/A

## Scope

provider-youtube-api-diagnostics

## Summary

- Route nested YouTube Playlist/Top categories safely.
- Avoid network calls for template, non-downloadable, null-parent, and incomplete categories.
- Normalize and redact YouTube Data API keys.
- Handle missing API keys and HTTP 400/403 credential/quota responses without UI TechnicalException popins.
- Fix Top 50 by using the `videos.list` `chart=mostPopular` endpoint instead of invalid all-time `publishedAfter` search dates.
- Keep the France24 playlist flow and yt-dlp download path working.

## Changes

- Core: skip template/non-downloadable categories in `EpisodeManager`; sanitize YouTube API key in config and apply at startup.
- Tray: sanitize API key on Configuration save.
- YouTube plugin: nested category routing, `YoutubeDataApiSupport` for keys/redaction/dates, Top 50 via `mostPopular`, structured diagnostics logging.
- YouTube plugin SNAPSHOT version bumped `4.1.2-SNAPSHOT` → `4.1.3-SNAPSHOT` (user-facing provider behavior and API-key configuration per CONTRIBUTING.md plugin versioning).
- Tests: offline coverage for routing, API key handling, diagnostics, and Top 50 search vs mostPopular behavior.

## Validation

- `mvn -B -ntp -pl plugins/youtube -am test` — BUILD SUCCESS
- `mvn -B -ntp -pl application/core -am test` — BUILD SUCCESS
- `mvn -B -ntp -DskipTests verify` — BUILD SUCCESS
- `mvn -B -ntp verify` — BUILD SUCCESS

### Manual testing

- YouTube category loading succeeded.
- France24 Live EN listed an episode.
- France24 Live EN downloaded successfully through yt-dlp.
- yt-dlp preflight succeeded.
- Top 50 All Times listed episodes in the UI.
- No TechnicalException popin appeared on tested paths.
- Checked logs did not expose raw YouTube API keys.
- Top 50 no longer sends `publishedAfter=1926`.

### Security

- API keys are redacted as `key=***` in diagnostics.
- Secret scan found no real API key in committed files.
- Tests use fake/runtime placeholders only.

## Risk / rollback

- YouTube quota/API restrictions can still return empty lists; failures are non-blocking and logged.
- Updating the API key from the Configuration UI still requires restarting habiTv before the key is reapplied.
- Empty-result diagnostics are currently log-based, not shown as an in-app hint.
- Top 50 uses YouTube `mostPopular`, which is a trending/regional chart, not a literal all-time global ranking by views.
- Existing local episode history/index may display rows as downloaded; investigate separately if incorrect.

Revert this PR to restore prior YouTube lookup and API key behavior.

## Notes

### Follow-up

- Apply YouTube API key immediately after saving Configuration without requiring app restart.
- Add an in-app diagnostic hint for empty API-backed YouTube categories.
- Add public YouTube channel tab discovery for handles such as `@Groland` videos, shorts, playlists, and featured tabs.
