### PR TITLE
docs(tracker): refresh modernization state after merged work

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,10 @@
 
 Habitv is a legacy Java 8 Maven multi-module application for downloading
 French TV catch-up content via pluggable provider plugins. Modernization
-is staged through tracker items in `docs/dev-tracker.md`.
+is staged through tracker items in `docs/dev-tracker.md` (last refresh
+2026-05-31 on `develop`). Supported **runtime** remains Java 8; planned
+LTS **runtime target** is Java 21, then Java 25 — see
+`docs/java-runtime-policy.md`.
 
 Treat the codebase as production legacy: prefer conservative,
 narrowly-scoped suggestions over rewrites.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,10 +167,11 @@ French TV catch-up content via pluggable provider plugins.
 | `mvn validate` on Ubuntu + Windows (CI) | ✅ |
 | `mvn compile` from root | ✅ |
 | `mvn test` (offline) | 🟡 partial |
-| `mvn package` (full app) | ⛔ blocked on JavaFX / `jdk.home` |
-| Legacy `dabiboo.free.fr` / SVN / FTP removed | ⬜ |
-| `youtube-dl` → `yt-dlp` complete migration | 🟡 wiring only |
-| Provider plugin endpoints audited | ⬜ |
+| `mvn package` (full app / GUI) | 🟡 JavaFX-capable JDK 8 or scoped console package; Windows installer foundation on `develop` |
+| Legacy `dabiboo.free.fr` / SVN / FTP removed | ✅ active POM/runtime |
+| `youtube-dl` → `yt-dlp` complete migration | 🟡 wiring done; habitv-repo tool publish pending |
+| Provider plugin endpoints audited | 🟡 inventory + offline fixtures; rewrites ongoing |
+| `develop` branch protection / required CI | 🟡 `protect-develop` documented; owner UI confirm pending |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ complement, but do not replace, the human review process.
 
 ## Agent rules metadata
 
-* **Version:** 1.4.0
-* **Last updated:** 2026-05-28
+* **Version:** 1.4.1
+* **Last updated:** 2026-05-31
 * **Maintainer:** repository maintainer
 * **Scope:** Habitv AI-assisted development workflow
 * **Canonical source:** `AGENTS.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-29 | PR [#132](https://github.com/Mika3578/habitv/pull/132) | Configure Maven resource encoding (`UTF-8`) |
+| 2026-05-29 | PR [#130](https://github.com/Mika3578/habitv/pull/130) | Add manual Maven CodeQL analysis workflow |
+| 2026-05-29 | PR [#131](https://github.com/Mika3578/habitv/pull/131) | Remove BOM from grabconfig XML |
 | 2026-05-27 | TBD | Harden and DRY the Maven CI workflows (inspired by Apache Commons, the `actions/starter-workflows` Maven template, and `spring-petclinic`): set `persist-credentials: false` on every `actions/checkout`, extract the shared JDK-setup and artifact-upload steps into `.github/actions/setup-build-jdk` and `.github/actions/upload-maven-artifacts` composite actions, and add a non-required `validate-macos` diagnostic job. No change to the four required `develop` checks |
 | 2026-05-26 | TBD | Match the live `protect-develop` ruleset required checks: remove the now-stale `validate (zulu-8)` / `CI / validate (zulu-8)` context (deleted with `ci.yml`) and require the four live contexts (`validate-java8`, `deterministic-tests-java8`, `compile-and-package-java8`, `dependency-review`), unblocking `develop` PRs stranded at "Expected — Waiting". Keep the ruleset payload aligned with GitHub Settings (bare contexts, plus squash-only, `code_scanning`, `code_quality`, `copilot_code_review`) and update the governance, required-checks-roadmap, and repository-settings docs |
 | 2026-05-26 | TBD | Relax Dependabot policy so it can actually open PRs: allow GitHub Actions major bumps (every action is pinned to a floating major tag, so majors were the only possible update and the blanket ignore suppressed all PRs) and allow Maven majors except for jakarta-crossing artifacts (`jaxb-api`, `jaxb-runtime`, `javax.mail:mail`) guarded by the Java 8 / no-jakarta hard rule |
@@ -36,6 +39,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-30 | `e38defdc` | Refresh static repository manifest after deploy (PR [#140](https://github.com/Mika3578/habitv/pull/140)) |
+| 2026-05-30 | `c9a4746d` | Improve sanitized download failure diagnostics (PR [#139](https://github.com/Mika3578/habitv/pull/139)) |
+| 2026-05-30 | PR [#138](https://github.com/Mika3578/habitv/pull/138) | Harden YouTube Data API lookup handling |
 | 2026-05-23 | TBD | Remove obsolete embedded `D8` sub-provider from `plugins/canalPlus` (dead `www.d8.tv` endpoints; channel rebranded to C8); drop `d8` from sample `grabconfig.xml`; update offline fixture baseline to `canalPlus,cstar` |
 | 2026-05-18 | TBD | Resolve JavaFX `jfxrt.jar` from common JDK 8 layouts in `HabitvLauncher` |
 
@@ -43,7 +49,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
-| 2026-05-29 | TBD | France.tv public hubs: API-first discovery via `/apps/channels/{hubSlug}?platform=apps` for Sport, Franceinfo, Arte, TV5 Monde Plus, France 24, INA, LCP, Public Sénat, and Mieux; partner hub children from API; episodes via `/generic/taxonomy/{taxonomySlug}/contents`; grabconfig refresh preserves public hub order and partner children with schema-valid merge; bump `francetv` plugin to `4.1.3-SNAPSHOT` |
+| 2026-05-29 | PR [#137](https://github.com/Mika3578/habitv/pull/137) | France.tv public hubs: API-first discovery via `/apps/channels/{hubSlug}?platform=apps` for Sport, Franceinfo, Arte, TV5 Monde Plus, France 24, INA, LCP, Public Sénat, and Mieux; partner hub children from API; episodes via `/generic/taxonomy/{taxonomySlug}/contents`; grabconfig refresh preserves public hub order and partner children with schema-valid merge; bump `francetv` plugin to `4.1.3-SNAPSHOT` |
 | 2026-05-19 | PR [#64](https://github.com/Mika3578/habitv/pull/64) | `francetv` provider: replace dead `france-o` channel slug with `la1ere` (Outre-mer La 1ère), centralise channel labels in `FranceTvUrls`, accept `franceinfo.fr` / `francetvinfo.fr` URLs in `canDownload`, raise `MAX_PAGES` to 100 |
 | 2026-05-18 | `2311bbc` | Replace `pluzz` provider with `francetv` (france.tv + yt-dlp) — users must rename `<plugin name="pluzz">` to `<plugin name="francetv">` in their grab-config XML (legacy `pluzz.` URLs in `canDownload` remain accepted) |
 | 2026-05-18 | PR [#52](https://github.com/Mika3578/habitv/pull/52) | Migrate YouTube plugin downloader defaults to yt-dlp |
@@ -53,6 +59,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-29 | PR [#135](https://github.com/Mika3578/habitv/pull/135) | Remove live URL dependency from deterministic test |
 | 2026-05-18 | PR [#52](https://github.com/Mika3578/habitv/pull/52) | Expand offline yt-dlp defaults and command wiring tests |
 | 2026-05-17 | `0163d9a` | Cover yt-dlp command wiring (offline test) |
 
@@ -60,6 +67,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 | Date | Commit | Change |
 |------|--------|--------|
+| 2026-05-31 | TBD | Refresh modernization tracker, plan, risks, provider inventory, and maintenance dashboard after merged May work |
+| 2026-05-29 | PR [#136](https://github.com/Mika3578/habitv/pull/136) | Plan JAXB and Activation deduplication (docs only) |
+| 2026-05-29 | PR [#134](https://github.com/Mika3578/habitv/pull/134) | Audit Maven Shade duplicate warnings |
+| 2026-05-29 | PR [#133](https://github.com/Mika3578/habitv/pull/133) | Document Lombok compiler warning (CodeQL context) |
+| 2026-05-28 | PR [#125](https://github.com/Mika3578/habitv/pull/125) | Centralize safe agent workflow rules (productivity profiles) |
 | 2026-05-20 | PR [#104](https://github.com/Mika3578/habitv/pull/104) | Add external tools recommendations and obsolescence analysis (`external-tools-recommendations`) |
 | 2026-05-18 | PR [#52](https://github.com/Mika3578/habitv/pull/52) | Document yt-dlp CLI compatibility and tracker progress |
 | 2026-05-17 | `750640d` | Update modernization status after console baseline |

--- a/docs/agent-rules-changelog.md
+++ b/docs/agent-rules-changelog.md
@@ -2,6 +2,34 @@
 
 Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AGENTS.md).
 
+## 2026-05-31 — v1.4.1
+
+### Added
+
+* None.
+
+### Changed
+
+* Refreshed the repository at-a-glance modernization/tracker state and Copilot
+  instruction pointer as part of PR #141, with no workflow or rule behavior
+  changes.
+
+### Removed
+
+* None.
+
+### Reason
+
+* Tracker synchronization PR #141 edited `AGENTS.md` and
+  `.github/copilot-instructions.md`; metadata and changelog audit trail
+  required per Section 17.
+
+### Follow-up
+
+* None.
+
+---
+
 ## 2026-05-28 — v1.4.0
 
 ### Added

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -16,7 +16,7 @@ later phase.
 ## 🎯 Phase progress
 
 ```
