### PR TITLE
fix(update): refresh static repository manifest after deploy

### DIFF
--- a/build/static-repo-publisher/pom.xml
+++ b/build/static-repo-publisher/pom.xml
@@ -13,12 +13,14 @@
 	<artifactId>static-repo-publisher</artifactId>
 	<packaging>pom</packaging>
 	<name>static repository publisher</name>
-	<description>Final reactor step: publish plugins.txt, manifest, index.html, and tool zips.</description>
+	<description>Final reactor step: publish plugins.txt, manifest, index.html, tool zips, and validate freshness.</description>
 
 	<properties>
 		<habitv.repo.root>${session.executionRootDirectory}</habitv.repo.root>
 		<static.repo.publish.script>${habitv.repo.root}/scripts/static-repo/publish-repository-extras.ps1</static.repo.publish.script>
 		<static.repo.metadata.script>${habitv.repo.root}/scripts/static-repo/generate_repository_metadata.py</static.repo.metadata.script>
+		<static.repo.freshness.script>${habitv.repo.root}/scripts/static-repo/validate_manifest_freshness.py</static.repo.freshness.script>
+		<static.repo.layout.script>${habitv.repo.root}/scripts/static-repo/validate_repository_layout.py</static.repo.layout.script>
 	</properties>
 
 	<build>
@@ -30,6 +32,20 @@
 				<executions>
 					<execution>
 						<id>publish-static-repository-extras</id>
+						<phase>deploy</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>validate-static-repository-layout</id>
+						<phase>deploy</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>validate-manifest-freshness</id>
 						<phase>deploy</phase>
 						<goals>
 							<goal>exec</goal>
@@ -53,17 +69,42 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
-						<configuration>
-							<executable>powershell.exe</executable>
-							<arguments>
-								<argument>-ExecutionPolicy</argument>
-								<argument>Bypass</argument>
-								<argument>-File</argument>
-								<argument>${static.repo.publish.script}</argument>
-								<argument>-RepositoryPath</argument>
-								<argument>${habitv.static.repo.path}</argument>
-							</arguments>
-						</configuration>
+						<executions>
+							<execution>
+								<id>publish-static-repository-extras</id>
+								<configuration>
+									<executable>powershell.exe</executable>
+									<arguments>
+										<argument>-ExecutionPolicy</argument>
+										<argument>Bypass</argument>
+										<argument>-File</argument>
+										<argument>${static.repo.publish.script}</argument>
+										<argument>-RepositoryPath</argument>
+										<argument>${habitv.static.repo.path}</argument>
+									</arguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>validate-static-repository-layout</id>
+								<configuration>
+									<executable>python</executable>
+									<arguments>
+										<argument>${static.repo.layout.script}</argument>
+										<argument>${habitv.static.repo.path}</argument>
+									</arguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>validate-manifest-freshness</id>
+								<configuration>
+									<executable>python</executable>
+									<arguments>
+										<argument>${static.repo.freshness.script}</argument>
+										<argument>${habitv.static.repo.path}</argument>
+									</arguments>
+								</configuration>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>
@@ -80,13 +121,38 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
-						<configuration>
-							<executable>python3</executable>
-							<arguments>
-								<argument>${static.repo.metadata.script}</argument>
-								<argument>${habitv.static.repo.path}</argument>
-							</arguments>
-						</configuration>
+						<executions>
+							<execution>
+								<id>publish-static-repository-extras</id>
+								<configuration>
+									<executable>python3</executable>
+									<arguments>
+										<argument>${static.repo.metadata.script}</argument>
+										<argument>${habitv.static.repo.path}</argument>
+									</arguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>validate-static-repository-layout</id>
+								<configuration>
+									<executable>python3</executable>
+									<arguments>
+										<argument>${static.repo.layout.script}</argument>
+										<argument>${habitv.static.repo.path}</argument>
+									</arguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>validate-manifest-freshness</id>
+								<configuration>
+									<executable>python3</executable>
+									<arguments>
+										<argument>${static.repo.freshness.script}</argument>
+										<argument>${habitv.static.repo.path}</argument>
+									</arguments>
+								</configuration>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -16,37 +16,68 @@ repository and served publicly via GitHub Pages. This replaces the legacy
 build/deploy time. Habitv at runtime never reads that path; it downloads from the
 HTTPS URL in `FrameworkConf.UPDATE_URL`.
 
-## One-command workflow (preferred)
+## Maven publication workflow (required)
 
-The `static-repo-publish` profile adds a final reactor module,
-`build/static-repo-publisher`, and activates the local file
-`distributionManagement` used for the static repository deploy.
+The `-Pstatic-repo-deploy` profile is the single publication command. It deploys
+Maven artifacts and runs the final `build/static-repo-publisher` reactor module,
+which regenerates repository extras and validates the result. No second manual
+script is required after Maven succeeds.
 
-Windows PowerShell:
+```powershell
+$env:HABITV_REPO_DIR = "D:\path\to\habitv-repo"
+
+mvn -B -ntp -Pstatic-repo-deploy deploy "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository"
+```
+
+What this single Maven command publishes:
+
+1. **Maven artifacts** — plugin and framework JARs/POMs under
+   `${habitv.static.repo.path}/com/dabi/habitv/`.
+2. **External tools** — `tools/<tool>/<version>/<tool>.zip` (Windows/PowerShell
+   via `publish-repository-extras.ps1`).
+3. **`plugins.txt`** — plugin id list for runtime discovery.
+4. **`habitv-update-manifest.properties`** — manifest entries for runtime discovery
+   (runtime prefers this over `maven-metadata.xml`):
+   - **plugin** entries point to the latest selected plugin JAR (timestamped Maven
+     SNAPSHOT builds when present);
+   - **tool** entries point to published tool ZIP files under `tools/`;
+   - the manifest can contain different packaging types (`jar`, `zip`, and others
+     as published).
+5. **`index.html`** — directory listings for static-host fallback discovery.
+6. **Validation** — layout and manifest freshness checks; Maven fails if the
+   manifest is stale or inconsistent.
+
+Publication-time requirements on Windows:
+
+- PowerShell (for tool zip publication and full repository extras)
+- Python 3 (for layout and manifest freshness validation invoked by Maven)
+
+The runtime updater resolves `habitv-update-manifest.properties` **before**
+falling back to `maven-metadata.xml`. If the manifest is not regenerated during
+deploy, startup downloads stale timestamped SNAPSHOT artifacts even when newer
+JARs were deployed.
+
+### Convenience wrapper (optional)
+
+`scripts/static-repo/publish-static-repository.ps1` is a thin alias around the
+Maven command above. It is not the authoritative workflow.
+
+```powershell
+$env:HABITV_REPO_DIR = "D:\path\to\habitv-repo"
+.\scripts\static-repo\publish-static-repository.ps1 -SkipTests
+```
+
+### Legacy `static-repo-publish` profile
+
+The older `static-repo-publish` profile remains for compatibility. New
+publications should use `-Pstatic-repo-deploy`, which now includes the same final
+publisher module and `${habitv.static.repo.path}` routing.
 
 ```powershell
 mvn -B -ntp -DskipTests clean deploy -Pstatic-repo-publish `
   '-DaltDeploymentRepository=habitv-local::default::file:///${habitv.static.repo.path}' `
   "-pl=!application/habiTv"
 ```
-
-Linux/macOS (PowerShell when available; otherwise metadata and `index.html` only):
-
-```bash
-mvn -B -ntp -DskipTests clean deploy -Pstatic-repo-publish \
-  '-DaltDeploymentRepository=habitv-local::default::file:///${habitv.static.repo.path}' \
-  '-pl=!application/habiTv'
-```
-
-What this single command does:
-
-1. **Maven deploy** — publishes plugin and framework JARs under
-   `${habitv.static.repo.path}/com/dabi/habitv/`.
-2. **`static-repo-publisher`** (final module) — generates:
-   - `plugins.txt`
-   - `habitv-update-manifest.properties`
-   - `index.html` directory listings
-   - `tools/<tool>/<version>/<tool>.zip` (Windows/PowerShell only)
 
 ## Static repository contract
 
@@ -78,10 +109,8 @@ mvn help:evaluate "-Dexpression=habitv.static.repo.path" -q "-DforceStdout"
 Override the staging path:
 
 ```powershell
-mvn -B -ntp -DskipTests clean deploy -Pstatic-repo-publish `
-  "-Dhabitv.static.repo.path=$env:USERPROFILE/dev/habitv-repo/repository" `
-  '-DaltDeploymentRepository=habitv-local::default::file:///${habitv.static.repo.path}' `
-  "-pl=!application/habiTv"
+$env:HABITV_REPO_DIR = "D:\path\to\habitv-repo"
+mvn -B -ntp -Pstatic-repo-deploy deploy "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository"
 ```
 
 Nothing is written under the `habitv` source tree; output goes only to
@@ -116,12 +145,13 @@ ${user.home}/dev/
       index.html
 ```
 
-## Manual fallback scripts
+## Internal helper scripts
 
-If you deploy without the profile, run the publisher script after `mvn deploy`:
+Maven invokes these automatically from `build/static-repo-publisher` during
+`-Pstatic-repo-deploy deploy`. Run them manually only when debugging:
 
 ```powershell
-.\scripts\static-repo\publish-repository-extras.ps1 -RepositoryPath (mvn help:evaluate "-Dexpression=habitv.static.repo.path" -q "-DforceStdout")
+.\scripts\static-repo\publish-repository-extras.ps1 -RepositoryPath "$env:HABITV_REPO_DIR/repository"
 ```
 
 ```bash
@@ -136,15 +166,25 @@ Skipped by default: `rtmpdump` (no reliable upstream Windows binary), `adobeHDS`
 
 ## Publish to GitHub Pages
 
-After the Maven command completes, commit the sibling `habitv-repo` checkout:
+After the publication workflow completes, commit the sibling `habitv-repo`
+checkout. Commit **only** `repository/`; do not commit `.trunk/` or local caches.
 
 ```powershell
-cd $env:USERPROFILE\dev\habitv-repo
-git status --short
+cd $env:HABITV_REPO_DIR
+git status --short --branch
+git diff --stat
 git add repository
-git commit -m "repo: publish habitv artifacts and tools"
+git commit -m "repo: update SNAPSHOT versions and refresh metadata"
 git push
 ```
+
+Wait for GitHub Pages propagation (typically 30–60 seconds), then verify:
+
+- https://mika3578.github.io/habitv-repo/repository/plugins.txt
+- https://mika3578.github.io/habitv-repo/repository/habitv-update-manifest.properties
+
+Run the isolated startup auto-update test (see project runbooks) and confirm the
+manifest points at the latest timestamped SNAPSHOT build ids.
 
 GitHub Pages serves `repository/` at
 `https://mika3578.github.io/habitv-repo/repository/`.
@@ -185,19 +225,22 @@ Supported values for `habitv.update.autoriseSnapshot` are `true` and `false`
 only. Invalid values are ignored and leave the XML setting in effect. The
 updater logs when the XML value is overridden.
 
-## Layout validation command
+## Manual validation commands
 