-███████████████▋░░░░  79%   (tracker-aligned overall progress)
+████████████████░░░░  80%   (tracker-aligned overall progress)
 ```
 
 | Phase | Title | Status | Progress | Tracker items |
@@ -27,8 +27,13 @@ later phase.
 | 3 | 🔗 Remove legacy free.fr / SVN / FTP | ✅ Done | `████████████████████` 100% | `legacy-url-migration`, `youtube-apikey` |
 | 4 | 📦 Publish artifacts via `habitv-repo` | ✅ Done | `████████████████████` 100% | `static-repo-publish` |
 | 5 | 🎬 Replace `youtube-dl` with `yt-dlp` | 🟡 In progress | `███████████████░░░░░` 75% | `ytdlp-migration` |
-| 6 | 🔌 Audit / deprecate obsolete providers | 🟡 In progress | `███████████░░░░░░░░░` 55% | `provider-inventory` |
-| 7 | 🖼️ Modernize UI / runtime packaging | 🔵 Proposed | `█░░░░░░░░░░░░░░░░░░░` 5% | `javafx-modernization` |
+| 6 | 🔌 Audit / deprecate obsolete providers | 🟡 In progress | `█████████████░░░░░░░` 65% | `provider-inventory` |
+| 7 | 🖼️ Modernize UI / runtime packaging | 🔵 Proposed | `███░░░░░░░░░░░░░░░░░` 15% | `javafx-modernization` |
+
+**Current execution focus (2026-05-31):** Phase 5–6 — modern replay downloading
+(`ytdlp-migration`, `provider-inventory`, France.tv hub work). Java runtime
+migration (17 → **21** LTS target, **25** later) stays in
+[`java-runtime-policy.md`](java-runtime-policy.md); not mixed into tracker-only PRs.
 
 ---
 
@@ -135,7 +140,7 @@ Remaining: live fixture validation, `habitv-repo` `yt-dlp` tool zip publication.
 
 ## 🔌 Phase 6 — Audit / deprecate obsolete providers
 
-🟡 **In progress** · `███████████░░░░░░░░░` 55%
+🟡 **In progress** · `█████████████░░░░░░░` 65%
 
 - Inventory all provider plugins and verify endpoints are reachable
   and parsable (offline against captured fixtures, not live).
@@ -151,7 +156,7 @@ Remaining: live fixture validation, `habitv-repo` `yt-dlp` tool zip publication.
 
 ## 🖼️ Phase 7 — Modernize UI / runtime packaging
 
-🔵 **Proposed** · `█░░░░░░░░░░░░░░░░░░░` 5%
+🔵 **Proposed** · `███░░░░░░░░░░░░░░░░░` 15%
 
 - Migrate JavaFX 2.x (`jfxrt.jar` on Java 8; optional provided OpenJFX at
   compile on JDK 11+ per PR #100) to **shipped** OpenJFX runtime packaging

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR). Legacy HBTV codes are historical-only and not for new workflow naming.",
-  "lastRefresh": "2026-05-26",
+  "lastRefresh": "2026-05-31",
   "statusValues": [
     "proposed",
     "in-progress",
@@ -18,12 +18,12 @@
   ],
   "summary": {
     "done": 13,
-    "inProgress": 6,
-    "proposed": 2,
+    "inProgress": 7,
+    "proposed": 1,
     "deferred": 0,
     "blocked": 0,
     "total": 21,
-    "overallProgressPercent": 78
+    "overallProgressPercent": 80
   },
   "items": [
     {
@@ -99,21 +99,22 @@
       "legacyCode": "HBTV-003",
       "displayTitle": "GitHub branch protection rules",
       "icon": "🛡️",
-      "status": "proposed",
+      "status": "in-progress",
       "priority": "P1",
-      "progressPercent": 0,
+      "progressPercent": 80,
       "scope": "Apply the GitHub settings documented in github-repository-settings.md: branch model, protection, merge strategy, required checks.",
       "acceptanceCriteria": [
         "master protected; linear history required.",
-        "develop protected; required CI: build workflow on Ubuntu + Windows.",
+        "develop protected; required CI matches live protect-develop contexts (validate-java8, deterministic-tests-java8, compile-and-package-java8, dependency-review).",
         "Squash merge enabled, merge commits disabled.",
         "Force-push disabled on protected branches."
       ],
       "validation": [
-        "Manual confirmation in the GitHub UI by the repo owner."
+        "Manual confirmation in the GitHub UI by the repo owner.",
+        "docs/github-rulesets/protect-develop.json matches live ruleset."
       ],
-      "pr": "N/A (settings change, not code)",
-      "notes": "Owner-only task; no code change."
+      "pr": "ci(governance): realign protect-develop required checks with Maven CI (#118)",
+      "notes": "Live protect-develop ruleset documented in docs/repository-governance.md and docs/required-checks-roadmap.md; payload in docs/github-rulesets/protect-develop.json. PR #118 aligned required contexts with ci-maven.yml. Owner should confirm GitHub UI still matches JSON (code_scanning, code_quality, copilot_code_review). Legacy ci.yml validate (zulu-8) context removed from docs."
     },
     {
       "id": "legacy-url-migration",
@@ -161,7 +162,7 @@
         "python scripts/static-repo/validate_repository_layout.py <repository-root>"
       ],
       "pr": "habitv-repo #2 (merged); habitv PR #49 (publication status + tracker refresh)",
-      "notes": "Runtime updates are enabled by default at startup. Publication cutover is live on GitHub Pages with token-free HTTPS access. Developer SNAPSHOT updates use -Dhabitv.update.autoriseSnapshot=true while configuration.xml keeps autoriseSnapshot false. Runtime artifact resolution now prioritizes explicit manifest download paths and falls back to maven-metadata.xml for timestamped SNAPSHOT JAR names. Local static-repo deploy uses static-repo-deploy profile and habitv.deploy.repository.url; deployAtEnd=true prevents partial habitv-repo updates on reactor failure. Default mvn test skips live *PluginManagerTest; use -Plive-provider-tests. Arte live test currently fails (empty categories) — provider drift, not deploy regression. Remaining follow-up: run one dedicated opt-in runtime update smoke test with habitv.update.autoriseSnapshot=true against the published URL."
+      "notes": "Runtime updates are enabled by default at startup. Publication cutover is live on GitHub Pages with token-free HTTPS access. Developer SNAPSHOT updates use -Dhabitv.update.autoriseSnapshot=true while configuration.xml keeps autoriseSnapshot false. Runtime artifact resolution now prioritizes explicit manifest download paths and falls back to maven-metadata.xml for timestamped SNAPSHOT JAR names. PR #140 (fix/update) refreshes habitv-update-manifest.properties after static-repo deploy so startup resolution matches published SNAPSHOT builds. Local static-repo deploy uses static-repo-deploy profile and habitv.deploy.repository.url; deployAtEnd=true prevents partial habitv-repo updates on reactor failure. Default mvn test skips live *PluginManagerTest; use -Plive-provider-tests. Arte live test currently fails (empty categories) — provider drift, not deploy regression. Remaining follow-up: run one dedicated opt-in runtime update smoke test with habitv.update.autoriseSnapshot=true against the published URL."
     },
     {
       "id": "provider-inventory",
@@ -170,7 +171,7 @@
       "icon": "🔌",
       "status": "in-progress",
       "priority": "P2",
-      "progressPercent": 60,
+      "progressPercent": 65,
       "scope": "Inventory every plugin in plugins/ (22 in aggregator + plugin-tester); record current status (working, obsolete endpoint, renamed, broken parser). No code removal in this item.",
       "acceptanceCriteria": [
         "Inventory table per plugin with last-known status.",
@@ -185,8 +186,8 @@
         "mvn -B -ntp -pl plugins/arte -am -Dtest=ArteOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test",
         "mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test"
       ],
-      "pr": "test/provider-offline-fixture-baseline (merged), fix(provider-canalplus): rename d17 to cstar and handle deprecated endpoints (PR #91), refactor(provider-canalplus): remove obsolete d8 sub-provider (PR #92)",
-      "notes": "Inventory baseline from PR #50 extended with offline fixture policy and tests for 6play, canalPlus, francetv (ex pluzz), arte, and youtube. docs/provider-inventory.md includes current-status table and legacy naming (Pluzz, CStar (ex D17), 6play). PR #91 preserves D17 -> CStar and adds graceful fallback for canalPlus/cstar category discovery when legacy or protected endpoints fail (service.mycanal.fr DNS failure, HTTP 403 on channel pages). PR #92 removes the obsolete embedded D8 sub-provider (dead www.d8.tv endpoints; channel rebranded to C8). Default Surefire excludes *PluginManagerTest. Arte live PluginManagerTest still fails (categorie liste vide) due to provider drift. See docs/automatic-category-download.md for runtime watch behavior."
+      "pr": "test/provider-offline-fixture-baseline (merged), fix(provider-canalplus): rename d17 to cstar (PR #91), refactor(provider-canalplus): remove obsolete d8 sub-provider (PR #92), feat(francetv): discover public hubs via API (PR #137)",
+      "notes": "Inventory baseline from PR #50 extended with offline fixture policy and tests for 6play, canalPlus, francetv (ex pluzz), arte, and youtube. docs/provider-inventory.md includes current-status table and legacy naming (Pluzz, CStar (ex D17), 6play). PR #137 adds API-first public hub discovery (Sport, Franceinfo, partner hubs) and bumps francetv to 4.1.3-SNAPSHOT. PR #91 preserves D17 -> CStar and adds graceful fallback for canalPlus/cstar category discovery when legacy or protected endpoints fail. PR #92 removes the obsolete embedded D8 sub-provider. Default Surefire excludes *PluginManagerTest; PR #135 removed live URL dependency from one deterministic test. Arte live PluginManagerTest still fails (categorie liste vide) due to provider drift. See docs/automatic-category-download.md for runtime watch behavior."
     },
     {
       "id": "ytdlp-migration",
@@ -243,7 +244,7 @@
       "icon": "🖼️",
       "status": "proposed",
       "priority": "P2",
-      "progressPercent": 10,
+      "progressPercent": 15,
       "scope": "Migrate JavaFX 2.x usage and ${jdk.home} packaging assumptions in application/trayView, application/habiTv-linux, application/habiTv-windows, zenjava/javafx-maven-plugin 2.0, and system-scope javafx:jfxrt.",
       "acceptanceCriteria": [
         "Surface inventory captured in audit doc (done in audit-master-baseline).",
@@ -256,7 +257,7 @@
         "mvn -B -ntp -pl application/habiTv -am -Dtest=JavaFxRuntimeLocatorTest -Dsurefire.failIfNoSpecifiedTests=false test -> BUILD SUCCESS"
       ],
       "pr": "TBD",
-      "notes": "Risk javafx-jdk8. HabitvLauncher now resolves jfxrt.jar from common JDK 8 layouts and supports -Dhabitv.jfxrt.path; GUI mode exits with diagnostics when JavaFX is missing. OpenJFX migration and platform packaging remain out of scope."
+      "notes": "Risk javafx-jdk8. HabitvLauncher now resolves jfxrt.jar from common JDK 8 layouts and supports -Dhabitv.jfxrt.path; GUI mode exits with diagnostics when JavaFX is missing. Windows packaging foundation landed (PR #124 staging, PR #126 launcher/installer, PR #128 native package verification); OpenJFX runtime migration and full cross-platform packaging remain out of scope for this item."
     },
     {
       "id": "plugin-tester-align",
@@ -343,7 +344,7 @@
         "mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test -> BUILD SUCCESS"
       ],
       "pr": "fix(youtube): externalize data api key and mask api errors (#29)",
-      "notes": "End users can set the key from the tray configuration tab. Runtime key lookup order: Java property habitv.youtube.apiKey, then environment variable HABITV_YOUTUBE_API_KEY. Risk youtube-key-hardcoded mitigated."
+      "notes": "End users can set the key from the tray configuration tab. Runtime key lookup order: Java property habitv.youtube.apiKey, then environment variable HABITV_YOUTUBE_API_KEY. PR #138 hardens Data API lookup error handling and diagnostics. Risk youtube-key-hardcoded mitigated."
     },
     {
       "id": "jaxb-launcher-recovery",
@@ -389,8 +390,8 @@
         "mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am test",
         "mvn -B -ntp -DskipTests package"
       ],
-      "pr": "ci: add Maven PR validation workflow (#65)",
-      "notes": "Java 8 remains the required baseline; Java 11+ stays diagnostic until JAXB and JavaFX modernization is complete."
+      "pr": "ci: add Maven PR validation workflow (#65); ci(workflows): harden checkout and dry maven jobs via composites (#120); ci: add manual Maven CodeQL analysis (#130)",
+      "notes": "Java 8 remains the required baseline; Java 11+ stays diagnostic until JAXB and JavaFX modernization is complete. CodeQL runs via .github/workflows/codeql.yml with manual Maven reactor build; see docs/ci.md for accepted Lombok tracer warnings."
     },
     {
       "id": "dependency-security-audit",
@@ -399,7 +400,7 @@
       "icon": "🔒",
       "status": "in-progress",
       "priority": "P1",
-      "progressPercent": 15,
+      "progressPercent": 20,
       "scope": "Establish a documentation-first Dependabot triage baseline for the Java 8 Maven reactor without mass dependency upgrades. Follow-up PRs upgrade build plugins, logging, HTTPS resolution, and runtime libraries in a safe order.",
       "acceptanceCriteria": [
         "docs/security-dependency-audit.md records GitHub vulnerability counts, scope, risks, remediation order, and first fix candidates.",
@@ -412,7 +413,7 @@
         "scripts/security/maven-dependency-inventory.ps1 (optional -DependencyTree)"
       ],
       "pr": "security: add dependency vulnerability audit baseline (this PR)",
-      "notes": "Baseline PR security/dependabot-audit-baseline. GitHub reports 294 vulnerabilities (87 critical, 90 high, 89 moderate, 28 low). Dependabot API export to target/dependabot-alerts.json is local-only (gitignored)."
+      "notes": "Baseline PR security/dependabot-audit-baseline. GitHub reports 294 vulnerabilities (87 critical, 90 high, 89 moderate, 28 low). Dependabot API export to target/dependabot-alerts.json is local-only (gitignored). Build hygiene docs added: PR #132 resource encoding, PR #133 Lombok compiler warning audit, PR #134 Maven Shade duplicate audit, PR #136 JAXB/Activation dedup plan (docs only)."
     },
     {
       "id": "critical-log4j-cve-remediation",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -14,7 +14,7 @@
 > Legacy codes are historical-only and must not be used for new branch
 > names, PR titles, commit subjects, or workflow naming.
 
-**Last refresh:** 2026-05-26 · **Active branch:** `develop`
+**Last refresh:** 2026-05-31 · **Active branch:** `develop`
 
 **Documentation entry point:** [`README.md`](../README.md) (overview, build matrix,
 automatic category behavior, provider summary, doc map).
@@ -24,14 +24,14 @@ automatic category behavior, provider summary, doc map).
 ## 📊 Overall progress
 
 ```
-███████████████▊░░░░  78%
+████████████████░░░░  80%
 ```
 
 | Category | Count |
 |---------|------:|
 | ✅ Delivered | **13** |
-| 🟡 In progress | **6** |
-| 🔵 Proposed | **2** |
+| 🟡 In progress | **7** |
+| 🔵 Proposed | **1** |
 | ⬜ Deferred | **0** |
 | ⛔ Blocked | **0** |
 | **Total work items** | **21** |
@@ -45,20 +45,20 @@ automatic category behavior, provider summary, doc map).
 | 🏗️ `gov-bootstrap` — Governance bootstrap from master | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | ⚙️ `maven-reactor` — Maven reactor stabilization | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | ☕ `java8-baseline` — Java 8 compile baseline | ✅ Done | 🔴 P0 | `████████████████████` 100% |
-| 🛡️ `branch-protection` — GitHub branch protection rules | 🔵 Proposed | 🟠 P1 | `░░░░░░░░░░░░░░░░░░░░` 0% |
+| 🛡️ `branch-protection` — GitHub branch protection rules | 🟡 In progress | 🟠 P1 | `████████████████░░░░` 80% |
 | 🔗 `legacy-url-migration` — Legacy URL migration (free.fr / SVN / FTP) | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 📦 `static-repo-publish` — Static artifact repository publication | ✅ Done | 🟠 P1 | `████████████████████` 100% |
-| 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🟡 In progress | 🟡 P2 | `████████████░░░░░░░░` 60% |
+| 🔌 `provider-inventory` — Provider plugin inventory & cleanup | 🟡 In progress | 🟡 P2 | `█████████████░░░░░░░` 65% |
 | 🎬 `ytdlp-migration` — `youtube-dl` → `yt-dlp` migration | 🟡 In progress | 🟡 P2 | `███████████████░░░░░` 75% |
 | 🩺 `ytdlp-runtime-diagnostics` — yt-dlp Windows runtime diagnostics | 🟡 In progress | 🟡 P2 | `██████████████████░░` 90% |
-| 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `██░░░░░░░░░░░░░░░░░░` 10% |
+| 🖼️ `javafx-modernization` — JavaFX & runtime packaging modernization | 🔵 Proposed | 🟡 P2 | `███░░░░░░░░░░░░░░░░░` 15% |
 | 🧪 `plugin-tester-align` — `plugin-tester` reactor alignment | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | ▶️ `console-runnable` — Runnable console baseline | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 🔗 `own-version-deps-align` — Own-version plugin dependency alignment | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 🔑 `youtube-apikey` — YouTube Data API key externalization | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧩 `jaxb-launcher-recovery` — JAXB generated sources & launcher classpath recovery | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧱 `maven-pr-validation` — Maven PR validation workflow | ✅ Done | 🟠 P1 | `████████████████████` 100% |
-| 🔒 `dependency-security-audit` — Dependency security audit & remediation | 🟡 In progress | 🟠 P1 | `███░░░░░░░░░░░░░░░░░` 15% |
+| 🔒 `dependency-security-audit` — Dependency security audit & remediation | 🟡 In progress | 🟠 P1 | `████░░░░░░░░░░░░░░░░` 20% |
 | 📝 `clean-squash-merge-policy` — Clean squash merge policy | 🟡 In progress | 🟢 P3 | `██████████░░░░░░░░░░` 50% |
 | 🔒 `critical-log4j-cve-remediation` — Critical Log4j 1.x CVE remediation | ✅ Done | 🔴 P0 | `████████████████████` 100% |
 | 📥 `batch-episode-download-ui` — Batch episode download UI & queue controls | ✅ Done | 🟡 P2 | `████████████████████` 100% |
@@ -192,25 +192,33 @@ mvn -B -ntp -DskipTests compile      # BUILD SUCCESS (after plugin-tester-align 
 
 | | |
 |---|---|
-| **Status** | 🔵 Proposed |
+| **Status** | 🟡 In progress |
 | **Priority** | 🟠 P1 |
-| **Progress** | `░░░░░░░░░░░░░░░░░░░░` 0% |
+| **Progress** | `████████████████░░░░` 80% |
 | **Legacy code** | HBTV-003 |
 
 **Scope** — Apply the GitHub settings documented in
-[`github-repository-settings.md`](github-repository-settings.md):
-branch model, protection, merge strategy, required checks.
+[`github-repository-settings.md`](github-repository-settings.md) and
+[`repository-governance.md`](repository-governance.md): branch model,
+protection, merge strategy, required checks.
 
 **Acceptance criteria**
-- ⬜ `master` protected; linear history required
-- ⬜ `develop` protected; required CI: `build` workflow on Ubuntu + Windows
-- ⬜ Squash merge enabled, merge commits disabled
-- ⬜ Force-push disabled on protected branches
+- 🟡 `master` protected; linear history required *(confirm in GitHub UI)*
+- ✅ `develop` protected; required CI matches live `protect-develop` contexts
+  (`validate-java8`, `deterministic-tests-java8`,
+  `compile-and-package-java8`, `dependency-review`)
+- 🟡 Squash merge enabled, merge commits disabled *(confirm in GitHub UI)*
+- 🟡 Force-push disabled on protected branches *(confirm in GitHub UI)*
 
-**Validation** — Manual confirmation in the GitHub UI by the repo owner.
+**Validation** — Manual confirmation in the GitHub UI by the repo owner;
+compare with [`github-rulesets/protect-develop.json`](github-rulesets/protect-develop.json).
 
-**Notes** — Owner-only task; no code change. Currently blocking
-nothing technical but everyone has push access to `develop`.
+**Related PR** · `ci(governance): realign protect-develop required checks with Maven CI` ([#118](https://github.com/Mika3578/habitv/pull/118))
+
+**Notes** — Live ruleset payload and required-check names are documented in-repo.
+PR #118 removed stale `validate (zulu-8)` / legacy `ci.yml` context from
+governance docs. Remaining owner step: verify GitHub Settings still match JSON
+(`code_scanning`, `code_quality`, `copilot_code_review`).
 
 ---
 
@@ -299,6 +307,9 @@ run one dedicated opt-in runtime update smoke test with
 `-Dhabitv.update.autoriseSnapshot=true` against the published Pages URL.
 Runtime artifact resolution now prefers explicit manifest download paths and
 falls back to `maven-metadata.xml` for timestamped SNAPSHOT JAR filenames.
+PR [#140](https://github.com/Mika3578/habitv/pull/140) refreshes
+`habitv-update-manifest.properties` after static-repo deploy so startup
+resolution matches the latest published SNAPSHOT builds.
 
 ---
 
@@ -308,7 +319,7 @@ falls back to `maven-metadata.xml` for timestamped SNAPSHOT JAR filenames.
 |---|---|
 | **Status** | 🟡 In progress |
 | **Priority** | 🟡 P2 |
-| **Progress** | `████████████░░░░░░░░` 60% |
+| **Progress** | `█████████████░░░░░░░` 65% |
 | **Legacy code** | HBTV-006 |
 
 **Scope** — Inventory every plugin in `plugins/` (22 in the aggregator
@@ -331,14 +342,16 @@ mvn -B -ntp -pl plugins/arte -am -Dtest=ArteOfflineFixtureBaselineTest -Dsurefir
 mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeOfflineFixtureBaselineTest -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
-**Related PR** · `docs: capture provider offline fixture baseline` (merged), `fix(provider-canalplus): rename d17 to cstar and handle deprecated endpoints` (PR #91), `refactor(provider-canalplus): remove obsolete d8 sub-provider` (PR #92)
+**Related PRs** · offline fixture baseline (merged) · [#91](https://github.com/Mika3578/habitv/pull/91) · [#92](https://github.com/Mika3578/habitv/pull/92) · [#137](https://github.com/Mika3578/habitv/pull/137) (France.tv public hubs) · [#135](https://github.com/Mika3578/habitv/pull/135) (deterministic test quarantine)
 
 **Notes** — Inventory baseline is now documented in
 [`provider-inventory.md`](provider-inventory.md) for every plugin module
 plus historical references (`CStar` (ex `D17`), `nrj12`, FranceTV/Pluzz,
 Kewego). An offline fixture policy and first local fixture baseline are
 now documented for `6play`, `canalPlus`, `francetv` (ex `pluzz`), `arte`, and `youtube`
-without rewriting providers. Default `mvn test` skips live
+without rewriting providers. PR #137 adds API-first public hub discovery
+(Sport, Franceinfo, partner hubs); `francetv` plugin version `4.1.3-SNAPSHOT`.
+Default `mvn test` skips live
 `*PluginManagerTest`; use `-Plive-provider-tests`. PR #91 keeps the
 `D17` rename to `CStar` and adds graceful fallback in the Canal+ family:
 category discovery now returns an empty set with a provider-level
@@ -424,7 +437,7 @@ architecture rewrite.
 |---|---|
 | **Status** | 🔵 Proposed |
 | **Priority** | 🟡 P2 |
-| **Progress** | `██░░░░░░░░░░░░░░░░░░` 10% |
+| **Progress** | `███░░░░░░░░░░░░░░░░░` 15% |
 | **Legacy code** | HBTV-008 |
 
 **Scope** — Migrate JavaFX 2.x usage and `${jdk.home}` packaging
@@ -446,10 +459,11 @@ targeted unit tests.
 
 **Notes** — Risk `javafx-jdk8`. `HabitvLauncher` resolves `jfxrt.jar`
 from common JDK 8 layouts and supports `-Dhabitv.jfxrt.path`; GUI mode
-exits with diagnostics when JavaFX is missing. OpenJFX migration and
-platform packaging remain out of scope. Largest single piece of remaining
-work once `legacy-url-migration` + `static-repo-publish` +
-`provider-inventory` are clear.
+exits with diagnostics when JavaFX is missing. Windows packaging foundation:
+PR [#124](https://github.com/Mika3578/habitv/pull/124) staging,
+[#126](https://github.com/Mika3578/habitv/pull/126) launcher/installer,
+[#128](https://github.com/Mika3578/habitv/pull/128) native package verification.
+OpenJFX runtime migration and full cross-platform packaging remain out of scope.
 
 ---
 
@@ -583,7 +597,7 @@ mvn -B -ntp -DskipTests -pl application/trayView,plugins/youtube -am compile   #
 mvn -B -ntp -pl plugins/youtube -am -Dtest=YoutubeConfTest -Dsurefire.failIfNoSpecifiedTests=false test  # BUILD SUCCESS
 ```
 