-After publishing metadata/index files, validate the generated repository layout:
+Maven runs these during deploy. Use the commands below only for ad hoc checks:
 
 ```bash
 python scripts/static-repo/validate_repository_layout.py "<path-to-repository>"
+python scripts/static-repo/validate_manifest_freshness.py "<path-to-repository>"
 ```
 
 Windows example:
 
 ```powershell
 python .\scripts\static-repo\validate_repository_layout.py `
-  "$env:USERPROFILE/dev/habitv-repo/repository"
+  "$env:HABITV_REPO_DIR/repository"
+python .\scripts\static-repo\validate_manifest_freshness.py `
+  "$env:HABITV_REPO_DIR/repository"
 ```
 
 ## Validation URLs

--- a/docs/static-repository-deploy.md
+++ b/docs/static-repository-deploy.md
@@ -26,8 +26,14 @@ script is required after Maven succeeds.
 ```powershell
 $env:HABITV_REPO_DIR = "D:\path\to\habitv-repo"
 
-mvn -B -ntp -Pstatic-repo-deploy deploy "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository"
+mvn -B -ntp -Pstatic-repo-deploy deploy `
+  "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository" `
+  "-pl=!application/habiTv"
 ```
+
+`application/habiTv` is excluded with `-pl=!application/habiTv` because of the
+existing JDK/`utils4j` compile blocker, which is unrelated to static repository
+deployment.
 
 What this single Maven command publishes:
 
@@ -67,11 +73,15 @@ $env:HABITV_REPO_DIR = "D:\path\to\habitv-repo"
 .\scripts\static-repo\publish-static-repository.ps1 -SkipTests
 ```
 
-### Legacy `static-repo-publish` profile
+### Legacy `static-repo-publish` profile (deprecated)
 
-The older `static-repo-publish` profile remains for compatibility. New
-publications should use `-Pstatic-repo-deploy`, which now includes the same final
-publisher module and `${habitv.static.repo.path}` routing.
+The older `-Pstatic-repo-publish` profile remains only as a legacy compatibility
+fallback for older runbooks. **New publications must use `-Pstatic-repo-deploy`.**
+
+Do not treat the legacy profile as equivalent to `-Pstatic-repo-deploy`. It is a
+best-effort fallback only and is **not** the validated workflow for deploy
+ordering, manifest freshness validation, or `${habitv.static.repo.path}` routing.
+Use it only when an exceptional compatibility case requires it:
 
 ```powershell
 mvn -B -ntp -DskipTests clean deploy -Pstatic-repo-publish `
@@ -96,10 +106,6 @@ host-provided autoindex. The generated tree must include:
 No GitHub Packages endpoint is used, and runtime update checks must never require a
 token.
 
-`application/habiTv` remains excluded (`-pl=!application/habiTv`) because of the
-existing JDK/`utils4j` compile blocker, which is unrelated to static repository
-deployment.
-
 Inspect the resolved staging path:
 
 ```powershell
@@ -110,7 +116,9 @@ Override the staging path:
 
 ```powershell
 $env:HABITV_REPO_DIR = "D:\path\to\habitv-repo"
-mvn -B -ntp -Pstatic-repo-deploy deploy "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository"
+mvn -B -ntp -Pstatic-repo-deploy deploy `
+  "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository" `
+  "-pl=!application/habiTv"
 ```
 
 Nothing is written under the `habitv` source tree; output goes only to

--- a/pom.xml
+++ b/pom.xml
@@ -217,8 +217,11 @@
 		<profile>
 			<id>static-repo-deploy</id>
 			<properties>
-				<habitv.deploy.repository.url>file:///${user.home}/dev/habitv-repo/repository</habitv.deploy.repository.url>
+				<habitv.deploy.repository.url>file:///${habitv.static.repo.path}</habitv.deploy.repository.url>
 			</properties>
+			<modules>
+				<module>build/static-repo-publisher</module>
+			</modules>
 			<distributionManagement>
 				<repository>
 					<id>habitv-static-deploy</id>
@@ -231,6 +234,17 @@
 					<url>${habitv.deploy.repository.url}</url>
 				</snapshotRepository>
 			</distributionManagement>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-deploy-plugin</artifactId>
+						<configuration>
+							<deployAtEnd combine.self="override">false</deployAtEnd>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<id>live-provider-tests</id>

--- a/scripts/static-repo/deploy-static-repo.ps1
+++ b/scripts/static-repo/deploy-static-repo.ps1
@@ -1,6 +1,7 @@
 param(
     [Parameter(Mandatory = $false)]
-    [string]$StaticRepoPath
+    [string]$StaticRepoPath,
+    [switch]$SkipTests
 )
 
 Set-StrictMode -Version Latest
@@ -36,4 +37,9 @@ if (-not [string]::IsNullOrWhiteSpace($StaticRepoPath)) {
     $env:HABITV_REPO_DIR = Resolve-HabitvRepoDirFromStaticRepoPath -StaticRepoPath $StaticRepoPath
 }
 
-& (Join-Path $PSScriptRoot "publish-static-repository.ps1") -SkipTests
+$publishArgs = @()
+if ($SkipTests) {
+    $publishArgs += "-SkipTests"
+}
+
+& (Join-Path $PSScriptRoot "publish-static-repository.ps1") @publishArgs