-**Related PR** · `fix(youtube): externalize data api key and mask api errors` (#29)
+**Related PRs** · [#29](https://github.com/Mika3578/habitv/pull/29) (externalize key) · [#138](https://github.com/Mika3578/habitv/pull/138) (harden Data API lookup diagnostics)
 
 **Notes** — Risk `youtube-key-hardcoded` mitigated. End users can set
 the key from the tray configuration tab. Runtime key lookup order:
@@ -675,10 +689,12 @@ mvn -B -ntp -pl fwk/api,fwk/framework,application/core,plugins/plugin-tester -am
 mvn -B -ntp -DskipTests package
 ```
 
-**Related PR** · `ci: add Maven PR validation workflow` (#65)
+**Related PRs** · [#65](https://github.com/Mika3578/habitv/pull/65) · [#120](https://github.com/Mika3578/habitv/pull/120) (composite actions) · [#130](https://github.com/Mika3578/habitv/pull/130) (manual CodeQL Maven analysis)
 
 **Notes** — Java 8 remains the required baseline; Java 11+ stays
-diagnostic until JAXB and JavaFX modernization work is complete.
+diagnostic until JAXB and JavaFX modernization work is complete. CodeQL:
+`.github/workflows/codeql.yml`; see [`ci.md`](ci.md) for accepted Lombok
+tracer warnings during analysis.
 
 ---
 
@@ -688,7 +704,7 @@ diagnostic until JAXB and JavaFX modernization work is complete.
 |---|---|
 | **Status** | 🟡 In progress |
 | **Priority** | 🟠 P1 |
-| **Progress** | `███░░░░░░░░░░░░░░░░░` 15% |
+| **Progress** | `████░░░░░░░░░░░░░░░░` 20% |
 | **Legacy code** | HBTV-016 |
 
 **Scope** — Establish a documentation-first Dependabot triage baseline
@@ -714,7 +730,7 @@ pwsh -File scripts/security/maven-dependency-inventory.ps1 -DependencyTree
 **Notes** — Baseline branch `security/dependabot-audit-baseline`. GitHub
 reports **294** vulnerabilities (87 critical, 90 high, 89 moderate,
 28 low). Dependabot API export to `target/dependabot-alerts.json` is
-local-only (gitignored).
+local-only (gitignored). Build hygiene documentation: PR [#132](https://github.com/Mika3578/habitv/pull/132) resource encoding, [#133](https://github.com/Mika3578/habitv/pull/133) Lombok warning audit, [#134](https://github.com/Mika3578/habitv/pull/134) Shade duplicates audit, [#136](https://github.com/Mika3578/habitv/pull/136) JAXB/Activation dedup plan.
 
 ---
 
@@ -722,9 +738,9 @@ local-only (gitignored).
 
 Recommended merge / start order (see `dev-plan.md` for phase reasoning):
 
-1. 🔵 **Apply branch protection** → close `branch-protection`
-2. 🟡 **Complete `provider-inventory` follow-up fixture/rewrite PRs**
-3. 🔵 Then in any order: `ytdlp-migration`, `javafx-modernization`
+1. 🟡 **Confirm branch protection in GitHub UI** → close `branch-protection`
+2. 🟡 **Complete `provider-inventory` follow-up fixture/rewrite PRs** (replay providers)
+3. 🟡 **`ytdlp-migration`** (habitv-repo `yt-dlp` tool publication) then **`javafx-modernization`**
 
 ---
 

--- a/docs/external-tools-recommendations.md
+++ b/docs/external-tools-recommendations.md
@@ -1,6 +1,8 @@
 # 🧰 External tools — recommendations and obsolescence analysis
 
 **Tracker item**: `external-tools-recommendations`
+**Last refresh:** 2026-05-31 (tracker sync; content unchanged since initial analysis PR #104)
+
 **Scope in this PR**: documentation, classification, and recommended
 follow-up PR queue. **No** plugin module is added or removed, **no**
 `configuration.xml` change, **no** `tool-sources.properties` change,

--- a/docs/java-runtime-policy.md
+++ b/docs/java-runtime-policy.md
@@ -17,6 +17,7 @@ supersedes informal README wording where they conflict.
 | **Compiler `source` / `target`** | **1.8** across the in-reactor modules |
 | **End-user GUI runtime** | JDK/JRE 8 with a **JavaFX-capable** distribution (see below) |
 | **JDK 11+ on developer/CI machines** | Allowed for **build** (`validate`, `compile`, and scoped `package`) via the `javafx-openjfx-compile` Maven profile; **not** a supported end-user runtime yet |
+| **Planned runtime LTS target** | **Java 21** (after Java 17 milestone); **Java 25** evaluated later — not supported yet |
 | **Runtime migration to Java 11/17/21** | **Not complete** — documentation and CI diagnostics only where noted |
 
 ---
@@ -159,8 +160,8 @@ High-level steps (documentation-only sequencing; tracker items own delivery):
 | **1** | Keep **Java 8** baseline stable (`validate` / `compile` / required CI on 8) | In progress — baseline done; maintenance ongoing |
 | **2** | Make **build** compatible with **JDK 11+** hosts (compile/package bridge) | **Partial** — PR #100 (`javafx-openjfx-compile` profile) |
 | **3** | Prepare **Java 17** runtime compatibility (JAXB, OpenJFX packaging, launcher) | Not started for runtime |
-| **4** | Prepare **Java 21** runtime target (LTS stable deployment) | Future |
-| **5** | Evaluate **Java 25** later (experimental CI only until blockers clear) | Diagnostic only |
+| **4** | Prepare **Java 21** runtime target (LTS stable deployment — primary long-term target) | Future |
+| **5** | Evaluate **Java 25** after 21 is proven (experimental CI until blockers clear) | Diagnostic only |
 
 Step 2 does **not** imply Step 3 is complete. Steps 3–4 require ADR
 superseding `keep-java8-baseline`, green required CI on the target JDK, and

--- a/docs/maintenance-dashboard.md
+++ b/docs/maintenance-dashboard.md
@@ -10,63 +10,96 @@ directly relevant (Section 19.24).
 
 ## Current phase
 
-*(e.g. stabilization, provider restoration, CI hardening — see AGENTS.md §18.1)*
+**Provider restoration / modern replay** (dev-plan Phases 5–6): `ytdlp-migration`,
+`provider-inventory`, France.tv hub discovery merged ([#137](https://github.com/Mika3578/habitv/pull/137)).
+**Stabilization** (Phases 0–4) largely complete on `develop`.
+
+**Java:** supported **runtime** remains **Java 8**; planned LTS **runtime target**
+is **Java 21**, then **25** — see [`java-runtime-policy.md`](java-runtime-policy.md).
+
+---
 
 ## Open PR priorities
 
 | Priority | Scope | Branch/PR | Status |
 |----------|-------|-----------|--------|
-| — | — | — | — |
+| P1 | Confirm `protect-develop` ruleset in GitHub UI | `branch-protection` | In progress (docs + #118 merged) |
+| P2 | `habitv-repo` publish `yt-dlp` tool zip | `ytdlp-migration` | Follow-up |
+| P2 | Provider fixture/rewrite PRs (6play, arte, lequipe, …) | per module | Queued |
+
+---
 
 ## Security alerts
 
 | Alert | Scope | Action | PR |
 |-------|-------|--------|-----|
-| — | — | — | — |
+| Dependabot baseline | 294 reported (audit doc) | Triage per `dependency-security-audit` | Ongoing |
+| Log4j 1.x CVEs | Runtime | Mitigated via reload4j | Done |
+
+---
 
 ## Dependency updates
 
 | Dependency | Type | Status | PR |
 |------------|------|--------|-----|
-| — | — | — | — |
+| reload4j | security | Done | critical-log4j item |
+| Maven plugins / transitives | audit | Documented; selective bumps | #132–#134, #136 (docs) |
+
+---
 
 ## Providers
 
 | Provider | Status | Notes |
 |----------|--------|-------|
-| *(see provider-inventory.md)* | | |
+| `francetv` | working | Public hubs API (#137); yt-dlp download |
+| `youtube` | working | yt-dlp wiring; API key externalized; #138 diagnostics |
+| `canalPlus` / CStar | degraded | Graceful empty categories when protected/unreachable |
+| `arte`, `6play`, `lequipe` | needs rewrite | Live drift; offline fixtures started |
+| `wat`, `beinsport`, `clubic` | obsolete | Deprecation PRs TBD |
 
 ### Broken / degraded summary
 
-- **Broken:** —
-- **Degraded:** —
+- **Broken:** none classified as hard-fail in inventory (live tests quarantined)
+- **Degraded:** `canalPlus` family (protected/legacy endpoints)
 - **Obsolete:** see [`obsolescence-register.md`](obsolescence-register.md)
+
+---
 
 ## CI issues
 
 | Check | Status | Notes |
 |-------|--------|-------|
-| Maven CI (Java 8) | — | |
-| Dependency review | — | |
+| Maven CI (Java 8) | Required on `develop` | `ci-maven.yml`; four blocking contexts |
+| Dependency review | Required | High severity fails PR |
+| CodeQL | Enabled | Manual Maven build; non-blocking Lombok tracer warnings ([`ci.md`](ci.md)) |
+
+---
 
 ## Packaging status
 
-*(Java 8 + JavaFX assumptions; blockers — see release-policy.md)*
+Windows launcher/installer foundation merged (#124, #126, #128). Full GUI
+package still needs JavaFX-capable JDK 8 or future OpenJFX runtime packaging
+(`javafx-modernization`).
+
+---
 
 ## Java migration status
 
 **Current support:** Java 8 only ([`java-runtime-policy.md`](java-runtime-policy.md))
 
-**Preparation:** —
-
-## Next 5 recommended PRs
-
-1. —
-2. —
-3. —
-4. —
-5. —
+**Preparation:** JDK 11+ compile bridge (PR #100); CI diagnostics on 11/17/21/25;
+**planned runtime target:** Java 21 LTS, then Java 25 evaluation.
 
 ---
 
-Last reviewed: *(YYYY-MM-DD)*
+## Next 5 recommended PRs
+
+1. Owner-verify `protect-develop` → close `branch-protection`
+2. Publish `yt-dlp` to `habitv-repo` (`ytdlp-migration`)
+3. Offline fixture PR for next priority provider (e.g. `arte` or `6play`)
+4. Opt-in runtime update smoke test against live Pages manifest
+5. Dedicated provider rewrite or deprecation PR per inventory row
+
+---
+
+Last reviewed: **2026-05-31**

--- a/docs/obsolescence-register.md
+++ b/docs/obsolescence-register.md
@@ -9,11 +9,21 @@ current provider status table.
 Do not delete legacy providers silently. Mark, replace, deprecate, or remove
 in focused PRs.
 
-## Register template
+**Last refresh:** 2026-05-31
+
+## Register
 
 | Provider / feature | Old endpoint or behavior | Replacement | Status | Removal plan | Risk | Related PR |
 |--------------------|--------------------------|-------------|--------|--------------|------|------------|
-| *(example)* | *(dead URL)* | *(new service)* | obsolete | *(tracker/PR)* | low | — |
+| `plugins/pluzz` | Pluzz module id and branding | `plugins/francetv` | removed | Users rename grab-config plugin to `francetv` | low | #58 |
+| Canal+ `D8` sub-provider | `www.d8.tv`, `service.canal-plus.com` D8 paths | C8 branding (no Habitv sub-provider) | removed | Removed from `canalPlus` module | low | #92 |
+| Canal+ `D17` | Legacy D17 channel naming | CStar sub-provider in `canalPlus` | obsolete | Graceful degrade; rewrite TBD | medium | #91 |
+| `plugins/wat` | TF1/WAT-era URLs | Modern TF1+ replay (not implemented) | obsolete | Dedicated rewrite or deprecate PR | medium | — |
+| `plugins/beinsport` | Legacy beinsports.com video pages | Protected / platform-specific replay | obsolete | Deprecate or auth-aware rewrite | high | — |
+| `plugins/clubic` | Legacy Clubic HTML video pages | N/A (site model changed) | obsolete | Deprecate provider PR | low | — |
+| `youtube-dl` binary name | `youtube-dl` executable defaults | `yt-dlp` (`ytdlp-migration`) | obsolete | User config migration documented | medium | #52 |
+| `dabiboo.free.fr` Maven/update host | HTTP free.fr repository and updater | `habitv-repo` GitHub Pages HTTPS | removed | `legacy-url-migration`, `static-repo-publish` | high | #36, habitv-repo #2 |
+| NRJ12 module | Historical README provider name | None in reactor | removed | Document only | low | — |
 
 ### Status values
 
@@ -32,9 +42,3 @@ working, degraded, protected, obsolete, removed, unknown.
 - provider restored or degraded status changes;
 - replacement service validated;
 - removal completed — move to **removed** with PR reference.
-
-## Initial notes
-
-Populate from [`provider-inventory.md`](provider-inventory.md) and tracker
-items as providers are validated. This register is the **removal/obsolete
-planning** view; inventory is the **current status** view.

--- a/docs/provider-inventory.md
+++ b/docs/provider-inventory.md
@@ -2,8 +2,8 @@
 
 **Tracker item**: `provider-inventory`  
 **Legacy code**: `HBTV-006` (historical reference only)  
-**Status:** in progress (~55%) — inventory and offline fixtures; rewrites are
-separate PRs per module.
+**Status:** in progress (~65%) — inventory and offline fixtures; rewrites are
+separate PRs per module. **Last refresh:** 2026-05-31.
 
 ---
 
@@ -12,7 +12,7 @@ separate PRs per module.
 | Area | Status | Next steps |
 |------|--------|------------|
 | Reactor / build | All listed modules compile in the Maven reactor | Keep `mvn validate` green |
-| `francetv` (ex Pluzz) | **Keep** — France.tv mobile API + yt-dlp download | Migrate user grab-config `pluzz` → `francetv` |
+| `francetv` (ex Pluzz) | **Keep** — France.tv mobile API + public hub discovery (PR #137) + yt-dlp download | Migrate user grab-config `pluzz` → `francetv`; refresh hubs after upgrade |
 | `youtube` | **Keep** — yt-dlp binary contract (see `ytdlp-migration`) | Publish `yt-dlp` tool zip to `habitv-repo` |
 | `arte`, `6play`, `lequipe`, … | **Needs rewrite** or live drift | Fixture-first parser PRs |
 | `canalPlus` (+ embedded CStar) | **Obsolete** Canal-era endpoints | Dedicated canal-family rewrite |
@@ -77,7 +77,7 @@ no provider rewrite, no runtime behavior change in inventory-only work.
 | `plugins/lequipe` | `lequipe` | provider | needs live endpoint rewrite | Provider/downloader plugin uses HTML scraping; tests include historical Kewego stream-init references | rewrite provider |
 | `plugins/mlssoccer` | `mlssoccer` | provider | unknown / needs fixture | `MLSSoccerPluginManager` provider/downloader with HTTPS URLs; live endpoint compatibility not validated offline | add fixture tests |
 | `plugins/plugin-tester` | `plugin-tester` | test harness | infrastructure-only | `BasePluginProviderTester` / `BasePluginUpdateTester` provide shared live-style harness utilities | keep as-is |
-| `plugins/francetv` | `francetv` | provider | keep | `FranceTvPluginManager` queries `api-mobile.yatta.francetv.fr` catalogue; download delegated to `youtube` (yt-dlp); offline `FranceTvUrlsTest` + live `FranceTvPluginManagerTest`; replaces former `plugins/pluzz` (legacy `pluzz.` URLs still recognised by `canDownload`, but existing grab-config entries still need the plugin id renamed to `francetv`) | keep |
+| `plugins/francetv` | `francetv` | provider | keep | `FranceTvPluginManager` queries `api-mobile.yatta.francetv.fr` catalogue and public hubs via `/apps/channels/{hubSlug}?platform=apps` (PR #137, plugin `4.1.3-SNAPSHOT`); download delegated to `youtube` (yt-dlp); offline `FranceTvUrlsTest` + fixture baseline; live `FranceTvPluginManagerTest` opt-in only; replaces former `plugins/pluzz` (legacy `pluzz.` URLs still recognised by `canDownload`; grab-config plugin id must be `francetv`) | keep |
 | `plugins/rtmpDump` | `rtmpDump` | downloader | keep | `RtmpDumpPluginDownloader` is binary wrapper with updater version pattern; dedicated test exists | keep as-is |
 | `plugins/sfr` | `sfr` | provider | unknown / needs fixture | `SFRConf` uses `sport.sfr.fr` API path; provider tests are live-network style only | add fixture tests |
 | `plugins/wat` | `wat` | provider | obsolete endpoint | `WatConf` points to TF1/WAT-era URLs; plugin naming and endpoint model reflect legacy provider branding | rewrite provider |

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -218,18 +218,17 @@ modular JDK / Java 21+ when migrating off Java 8.
 at runtime. A dev build can pull whatever is on that host (or
 fail noisily if it is down).
 
-**Mitigation** — Updates are disabled by default; explicit opt-in
-required before any runtime fetch (`habitv.update.enabled=true`,
-optional `habitv.update.url`).
+**Mitigation** — Runtime updates use HTTPS `habitv-repo` by default;
+set `habitv.update.enabled=false` to disable startup checks. Optional
+`habitv.update.url` override. SNAPSHOT consumption for developers uses
+`-Dhabitv.update.autoriseSnapshot=true`.
 
 **Status update (`legacy-url-migration` / `static-repo-publish`)** —
-`UpdateManager` returns immediately unless
-`habitv.update.enabled=true`. The default target base URL constant is
-`https://mika3578.github.io/habitv-repo/repository` (legacy DabiBoo
-removed). Publication cutover and live Pages layout validation are now
-complete (habitv-repo PR #2 merged), and updates remain disabled by
-default. Remaining follow-up: one dedicated opt-in runtime update
-smoke test against the live Pages URL.
+Default `UPDATE_URL` is `https://mika3578.github.io/habitv-repo/repository`.
+Publication cutover is live (habitv-repo PR #2). Manifest-first resolution
+with `maven-metadata.xml` fallback. PR [#140](https://github.com/Mika3578/habitv/pull/140)
+refreshes `habitv-update-manifest.properties` after deploy. Remaining follow-up:
+one dedicated opt-in runtime update smoke test against the live Pages URL.
 
 ---
 
@@ -250,7 +249,12 @@ remote availability and HTML/JSON changes.
 
 **Mitigation** — Keep tests excluded from the default lifecycle
 in `java8-baseline`; quarantine network tests behind an opt-in
-profile.
+profile (`-Plive-provider-tests`).
+
+**Status update** — PR [#135](https://github.com/Mika3578/habitv/pull/135)
+removed live URL dependency from a deterministic test. Offline fixture
+baselines exist for priority providers; default Surefire still excludes
+`*PluginManagerTest`.
 
 ---
 


### PR DESCRIPTION
## Related issue

(none)

## Scope

tracker-state-sync

## Summary

- Align dev-tracker, dev-plan, risk register, provider inventory, maintenance dashboard, and obsolescence register with merged work on develop through PR #140.
- Refresh AGENTS.md "at a glance", CHANGELOG Unreleased, java-runtime-policy targets, and Copilot instructions pointer.

## Changes

- Tracker: last refresh 2026-05-31, overall 80%; branch-protection in-progress; provider-inventory 65%; javafx-modernization 15%.
- Document recent merged work including #118, #124, #126, #128, and #130–#140 where relevant.
- Populate maintenance dashboard and obsolescence register from inventory evidence.

## Validation

- `git diff --check` → clean
- Tracker JSON↔MD Python sync → OK (21 items, summary matches)
- Maven skipped (documentation-only)

## Risk / rollback

Low — docs only. Revert the single commit if any progress percentage or status wording needs correction.

## Notes

No Java, provider, Maven, or workflow behavior changes.