--- a/scripts/static-repo/deploy-static-repo.ps1
+++ b/scripts/static-repo/deploy-static-repo.ps1
@@ -6,75 +6,34 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-function Get-RepoRoot {
-    $scriptDirectory = Split-Path -Parent $PSCommandPath
-    return (Resolve-Path (Join-Path $scriptDirectory "..\..")).Path
-}
+function Resolve-HabitvRepoDirFromStaticRepoPath {
+    param([string]$StaticRepoPath)
 
-function Get-MavenStaticRepoPath {
-    param(
-        [string]$RepoRootPath,
-        [string]$OverridePath
-    )
-
-    $mvnArgs = @(
-        "help:evaluate",
-        "-Dexpression=habitv.static.repo.path",
-        "-q",
-        "-DforceStdout"
-    )
-    if (-not [string]::IsNullOrWhiteSpace($OverridePath)) {
-        $normalized = $OverridePath.Trim() -replace '\\', '/'
-        $mvnArgs = @("-Dhabitv.static.repo.path=$normalized") + $mvnArgs
+    if ([string]::IsNullOrWhiteSpace($StaticRepoPath)) {
+        throw "StaticRepoPath is empty."
     }
 
-    Push-Location $RepoRootPath
-    try {
-        $evaluated = (& mvn @mvnArgs | Select-Object -Last 1).Trim()
-        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($evaluated)) {
-            throw "Unable to evaluate habitv.static.repo.path."
+    $normalized = $StaticRepoPath.Trim().Replace('\', '/')
+    while ($normalized.EndsWith('/')) {
+        $normalized = $normalized.Substring(0, $normalized.Length - 1)
+    }
+
+    if ($normalized.EndsWith('/repository')) {
+        $normalized = $normalized.Substring(0, $normalized.Length - '/repository'.Length)
+        while ($normalized.EndsWith('/')) {
+            $normalized = $normalized.Substring(0, $normalized.Length - 1)
         }
-        return ($evaluated -replace '\\', '/')
-    }
-    finally {
-        Pop-Location
-    }
-}
-
-$repoRoot = Get-RepoRoot
-$staticRepoPath = Get-MavenStaticRepoPath -RepoRootPath $repoRoot -OverridePath $StaticRepoPath
-
-if (-not (Test-Path -Path $staticRepoPath -PathType Container)) {
-    New-Item -Path $staticRepoPath -ItemType Directory -Force | Out-Null
-}
-
-$habitvRepoRoot = Split-Path -Parent $staticRepoPath
-Write-Host ("habitv.static.repo.path = {0}" -f $staticRepoPath)
-Write-Host "Deploying with Maven property-based file repository (no hardcoded machine path)."
-
-Push-Location $repoRoot
-try {
-    $deployArgs = @(
-        "-B", "-ntp", "-DskipTests", "clean", "deploy",
-        '-DaltDeploymentRepository=habitv-local::default::file:///${habitv.static.repo.path}'
-    )
-    if (-not [string]::IsNullOrWhiteSpace($StaticRepoPath)) {
-        $normalized = $StaticRepoPath.Trim() -replace '\\', '/'
-        $deployArgs = @("-Dhabitv.static.repo.path=$normalized") + $deployArgs
     }
 
-    & mvn @deployArgs
-    if ($LASTEXITCODE -ne 0) {
-        throw "Maven deploy failed."
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+        throw "StaticRepoPath resolved to an empty habitv-repo root: $StaticRepoPath"
     }
-}
-finally {
-    Pop-Location
+
+    return ($normalized -replace '/', [System.IO.Path]::DirectorySeparatorChar)
 }
 
-Write-Host "Deploy complete. Publish with:"
-Write-Host "  cd $habitvRepoRoot"
-Write-Host "  git status --short"
-Write-Host "  git add repository"
-Write-Host '  git commit -m "repo: publish habitv artifacts"'
-Write-Host "  git push"
+if (-not [string]::IsNullOrWhiteSpace($StaticRepoPath)) {
+    $env:HABITV_REPO_DIR = Resolve-HabitvRepoDirFromStaticRepoPath -StaticRepoPath $StaticRepoPath
+}
+
+& (Join-Path $PSScriptRoot "publish-static-repository.ps1") -SkipTests

--- a/scripts/static-repo/generate_repository_metadata.py
+++ b/scripts/static-repo/generate_repository_metadata.py
@@ -8,6 +8,13 @@ import re
 import sys
 
 
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+from validate_manifest_freshness import newest_jar_in_directory  # noqa: E402
+
+
 def read_plugin_ids(plugins_pom):
     with open(plugins_pom, "r") as handle:
         content = handle.read()
@@ -16,16 +23,7 @@ def read_plugin_ids(plugins_pom):
 
 
 def latest_jar(version_dir):
-    jars = [
-        name
-        for name in os.listdir(version_dir)
-        if name.endswith(".jar")
-        and not name.endswith("-sources.jar")
-        and not name.endswith("-javadoc.jar")
-    ]
-    if not jars:
-        return None
-    return sorted(jars)[-1]
+    return newest_jar_in_directory(version_dir)
 
 
 def build_manifest_lines(repository_root, plugin_ids):

--- a/scripts/static-repo/publish-repository-extras.ps1
+++ b/scripts/static-repo/publish-repository-extras.ps1
@@ -117,16 +117,38 @@ function Write-PluginsTxt {
     Write-Host "Wrote $path ($($PluginIds.Count) plugins)"
 }
 
+function Get-BuildSortKeyFromFileName {
+    param([string]$FileName)
+
+    if ($FileName -match '-(\d{8}\.\d{6}-\d+)(?:-all)?\.jar$') {
+        $buildId = $Matches[1]
+        $parts = $buildId.Split('-', 2)
+        if ($parts.Length -eq 2) {
+            $dateTimeParts = $parts[0].Split('.', 2)
+            if ($dateTimeParts.Length -eq 2) {
+                $datePart = $dateTimeParts[0]
+                $timePart = [int]$dateTimeParts[1]
+                $buildNumber = [long]$parts[1]
+                $allPenalty = if ($FileName.EndsWith('-all.jar')) { 1 } else { 0 }
+                return "1:{0}.{1:D6}-{2:D10}:{3}:{4}" -f $datePart, $timePart, $buildNumber, (-1 * $allPenalty), $FileName
+            }
+        }
+        return "0:{0}" -f $FileName
+    }
+
+    return "0:{0}" -f $FileName
+}
+
 function Get-LatestSnapshotJar {
     param([string]$VersionDir)
 
     $jars = @(Get-ChildItem -Path $VersionDir -Filter "*.jar" -File |
-        Where-Object { $_.Name -notmatch '(-sources|-javadoc)\.jar$' } |
-        Sort-Object Name)
+        Where-Object { $_.Name -notmatch '(-sources|-javadoc)\.jar$' })
     if ($jars.Count -eq 0) {
         return $null
     }
-    return $jars[$jars.Count - 1]
+
+    return ($jars | Sort-Object { Get-BuildSortKeyFromFileName $_.Name } | Select-Object -Last 1)
 }
 
 function Build-ManifestLines {

--- a/scripts/static-repo/publish-static-repository.ps1
+++ b/scripts/static-repo/publish-static-repository.ps1
@@ -1,0 +1,60 @@
+<#
+.SYNOPSIS
+  Convenience wrapper around the Maven static repository deploy profile.
+
+.DESCRIPTION
+  Delegates to:
+
+  mvn -B -ntp -Pstatic-repo-deploy deploy "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository"
+
+  Maven deploy publishes artifacts, external tools, plugins.txt,
+  habitv-update-manifest.properties, repository indexes, and manifest validation.
+#>
+[CmdletBinding()]
+param(
+    [switch]$SkipTests
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($env:HABITV_REPO_DIR)) {
+    throw "HABITV_REPO_DIR is not set. Point it at the local habitv-repo Git checkout root."
+}
+
+$repoRoot = (Resolve-Path $env:HABITV_REPO_DIR).Path
+$repositoryPath = Join-Path $repoRoot "repository"
+if (-not (Test-Path $repositoryPath)) {
+    New-Item -Path $repositoryPath -ItemType Directory -Force | Out-Null
+}
+
+$normalized = $repositoryPath.Trim() -replace '\\', '/'
+$habitvRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+
+Write-Host "Running Maven static repository deploy via -Pstatic-repo-deploy"
+Write-Host "Repository path: $normalized"
+
+Push-Location $habitvRoot
+try {
+    $mvnArgs = @("-B", "-ntp", "-Pstatic-repo-deploy", "deploy", "-Dhabitv.static.repo.path=$normalized")
+    if ($SkipTests) {
+        $mvnArgs = @("-DskipTests") + $mvnArgs
+    }
+
+    & mvn @mvnArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Maven static repository deploy failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host ""
+Write-Host "Next steps in habitv-repo (manual Git publication):"
+Write-Host "  Push-Location '$repoRoot'"
+Write-Host "  git status --short --branch"
+Write-Host "  git add repository"
+Write-Host "  git commit -m `"repo: update SNAPSHOT versions and refresh metadata`""
+Write-Host "  git push"
+Write-Host "  Pop-Location"

--- a/scripts/static-repo/test_generate_repository_metadata.py
+++ b/scripts/static-repo/test_generate_repository_metadata.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Offline tests for generate_repository_metadata.py SNAPSHOT jar selection."""
+
+from __future__ import print_function
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+from generate_repository_metadata import latest_jar  # noqa: E402
+from validate_manifest_freshness import build_sort_key  # noqa: E402
+
+
+class GenerateRepositoryMetadataSnapshotTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="habitv-metadata-test-")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def write_jar(self, filename):
+        path = os.path.join(self.temp_dir, filename)
+        with open(path, "wb") as handle:
+            handle.write(b"jar")
+
+    def test_build_10_sorts_newer_than_build_9(self):
+        build_9 = "sample-4.1.0-20260530.144853-9.jar"
+        build_10 = "sample-4.1.0-20260530.144853-10.jar"
+        self.assertLess(build_sort_key(build_9), build_sort_key(build_10))
+
+        for name in (build_9, build_10):
+            self.write_jar(name)
+        self.assertEqual(build_10, latest_jar(self.temp_dir))
+
+    def test_timestamped_outranks_plain_snapshot_jar(self):
+        plain = "sample-4.1.0-SNAPSHOT.jar"
+        timestamped = "sample-4.1.0-20260530.144853-2.jar"
+        for name in (plain, timestamped):
+            self.write_jar(name)
+        self.assertEqual(timestamped, latest_jar(self.temp_dir))
+
+    def test_plain_jar_outranks_all_jar_for_same_build(self):
+        plain = "sample-4.1.0-20260530.144853-2.jar"
+        all_jar = "sample-4.1.0-20260530.144853-2-all.jar"
+        for name in (plain, all_jar):
+            self.write_jar(name)
+        self.assertEqual(plain, latest_jar(self.temp_dir))
+
+    def test_ignores_sources_and_javadoc_jars(self):
+        main_jar = "sample-4.1.0-20260530.144853-2.jar"
+        for name in (
+            main_jar,
+            "sample-4.1.0-20260530.144853-2-sources.jar",
+            "sample-4.1.0-20260530.144853-2-javadoc.jar",
+        ):
+            self.write_jar(name)
+        self.assertEqual(main_jar, latest_jar(self.temp_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/static-repo/test_validate_manifest_freshness.py
+++ b/scripts/static-repo/test_validate_manifest_freshness.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Offline tests for validate_manifest_freshness.py."""
+
+from __future__ import print_function
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+VALIDATOR = os.path.join(SCRIPT_DIR, "validate_manifest_freshness.py")
+
+sys.path.insert(0, SCRIPT_DIR)
+from validate_manifest_freshness import (  # noqa: E402
+    build_sort_key,
+    newest_jar_in_directory,
+    parse_manifest_line,
+)
+
+
+class ValidateManifestFreshnessTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="habitv-manifest-test-")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def write_manifest(self, lines):
+        manifest_path = os.path.join(
+            self.temp_dir, "habitv-update-manifest.properties"
+        )
+        with open(manifest_path, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+
+    def write_jar(self, relative_path):
+        target_path = os.path.join(self.temp_dir, *relative_path.split("/"))
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        with open(target_path, "wb") as handle:
+            handle.write(b"jar")
+
+    def run_validator(self):
+        completed = subprocess.run(
+            [sys.executable, VALIDATOR, self.temp_dir],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.last_stderr = completed.stderr.decode("utf-8", errors="replace")
+        return completed.returncode
+
+    def test_accepts_newest_snapshot_jar(self):
+        self.write_jar(
+            "com/dabi/habitv/sample/4.1.0-SNAPSHOT/sample-4.1.0-20260519.221134-1.jar"
+        )
+        self.write_jar(
+            "com/dabi/habitv/sample/4.1.0-SNAPSHOT/sample-4.1.0-20260530.144853-2.jar"
+        )
+        self.write_manifest(
+            [
+                "# comment",
+                "plugin|com.dabi.habitv|sample|4.1.0-SNAPSHOT|jar|"
+                "com/dabi/habitv/sample/4.1.0-SNAPSHOT/"
+                "sample-4.1.0-20260530.144853-2.jar",
+            ]
+        )
+        self.assertEqual(0, self.run_validator())
+
+    def test_accepts_manifest_with_optional_checksum(self):
+        self.write_jar(
+            "com/dabi/habitv/sample/4.1.0-SNAPSHOT/sample-4.1.0-20260530.144853-2.jar"
+        )
+        self.write_manifest(
+            [
+                "plugin|com.dabi.habitv|sample|4.1.0-SNAPSHOT|jar|"
+                "com/dabi/habitv/sample/4.1.0-SNAPSHOT/"
+                "sample-4.1.0-20260530.144853-2.jar|deadbeef",
+            ]
+        )
+        self.assertEqual(0, self.run_validator())
+
+    def test_parse_manifest_line_keeps_checksum_separate(self):
+        entry = parse_manifest_line(
+            "plugin|com.dabi.habitv|sample|4.1.0-SNAPSHOT|jar|"
+            "com/dabi/habitv/sample/4.1.0-SNAPSHOT/sample.jar|abc123"
+        )
+        self.assertIsNotNone(entry)
+        self.assertEqual(
+            entry["relativeUrl"],
+            "com/dabi/habitv/sample/4.1.0-SNAPSHOT/sample.jar",
+        )
+        self.assertEqual(entry["checksum"], "abc123")
+
+    def test_rejects_stale_snapshot_jar(self):
+        self.write_jar(
+            "com/dabi/habitv/sample/4.1.0-SNAPSHOT/sample-4.1.0-20260519.221134-1.jar"
+        )
+        self.write_jar(
+            "com/dabi/habitv/sample/4.1.0-SNAPSHOT/sample-4.1.0-20260530.144853-2.jar"
+        )
+        self.write_manifest(
+            [
+                "plugin|com.dabi.habitv|sample|4.1.0-SNAPSHOT|jar|"
+                "com/dabi/habitv/sample/4.1.0-SNAPSHOT/"
+                "sample-4.1.0-20260519.221134-1.jar",
+            ]
+        )
+        self.assertNotEqual(0, self.run_validator())
+
+    def test_rejects_missing_manifest_target(self):
+        self.write_manifest(
+            [
+                "plugin|com.dabi.habitv|sample|4.1.0-SNAPSHOT|jar|"
+                "com/dabi/habitv/sample/4.1.0-SNAPSHOT/missing.jar",
+            ]
+        )
+        self.assertNotEqual(0, self.run_validator())
+        self.assertIn("missing file", self.last_stderr)
+
+    def test_rejects_missing_manifest_file(self):
+        self.assertNotEqual(0, self.run_validator())
+        self.assertIn("Missing manifest", self.last_stderr)
+
+    def test_non_timestamped_snapshot_jar_sorts_below_timestamped(self):
+        version_dir = os.path.join(
+            self.temp_dir, "com", "dabi", "habitv", "sample", "4.1.0-SNAPSHOT"
+        )
+        os.makedirs(version_dir)
+        plain = "sample-4.1.0-SNAPSHOT.jar"
+        timestamped = "sample-4.1.0-20260530.144853-2.jar"
+        for name in (plain, timestamped):
+            with open(os.path.join(version_dir, name), "wb") as handle:
+                handle.write(b"jar")
+
+        self.assertLess(build_sort_key(plain), build_sort_key(timestamped))
+        self.assertEqual(timestamped, newest_jar_in_directory(version_dir))
+
+    def test_timestamp_tie_breaks_deterministically_on_filename(self):
+        version_dir = os.path.join(
+            self.temp_dir, "com", "dabi", "habitv", "sample", "4.1.0-SNAPSHOT"
+        )
+        os.makedirs(version_dir)
+        plain = "sample-4.1.0-20260530.144853-2.jar"
+        all_jar = "sample-4.1.0-20260530.144853-2-all.jar"
+        for name in (plain, all_jar):
+            with open(os.path.join(version_dir, name), "wb") as handle:
+                handle.write(b"jar")
+
+        self.assertGreater(build_sort_key(plain), build_sort_key(all_jar))
+        self.assertEqual(plain, newest_jar_in_directory(version_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/static-repo/validate_manifest_freshness.py
+++ b/scripts/static-repo/validate_manifest_freshness.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Validate habitv-update-manifest.properties points at the newest local SNAPSHOT jars."""
+
+from __future__ import print_function
+
+import argparse
+import os
+import re
+import sys
+
+
+BUILD_ID_PATTERN = re.compile(r"-(\d{8}\.\d{6}-\d+)(?:-all)?\.jar$")
+OBSOLETE_HOST_PATTERN = re.compile(r"dabiboo|free\.fr", re.IGNORECASE)
+VALID_ENTRY_TYPES = frozenset(["plugin", "tool"])
+
+
+def fail(errors, message):
+    errors.append(message)
+
+
+def build_sort_key(filename):
+    """Return a sortable key; timestamped Maven SNAPSHOT jars outrank plain *-SNAPSHOT.jar names."""
+    match = BUILD_ID_PATTERN.search(filename)
+    if not match:
+        return (0, "", -1, -1, 0, filename)
+
+    build_id = match.group(1)
+    parts = build_id.split("-", 1)
+    if len(parts) != 2:
+        return (0, "", -1, -1, 0, filename)
+
+    date_time, build_number = parts
+    if "." not in date_time:
+        return (0, "", -1, -1, 0, filename)
+
+    date_part, time_part = date_time.split(".", 1)
+    try:
+        all_penalty = 1 if filename.endswith("-all.jar") else 0
+        return (1, date_part, int(time_part), int(build_number), -all_penalty, filename)
+    except ValueError:
+        return (0, "", -1, -1, 0, filename)
+
+
+def newest_jar_in_directory(version_dir):
+    jars = []
+    for name in os.listdir(version_dir):
+        if not name.endswith(".jar"):
+            continue
+        if name.endswith("-sources.jar") or name.endswith("-javadoc.jar"):
+            continue
+        jars.append(name)
+    if not jars:
+        return None
+    return max(jars, key=build_sort_key)
+
+
+def parse_manifest_line(line):
+    """Parse one manifest line: type|groupId|artifactId|version|packaging|relativeUrl[|checksum]."""
+    parts = line.split("|")
+    if len(parts) < 6:
+        return None
+    if parts[0] not in VALID_ENTRY_TYPES:
+        return None
+
+    entry_type = parts[0]
+    group_id = parts[1]
+    artifact_id = parts[2]
+    version = parts[3]
+    packaging = parts[4]
+    relative_url = parts[5]
+    checksum = parts[6] if len(parts) > 6 else None
+
+    return {
+        "type": entry_type,
+        "groupId": group_id,
+        "artifactId": artifact_id,
+        "version": version,
+        "packaging": packaging,
+        "relativeUrl": relative_url.replace("\\", "/"),
+        "checksum": checksum,
+    }
+
+
+def parse_manifest(manifest_path, errors):
+    entries = []
+    if not os.path.isfile(manifest_path):
+        fail(errors, "Missing manifest {}".format(manifest_path))
+        return entries
+
+    with open(manifest_path, "r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if OBSOLETE_HOST_PATTERN.search(line):
+                fail(
+                    errors,
+                    "Obsolete host reference in manifest line {}: {}".format(
+                        line_number, line
+                    ),
+                )
+                continue
+
+            parsed = parse_manifest_line(line)
+            if parsed is None:
+                fail(
+                    errors,
+                    "Invalid manifest line {}: {}".format(line_number, line),
+                )
+                continue
+
+            parsed["line"] = line_number
+            entries.append(parsed)
+
+    return entries
+
+
+def validate_manifest_entries(repository_root, entries, errors):
+    for entry in entries:
+        relative_url = entry["relativeUrl"]
+        target_path = os.path.join(repository_root, *relative_url.split("/"))
+        if not os.path.isfile(target_path):
+            fail(
+                errors,
+                "Manifest line {} references missing file: {}".format(
+                    entry["line"], relative_url
+                ),
+            )
+            continue
+
+        if entry["type"] != "plugin":
+            continue
+
+        version_dir = os.path.dirname(target_path)
+        manifest_jar = os.path.basename(target_path)
+        newest_jar = newest_jar_in_directory(version_dir)
+        if newest_jar is None:
+            fail(
+                errors,
+                "No plugin jars found for manifest line {} in {}".format(
+                    entry["line"], version_dir
+                ),
+            )
+            continue
+
+        if manifest_jar != newest_jar:
+            fail(
+                errors,
+                (
+                    "Stale manifest entry for {0}: manifest points to {1}, "
+                    "newest local jar is {2}"
+                ).format(entry["artifactId"], manifest_jar, newest_jar),
+            )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate habitv-update-manifest.properties freshness and file presence."
+        )
+    )
+    parser.add_argument(
+        "repository_root",
+        help="Path to generated static repository root.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    repository_root = os.path.abspath(args.repository_root)
+    errors = []
+
+    manifest_path = os.path.join(
+        repository_root, "habitv-update-manifest.properties"
+    )
+    entries = parse_manifest(manifest_path, errors)
+    validate_manifest_entries(repository_root, entries, errors)
+
+    if errors:
+        for error in errors:
+            print("ERROR:", error, file=sys.stderr)
+        return 1
+
+    print(
+        "Manifest freshness validation passed: {} entries checked in {}".format(
+            len(entries), manifest_path
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes the static repository publication workflow so the Maven deploy lifecycle performs the full Habitv static repository publication.

The required publication command is now:

```powershell
$env:HABITV_REPO_DIR = "D:\path\to\habitv-repo"

mvn -B -ntp -Pstatic-repo-deploy deploy `
  "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository" `
  "-pl=!application/habiTv"
```

This command now publishes Maven artifacts, plugins, external tools, `plugins.txt`, `habitv-update-manifest.properties`, repository indexes, and validates manifest freshness.

## Root cause

The previous `-Pstatic-repo-deploy deploy` workflow only deployed Maven artifacts into the static repository. It did not add the final static repository publisher module, so `publish-repository-extras.ps1` did not run.

As a result, `habitv-update-manifest.properties` stayed stale and pointed to `20260519.221134-1` while newer SNAPSHOT artifacts such as `20260530.144853-*` had been deployed.

Runtime update resolution prefers `habitv-update-manifest.properties` before falling back to `maven-metadata.xml`, so the stale manifest caused Habitv to download older plugin artifacts despite a successful Maven deploy.

## Changes

* Activate `build/static-repo-publisher` from the `static-repo-deploy` profile as the final reactor publisher module.
* Route Maven deploy to `file:///${habitv.static.repo.path}` through `habitv.deploy.repository.url`.
* Set the static repository deploy flow so repository extras run after plugin artifacts are deployed.
* Regenerate:

  * external tools
  * `plugins.txt`
  * `habitv-update-manifest.properties`
  * repository index files
* Add manifest freshness validation so Maven fails when the manifest points to stale SNAPSHOT artifacts.
* Improve SNAPSHOT artifact ordering in `publish-repository-extras.ps1` and `generate_repository_metadata.py`.
* Add offline tests for manifest freshness validation and repository metadata generation.
* Update static repository deployment documentation.
* Keep `publish-static-repository.ps1` only as an optional Maven alias, not as the primary workflow.
* Preserve deploy wrapper default test behavior: `deploy-static-repo.ps1` accepts optional `-SkipTests` and forwards it to `publish-static-repository.ps1` only when explicitly requested.

## Validation

* `python scripts/static-repo/test_validate_manifest_freshness.py -v`

  * 8/8 OK
* `python scripts/static-repo/test_generate_repository_metadata.py -v`

  * 4/4 OK
* `git diff --check`

  * Pass
* `Get-Help scripts/static-repo/deploy-static-repo.ps1`

  * Shows `[-SkipTests]`
* `mvn -B -ntp -DskipTests verify`

  * BUILD SUCCESS
* `mvn -B -ntp -pl fwk/framework test -Dtest=FindArtifactUtilsTest,HabitvUpdateManifestTest`

  * 16 tests, 0 failures
* `mvn -B -ntp -Pstatic-repo-deploy deploy "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository" "-pl=!application/habiTv"`

  * BUILD SUCCESS

## Local purge-and-redeploy validation

A controlled local purge-and-redeploy test was run from source commit `d1f3b04a155159692f165b54b0d590b4949c971d`.

Results:

* Purge scope: local `habitv-repo/repository/` only.
* `habitv-repo` commit before purge: `15c3761aac63759fd5ff02daeb74ad987ec91cb4`.
* Files before purge: 1,097.
* Files after redeploy: 486.
* Deleted: 803.
* Added: 192.
* Unchanged: 294.
* Maven deploy: BUILD SUCCESS, 34/34 modules.
* `plugins.txt`: 23 plugins.
* `habitv-update-manifest.properties`: 28 entries.
* Latest SNAPSHOT build id: `20260531.081033-1`.
* Tool ZIPs present: `aria2c`, `curl`, `ffmpeg`, `rclone`, `yt-dlp`.
* `validate_repository_layout.py`: pass.
* `validate_manifest_freshness.py`: pass.
* Legacy URL/local path scan: clean.
* `wat` remains expected because this PR republishes the current Maven reactor artifact set; TF1+ replacement is out of scope.
* No generated `habitv-repo` files were committed or pushed.

## Real static deploy evidence

The real Maven deploy command regenerated the static repository successfully:

* `plugins.txt` regenerated with 23 plugins.
* `habitv-update-manifest.properties` regenerated with 28 entries.
* Manifest freshness validation passed during Maven deploy.
* Latest SNAPSHOT build IDs were updated to `20260530.152622-*`.
* External tools published/refreshed:

  * `aria2c`
  * `curl`
  * `ffmpeg`
  * `rclone`
  * `yt-dlp`
* `adobeHDS` and `rtmpdump` remained skipped as before.
* No generated `dabiboo.free.fr` references were detected.

## Notes

* No runtime Java update behavior is changed.
* No provider behavior is changed.
* This PR changes the publication workflow only.
* `habitv-repo` generated files were not committed or pushed as part of this source PR.
* `agent_space/` and the local purge script were intentionally left uncommitted.

## Follow-up after merge

After this PR is merged:

1. Run:

   ```powershell
   $env:HABITV_REPO_DIR = "<local habitv-repo checkout>"
   mvn -B -ntp -Pstatic-repo-deploy deploy `
     "-Dhabitv.static.repo.path=$env:HABITV_REPO_DIR/repository" `
     "-pl=!application/habiTv"
   ```

2. Review `habitv-repo`:

   ```powershell
   Push-Location $env:HABITV_REPO_DIR
   git status --short --branch
   git diff --stat
   git diff --name-status
   Pop-Location
   ```

3. Commit and push only `repository/` in `habitv-repo`.

4. Wait for GitHub Pages propagation.

5. Re-run the isolated startup update E2E test.

6. Confirm runtime downloads the latest manifest entries, such as `20260531.081033-1` or newer.
