### PR TITLE
docs(ai-rules): streamline governance and relax protected-replay opt-in

### DIFF
--- a/.cursor/rules/90-rule-evolution.mdc
+++ b/.cursor/rules/90-rule-evolution.mdc
@@ -24,7 +24,8 @@ files.
 - Change rules through dedicated reviewable PRs — not silently during
   unrelated work (Section 17.1).
 - Update `AGENTS.md` metadata version and `docs/agent-rules-changelog.md`.
-- Run **Rule drift audit** (Section 17.6) before finishing.
+- Run **Rule drift audit v2** (Section 17.6, 20.16) before finishing —
+  template in [`docs/agent-rule-profiles.md`](../../docs/agent-rule-profiles.md#rule-drift-audit-v2).
 - End with **Agent rules update report** (Section 17.14).
 - Score new mandatory rules (Section 17.11); use backlog for candidates.
 - Apply rule budget and stop condition (Section 20.6, 20.10).
@@ -34,6 +35,7 @@ files.
 twice (Section 17.4).
 
 **Canonical reference:** [`AGENTS.md`](../../AGENTS.md) Section 17;
-[`docs/agent-rules-backlog.md`](../../docs/agent-rules-backlog.md).
+[`docs/agent-rule-profiles.md`](../../docs/agent-rule-profiles.md) (ownership,
+drift audit v2); [`docs/agent-rules-backlog.md`](../../docs/agent-rules-backlog.md).
 
 **Lifecycle:** mandatory for AI-rule PRs.

--- a/.cursor/rules/agent-productivity.mdc
+++ b/.cursor/rules/agent-productivity.mdc
@@ -25,3 +25,4 @@ slow every task.
 **Canonical reference:** [`docs/agent-rule-profiles.md`](../../docs/agent-rule-profiles.md)
 
 **Lifecycle:** always on; complements Sections 16–19 without replacing them.
+Rule ownership table and drift audit v2: same doc.

--- a/.cursor/rules/habitv-providers.mdc
+++ b/.cursor/rules/habitv-providers.mdc
@@ -21,7 +21,10 @@ and clear status tracking.
 - Preserve/improve **metadata** where validated (18.3).
 - Prefer **offline fixture tests**; live checks supplementary (18.4).
 - **External tool** updates in dedicated PRs with report (18.5).
-- No DRM bypass; no cookies/tokens/sessions in repo (18.4).
+- Protected content: Section 18.4 → [`docs/provider-policy.md`](../../docs/provider-policy.md)
+  (site authentication, protected replay — no secrets in repo).
+- Provider **public communication safety** (20.14): high-level PR/commit text;
+  see [`docs/provider-policy.md`](../../docs/provider-policy.md#public-communication-safety).
 - End tasks with **Habitv final report** (18.19).
 
 **Canonical reference:** [`docs/provider-policy.md`](../../docs/provider-policy.md),

--- a/.cursor/rules/pr-review.mdc
+++ b/.cursor/rules/pr-review.mdc
@@ -31,7 +31,7 @@ PR title, PR body, and validation result. Ask for explicit approval.
 
 ## Copilot review comments
 
-Before a PR is ready:
+Before a PR is ready (`AGENTS.md` Sections 14.4, 20.15):
 
 1. Inspect all Copilot review comments and unresolved conversations.
 2. Classify each as: accepted and fixed; intentionally rejected with
@@ -40,13 +40,21 @@ Before a PR is ready:
 3. Implement accepted recommendations.
 4. Reply to each comment in English with what was done or why not applied.
 5. Resolve only after review, handling, reply, and commit/push (if
-   applicable).
+   applicable) — not to silence review; not twice without a new commit
+   or explicit developer decision.
 6. Never resolve just to silence the review.
 
 If resolution needs a GitHub command or UI action, ask for developer
-approval first.
+approval first. Details:
+[`docs/dev-workflow.md`](../../docs/dev-workflow.md#copilot-review-loop).
 
 Never resolve conversations silently (root `AGENTS.md` Section 15.7).
+
+## Concise communication
+
+Keep PR titles, bodies, and review replies scoped and reviewer-friendly
+(Section 20.13). Details:
+[`docs/dev-workflow.md`](../../docs/dev-workflow.md#concise-communication).
 
 ## Review readiness
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,162 +1,86 @@
 # GitHub Copilot instructions for Habitv
 
-Habitv is a legacy Java 8 Maven multi-module application for downloading
-French TV catch-up content via pluggable provider plugins. Modernization
-is staged through tracker items in `docs/dev-tracker.md` (last refresh
-2026-05-31 on `develop`). Supported **runtime** remains Java 8; planned
-LTS **runtime target** is Java 21, then Java 25 — see
-`docs/java-runtime-policy.md`.
+Habitv is a Java 8 Maven multi-module app for French TV catch-up via
+pluggable provider plugins. Treat the codebase as production legacy: prefer
+narrow, conservative suggestions over rewrites.
 
-Treat the codebase as production legacy: prefer conservative,
-narrowly-scoped suggestions over rewrites.
+## Source of truth
 
-## Workflow policy source of truth
+`AGENTS.md` is the **canonical** source for mandatory AI agent rules.
+These files are **mirrors only** — they must not introduce unique mandatory
+rules (`AGENTS.md` Section 20.16):
 
-`AGENTS.md` is the canonical source for all AI agent behavior. These
-companion files mirror or point to the same mandatory rules:
-
-- `.cursor/rules/git-safety.mdc` — Git workflow and approval gates
-- `.cursor/rules/maven-validation.mdc` — pre-commit Maven validation
-- `.cursor/rules/pr-review.mdc` — PR policy and Copilot review handling
-- `.cursor/rules/java8-compatibility.mdc` — Java 8 and dependency rules
-- `.github/instructions/maven-java.instructions.md` — Java/POM path rules
-- `.github/instructions/plugins.instructions.md` — plugin path rules
-- `.github/instructions/github-actions.instructions.md` — GitHub Actions
-- `.github/instructions/github-pr.instructions.md` — PR/GitHub path rules
-- `.github/instructions/packaging.instructions.md` — packaging path rules
-- nested `AGENTS.md` files — path-specific extensions (Section 15.2)
-- `docs/dev-workflow.md`, `docs/dependency-policy.md`, `docs/security-policy.md`
-- `docs/provider-policy.md`, `docs/release-policy.md`, `docs/modernization-backlog.md`
-- `.cursor/rules/habitv-providers.mdc`, `90-rule-evolution.mdc`
+- `.cursor/rules/*.mdc` — topic summaries
+- `.github/instructions/*.instructions.md` — path-specific extensions
+- nested `AGENTS.md` — scoped extensions
+- `CLAUDE.md`, `GEMINI.md` — pointers
+- `docs/dev-workflow.md`, `docs/agent-rule-profiles.md` — detail and ownership
 
 When any file conflicts with `AGENTS.md`, `AGENTS.md` wins.
 
-At task start, report **Instruction files loaded** (Section 15.1).
+At task start: **Instruction files loaded** (Section 15.1). Pick a rule
+profile (Section 20.2).
 
-When changing AI rules, run drift audit (Section 17.6), update changelog,
-and bump `AGENTS.md` metadata version (Section 17).
+## Workflow gates (summary)
 
-Never chain approval-gated commands (Section 15.8). Stage only intentional
-files by path (Section 15.20). Inspect diffs for secrets (Section 15.9).
-No AI attribution (Section 15.10). Provide exact validation evidence
-(Section 15.15). Verify status checks before PR merge readiness (15.18).
-Ask approval before PR comment actions (Section 15.25).
+- Never commit, push, create/merge PRs, or resolve review threads without
+  explicit developer approval in the **current** conversation (Section 14).
+- Never chain approval-gated commands (Section 15.8).
+- Stage only intentional paths (Section 15.20); no secrets (Section 15.9);
+  no AI attribution (Section 15.10).
+- Rebase on `origin/develop` only; `--force-with-lease` after rebase with
+  approval — never plain `--force`.
+- PR target: `Mika3578/habitv` → `develop` (Section 14.10).
 
-## Fast safe modernization
+Details: [`docs/dev-workflow.md`](../docs/dev-workflow.md).
 
-See `AGENTS.md` Section 16 and `docs/dev-workflow.md`. Classify tasks
-before editing (16.2). Prefer small focused PRs. Security fixes outrank
-cosmetic work (16.19). Dependency updates need focused PRs and the
-Dependency update report (16.3).
+## Validation
 
-## Rule evolution
+Pre-commit tiers: `AGENTS.md` Section 14.2 and
+[`docs/dev-workflow.md`](../docs/dev-workflow.md#validation).
 
-See Section 17. AI rules change through dedicated PRs with changelog entry.
-Automation maturity: Level 1 — Assisted.
+Default CI-safe baseline (not sufficient alone for commit approval):
 
-## Habitv-specific modernization
-
-See Section 18 and `docs/provider-policy.md`. Declare phase before work.
-Provider status, metadata, offline tests, external tools, Java/JavaFX,
-release readiness — see companion docs in metadata block.
-
-## Maintainability
-
-See Section 19 and `docs/maintainability-policy.md`. Declare Definition of
-Done; classify PR risk; document ADRs for durable decisions; manual test
-evidence before commit on behavior changes.
-
-## Productivity and anti-bloat
-
-See Section 20 and `docs/agent-rule-profiles.md`. Pick a rule profile at
-task start; use speed mode for low-risk docs-only work; prefer backlog
-over new mandatory rules.
-
-AI agents must never commit, push, create PRs, merge PRs, or resolve
-review threads without explicit developer approval in the current
-conversation. See `AGENTS.md` Section 14. Never resolve GitHub review
-conversations silently (Section 15.7).
-
-## Compatibility constraints
-
-See `.github/instructions/maven-java.instructions.md` and
-`.cursor/rules/java8-compatibility.mdc` for Java 8 and Maven constraints.
-
-## Key modules
-
-- `fwk/api` — public API contracts shared by core and plugins.
-- `fwk/framework` — base utilities, retriever, updater helpers.
-- `application/core` — config, DAOs, JAXB-bound entities, updater.
-- `application/consoleView` — CLI front end.
-- `application/trayView` — JavaFX 2.x tray UI.
-- `application/habiTv` — application bundling entry point.
-- `plugins/*` — provider, downloader, and tool wrapper plugins
-  (e.g. youtube, ffmpeg, curl, RSS, canalPlus, arte, pluzz, 6play).
-- `plugins/plugin-tester` — shared test harness for plugin modules.
-
-## Default validation
-
-Pre-commit validation for AI agents is defined in `AGENTS.md` Section
-14.2 (tiered). Do **not** require root `clean package` for every code change.
-
-**Standard code** tier:
-
-```
-mvn -B -ntp validate
-mvn -B -ntp -pl <module> -am test   # when module-specific
-```
-
-**Risky / code-wide** tier:
-
-```
-mvn -B -ntp validate
-mvn -B -ntp test
-```
-
-**Packaging / full-app** tier (only when in scope and JavaFX/`jdk.home`
-environment supports it):
-
-```
-mvn -B -ntp -DskipTests clean package
-```
-
-**Docs-only:** Maven may be skipped with a clear note.
-
-CI-safe sanity check (not sufficient alone before commit approval unless
-the developer explicitly relaxes Section 14.2):
-
-```
+```bash
 mvn -B -ntp -DskipTests validate
 ```
 
-Do not invent richer commands (e.g. `verify`, `install`) unless a
-tracker item explicitly requires them — the reactor is not yet
-stabilized (see `docs/audit-master-baseline.md`).
+Do not require root `clean package` for every code change. Do not add live
+network tests to the default lifecycle.
+
+## Review and communication
+
+- Copilot review loop: Section 20.15; details in
+  [`docs/dev-workflow.md`](../docs/dev-workflow.md#copilot-review-loop).
+- Concise PR/commit text: Section 20.13.
+- Provider public text: Section 20.14 → [`docs/provider-policy.md`](../docs/provider-policy.md).
+
+Ask approval before PR comment actions (Section 15.25).
+
+## Habitv modernization (pointers)
+
+- Providers: Section 18, [`docs/provider-policy.md`](../docs/provider-policy.md)
+- Maintainability: Section 19, [`docs/maintainability-policy.md`](../docs/maintainability-policy.md)
+- Profiles / drift: Section 20, [`docs/agent-rule-profiles.md`](../docs/agent-rule-profiles.md)
+- Planning: [`docs/dev-tracker.md`](../docs/dev-tracker.md), [`docs/maintenance-dashboard.md`](../docs/maintenance-dashboard.md)
+
+## Key modules
+
+`fwk/api`, `fwk/framework`, `application/core`, `application/consoleView`,
+`application/trayView`, `application/habiTv`, `plugins/*`, `plugins/plugin-tester`.
 
 ## Things to avoid suggesting
 
-- Replacing `javax.xml.bind` with `jakarta.xml.bind`.
-- Replacing `youtube-dl` with `yt-dlp` (tracked under `ytdlp-migration`).
-- Upgrading or replacing JavaFX dependencies (tracked under
-  `javafx-modernization`).
-- Adding network-dependent tests to the default lifecycle.
-- Adding OWASP, SBOM, or static-analysis plugins in this phase.
-- Reformatting files, renaming variables outside a change, or moving
-  packages.
-- Bumping a `plugins/*/pom.xml` `<version>` for changes that do not
-  match a `plugin-versioning-policy` trigger (downloader/parser
-  behaviour, user-facing endpoint, user-facing configuration). See
-  the "Plugin versioning" section of `CONTRIBUTING.md`. Inside a
-  bumped plugin, internal reactor deps (`api`, `framework`,
-  `plugin-tester`) MUST use `${project.parent.version}`, never
-  `${project.version}`.
+- Jakarta JAXB migration, JavaFX replacement, `youtube-dl` → `yt-dlp` rewrites
+  (tracked items exist).
+- OWASP/SBOM/static-analysis plugins in this phase.
+- Broad reformatting or opportunistic refactors.
+- Plugin version bumps without `plugin-versioning-policy` trigger
+  (`CONTRIBUTING.md`).
 
 ## Things to encourage
 
-- Small, scoped diffs tied to one tracker item.
-- English-only comments and identifiers in new code.
-- Explicit error handling at meaningful boundaries (no swallow,
-  no broad catch).
-- Updating `docs/dev-tracker.md`, `docs/dev-tracker.json`,
-  `docs/risk-register.md`, and `docs/decision-log.md` when the
-  change is meaningful.
+- Small scoped diffs; English in new code and comments.
+- Meaningful doc sync: `dev-tracker.{md,json}`, `risk-register.md`,
+  `decision-log.md` when state changes (Section 12).
+- AI rule changes: version bump, changelog, drift audit v2 (Section 20.16).

--- a/.github/instructions/github-pr.instructions.md
+++ b/.github/instructions/github-pr.instructions.md
@@ -30,15 +30,24 @@ only (never `--force`).
 
 ## Copilot review comments
 
-Before PR readiness:
+Before PR readiness (`AGENTS.md` Sections 14.4, 20.15):
 
 1. Inspect all Copilot review comments and unresolved conversations.
 2. Classify each: accepted and fixed; intentionally rejected with reason;
    not applicable; outside current PR scope; needs developer decision.
 3. Implement accepted items; reply in English to each comment.
-4. Resolve only after handling and reply. Never resolve to silence review.
-5. Ask developer approval before GitHub commands that resolve threads.
-6. Never resolve conversations silently (`AGENTS.md` Section 15.7).
+4. Resolve only after handling and reply — not to silence review; not twice
+   without a new commit or explicit developer decision.
+5. Ask developer approval before GitHub commands that resolve threads or
+   re-request review.
+
+Details: [`docs/dev-workflow.md`](../docs/dev-workflow.md#copilot-review-loop).
+Never resolve conversations silently (Section 15.7).
+
+## Concise communication
+
+PR/commit/review text: English, scoped, reviewer-friendly (Section 20.13).
+Details: [`docs/dev-workflow.md`](../docs/dev-workflow.md#concise-communication).
 
 ## Instruction alignment
 

--- a/.github/instructions/github-pr.instructions.md
+++ b/.github/instructions/github-pr.instructions.md
@@ -41,13 +41,13 @@ Before PR readiness (`AGENTS.md` Sections 14.4, 20.15):
 5. Ask developer approval before GitHub commands that resolve threads or
    re-request review.
 
-Details: [`docs/dev-workflow.md`](../docs/dev-workflow.md#copilot-review-loop).
+Details: [`docs/dev-workflow.md`](../../docs/dev-workflow.md#copilot-review-loop).
 Never resolve conversations silently (Section 15.7).
 
 ## Concise communication
 
 PR/commit/review text: English, scoped, reviewer-friendly (Section 20.13).
-Details: [`docs/dev-workflow.md`](../docs/dev-workflow.md#concise-communication).
+Details: [`docs/dev-workflow.md`](../../docs/dev-workflow.md#concise-communication).
 
 ## Instruction alignment
 

--- a/.github/instructions/plugins.instructions.md
+++ b/.github/instructions/plugins.instructions.md
@@ -1,25 +1,56 @@
 ---
+
 applyTo: "plugins/**"
+
 ---
+
+
 
 # Habitv plugin instructions (Copilot)
 
+
+
 Extends `AGENTS.md` Section 18 and `docs/provider-policy.md`.
+
+
 
 ## Scope
 
+
+
 Provider, downloader, and export plugins under `plugins/`.
+
+
 
 ## Extends AGENTS.md
 
+
+
 - Phase declaration (18.1); status matrix (18.2); metadata contract (18.3).
+
 - Offline-first testing (18.4); external tools in dedicated PRs (18.5).
+
+- Protected content and provider policy: Section 18.4 → `docs/provider-policy.md`
+  (includes [site authentication for download](docs/provider-policy.md#site-authentication-for-download)).
+
+- Provider public communication safety (20.14): high-level PR/commit text only;
+
+  see `docs/provider-policy.md#public-communication-safety`.
+
+
 
 ## Validation expected
 
+
+
 - `mvn -B -ntp -pl plugins/<module> -am test`
+
 - offline fixtures preferred; document skipped live tests
 
-## Do not change
 
-- DRM bypass; cookies/tokens in repo; provider + dependency in same PR.
+
+## Do not change (without maintainer request)
+
+
+
+- protected-replay handling in unrelated docs/CI/dependency PRs; secrets in repo.

--- a/.github/instructions/plugins.instructions.md
+++ b/.github/instructions/plugins.instructions.md
@@ -31,11 +31,11 @@ Provider, downloader, and export plugins under `plugins/`.
 - Offline-first testing (18.4); external tools in dedicated PRs (18.5).
 
 - Protected content and provider policy: Section 18.4 → `docs/provider-policy.md`
-  (includes [site authentication for download](docs/provider-policy.md#site-authentication-for-download)).
+  (includes [site authentication for download](../../docs/provider-policy.md#site-authentication-for-download)).
 
 - Provider public communication safety (20.14): high-level PR/commit text only;
 
-  see `docs/provider-policy.md#public-communication-safety`.
+  see [`docs/provider-policy.md#public-communication-safety`](../../docs/provider-policy.md#public-communication-safety).
 
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ complement, but do not replace, the human review process.
 
 ## Agent rules metadata
 
-* **Version:** 1.4.1
+* **Version:** 1.5.1
 * **Last updated:** 2026-05-31
 * **Maintainer:** repository maintainer
 * **Scope:** Habitv AI-assisted development workflow
@@ -456,6 +456,8 @@ You **must**:
 
 - Always reply in **English** in code, commits, comments, docs, and PR
   text — regardless of the user's prompt language.
+- Keep **public PR, commit, and review text concise and scoped** (Section
+  20.13); provider/plugin public text must stay high-level (Section 20.14).
 - Be precise about what you ran vs. what you reasoned about. Cite
   exact command outputs, file paths, and line numbers.
 - Disagree with the user when their suggestion would break a hard
@@ -1640,7 +1642,7 @@ When changing plugins or replay providers, the agent should prefer:
 - manual live verification only as an additional check.
 
 If live tests are skipped because of network instability, geoblocking,
-authentication, DRM, or provider rate limits, the agent must say so
+authentication, geoblocking, or provider rate limits, the agent must say so
 clearly.
 
 ### 15.25 PR comment action gate
@@ -2116,10 +2118,13 @@ For replay provider work:
 
 - prefer deterministic parser tests with offline fixtures;
 - avoid relying only on live network tests;
-- document authentication, cookies, DRM, geoblocking, or browser session
-  requirements;
-- do not bypass DRM;
-- do not commit cookies, tokens, or browser profiles;
+- document site authentication, geoblocking, anti-bot, or browser session
+  requirements when replay is login-gated;
+- follow the protected content policy (Section 18.4); details in
+  [`docs/provider-policy.md`](docs/provider-policy.md);
+- in a **scoped provider PR** with maintainer direction, optional auth and
+  protected-replay paths may ship **disabled until user-local config** is set;
+- do not commit tokens, browser profiles, or credential files;
 - use yt-dlp behavior as integration inspiration only when legally and
   technically appropriate;
 - keep each provider change isolated.
@@ -2453,7 +2458,7 @@ Replay providers/plugins must have a clear status in
 |--------|---------|
 | **working** | validated with tests and real behavior when possible |
 | **degraded** | partial function; known metadata or endpoint gaps |
-| **protected** | auth, cookies, DRM, geoblocking, or anti-bot |
+| **protected** | auth, encryption, geoblocking, or anti-bot |
 | **obsolete** | dead or replaced endpoint/platform |
 | **removed** | intentionally removed from active UI/plugin list |
 | **unknown** | not recently validated |
@@ -2478,10 +2483,64 @@ Prefer deterministic offline tests: fixtures; parser tests; URL extraction;
 command-building; targeted `mvn -pl plugins/<module> -am test`.
 
 Live/network checks are supplementary — not the only proof. If skipped, state
-why (network, geoblocking, auth, DRM, rate limits, downtime).
+why (network, geoblocking, auth, rate limits, downtime).
 
-Do not bypass DRM. Do not commit cookies, browser profiles, sessions, tokens,
-or auth headers. See also Section 15.24.
+#### Protected content (tiered)
+
+Policy detail: [`docs/provider-policy.md`](docs/provider-policy.md).
+
+**Default (when maintainer has not requested protected-replay handling):**
+
+- use public discovery (HTML, GraphQL, fixtures) and delegate download to
+  existing external tools (for example yt-dlp through the youtube plugin);
+- mark protected, auth-gated, or encryption-restricted content as
+  `protected` or `degraded`;
+- fail gracefully with sanitized diagnostics when download is unavailable.
+
+When a provider requires **site login** before a replay URL is available,
+see [`docs/provider-policy.md`](docs/provider-policy.md#site-authentication-for-download).
+Habitv does not ship browser session import or an embedded browser by default.
+
+**Maintainer-directed protected replay (opt-in):**
+
+Agents **may** implement Stremio-equivalent protected replay (for example
+TF1+ auth plus external tool delegation) when **any** of:
+
+- the maintainer **explicitly requests** it in the **current conversation**; or
+- a **scoped provider PR** documents maintainer direction in its scope/body and
+  links the relevant tracker item (for example `provider-inventory` / TF1+ work).
+
+Requirements:
+
+- PR scope limited to that provider or downloader path;
+- PR body states legal/ToS residual risk and points to the
+  [residual risk entry](docs/risk-register.md#provider-drm-circumvention--provider-drm-circumvention-residual-risk)
+  in `docs/risk-register.md`;
+- user credentials, keys, and user-local license material remain **outside the
+  repo** (environment variables, local config paths, user-supplied files only);
+- prefer **delegation** — yt-dlp, ffmpeg, optional plugin-bundled helper scripts
+  that read env at runtime, or user-local services — over reimplementing
+  protected-replay handling in Java;
+- **disabled-by-default** is OK: public catalog and yt-dlp remain the default
+  path until the user configures local credentials and helpers;
+- no hardcoded account passwords, shared throwaway accounts, or committed
+  sessions;
+- provider-published public API identifiers may appear in source when required
+  for login flows; treat account secrets and license material as always forbidden
+  in git.
+
+An ADR update or Proposed ADR in the same docs batch is sufficient; a separate
+governance-only PR is recommended but not mandatory when the maintainer directs
+combined provider plus policy work.
+
+**Always forbidden in the repository:**
+
+- committing license material, key material, browser profiles, sessions,
+  tokens, auth headers, or shared credentials;
+- silently adding protected-replay handling to unrelated docs, CI, dependency,
+  or refactor PRs without maintainer request.
+
+See also Section 15.24 and [`docs/provider-policy.md`](docs/provider-policy.md).
 
 ### 18.5 External tools policy
 
@@ -2791,7 +2850,7 @@ without developer approval.
 Provider tests must not depend only on live network (see Section 18.4).
 
 Live tests clearly labeled; CI must not fail randomly on provider downtime,
-geoblocking, DRM, auth, or rate limits. Prefer offline fixtures; live
+geoblocking, auth, or rate limits. Prefer offline fixtures; live
 checks optional, manual, or scheduled.
 
 ### 19.10 XML configuration compatibility rule
@@ -2855,7 +2914,7 @@ If manual testing not done: **Ready for developer manual testing** — not
 Classify risk: **low** (docs/narrow fix); **medium** (provider, Maven, CI,
 dep patch/minor); **high** (dep major, Java migration, packaging, config
 migration, external tools); **critical** (security, release, destructive
-migration, DRM/auth/cookies).
+migration, protected content/auth/cookies).
 
 Validation scales with risk (Section 19.2, 14.2).
 
@@ -3007,3 +3066,54 @@ Prefer enforcing rules via branch protection, CI, CODEOWNERS, Dependabot,
 Dependency Review, CodeQL, Maven validation, small PRs, and provider tests —
 not endless mandatory text. Track gaps in
 [`docs/agent-rules-backlog.md`](docs/agent-rules-backlog.md#enforcement-over-expansion-section-2012).
+
+### 20.13 Concise public communication
+
+PR titles, commit subjects, PR bodies, and review replies must be **English**,
+**scoped**, and **reviewer-friendly**. Summarize intent, scope, validation,
+risk, rollback, and follow-up — not step-by-step implementation noise.
+
+Final reports and handoffs (Sections 16.25, 15.6) must be **useful but not
+overly verbose**. Details:
+[`docs/dev-workflow.md`](docs/dev-workflow.md#concise-communication).
+
+### 20.14 Provider communication safety
+
+Provider/plugin **public text** (PRs, commits, comments, user-facing docs)
+must avoid exposing unnecessary operational detail. Use high-level wording;
+see [`docs/provider-policy.md`](docs/provider-policy.md#public-communication-safety).
+
+### 20.15 Copilot review loop guard
+
+Do not mark a PR ready while Copilot or other review threads remain
+unhandled. Loop: **inspect → classify → fix or reject with reason → reply →
+resolve only with developer approval** (Sections 14.4, 15.7, 15.25).
+
+Do not resolve the same thread twice without a new commit or explicit
+developer decision. Do not request re-review without approval.
+
+Details: [`docs/dev-workflow.md`](docs/dev-workflow.md#copilot-review-loop).
+
+### 20.16 Rule ownership and drift control
+
+`AGENTS.md` owns **mandatory cross-tool rules**. Companion files (Cursor,
+Copilot, Claude, Gemini, nested `AGENTS.md`) are **mirrors only** — they
+must not introduce unique mandatory rules.
+
+**Ownership table** and **drift audit v2** live in
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md). On AI-rule
+changes: bump metadata version, update
+[`docs/agent-rules-changelog.md`](docs/agent-rules-changelog.md), run drift
+audit v2 (Sections 17.6, 20.6).
+
+### 20.17 Planning and follow-up ownership
+
+| Source | Role |
+|--------|------|
+| `docs/dev-tracker.md` + `docs/dev-tracker.json` | Planned work and tracker state |
+| `docs/maintenance-dashboard.md` | Short operational planning view |
+| `docs/agent-rules-backlog.md` | Future **rule** ideas only — not product roadmap |
+| `docs/modernization-backlog.md` | Larger modernization candidates |
+
+When a task surfaces follow-up work, record it in the appropriate tracker
+or backlog — not only in PR comments (Section 15.26).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2514,7 +2514,7 @@ Requirements:
 
 - PR scope limited to that provider or downloader path;
 - PR body states legal/ToS residual risk and points to the
-  [residual risk entry](docs/risk-register.md#provider-drm-circumvention--provider-drm-circumvention-residual-risk)
+  [residual risk entry](docs/risk-register.md#provider-protected-replay-residual--provider-protected-replay-residual-risk)
   in `docs/risk-register.md`;
 - user credentials, keys, and user-local license material remain **outside the
   repo** (environment variables, local config paths, user-supplied files only);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1642,7 +1642,7 @@ When changing plugins or replay providers, the agent should prefer:
 - manual live verification only as an additional check.
 
 If live tests are skipped because of network instability, geoblocking,
-authentication, geoblocking, or provider rate limits, the agent must say so
+authentication, or provider rate limits, the agent must say so
 clearly.
 
 ### 15.25 PR comment action gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3104,7 +3104,7 @@ must not introduce unique mandatory rules.
 [`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md). On AI-rule
 changes: bump metadata version, update
 [`docs/agent-rules-changelog.md`](docs/agent-rules-changelog.md), run drift
-audit v2 (Sections 17.6, 20.6).
+audit v2 (Sections 17.6, 20.16).
 
 ### 20.17 Planning and follow-up ownership
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,9 @@ Before making changes, read and follow `AGENTS.md` for branch naming,
 duplicate branch/PR prevention, commit style, PR structure, validation,
 PR target policy, and documentation sync.
 
+Rule ownership and mirrors: `AGENTS.md` Section 20.16;
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md).
+
 If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
 
 Use English for code comments, commit messages, PR text, and

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,6 +6,10 @@ agent behavior.
 Before making changes, read and follow `AGENTS.md`. At task start, report
 the **Instruction files loaded** checklist (`AGENTS.md` Section 15.1).
 
+Mirrors only — do not introduce unique mandatory rules (Section 20.16).
+Ownership table and drift audit v2:
+[`docs/agent-rule-profiles.md`](docs/agent-rule-profiles.md).
+
 Tool-specific mirrors:
 
 - `.cursor/rules/git-safety.mdc`

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,6 +22,11 @@ changes (Markdown, tracker JSON mirrors, ADRs, audit baselines).
   `docs/maintainability-policy.md` for Habitv-specific agent topics
   (Sections 18–19).
 - AI rule changes require version bump and changelog entry (Section 17).
+- Rule ownership and drift audit v2: Section 20.16,
+  [`agent-rule-profiles.md`](agent-rule-profiles.md).
+- Planned work lives in `dev-tracker.{md,json}`; short view in
+  [`maintenance-dashboard.md`](maintenance-dashboard.md); rule candidates in
+  [`agent-rules-backlog.md`](agent-rules-backlog.md) only.
 - For docs-only AI-rule work, use speed mode (Section 20.8); run drift
   audit when rules change (Section 17.6).
 - Prefer backlog over new mandatory rules (Section 20.10).

--- a/docs/agent-rule-profiles.md
+++ b/docs/agent-rule-profiles.md
@@ -143,6 +143,49 @@ Stop adding mandatory rules when:
 
 When unsure: add to [`docs/agent-rules-backlog.md`](agent-rules-backlog.md).
 
+## Rule ownership
+
+Mirrors must summarize or link — never introduce unique mandatory rules.
+Details: `AGENTS.md` Section 20.16.
+
+| Rule topic | Canonical owner | Mirrors/summaries | Detail doc | Status |
+|------------|-----------------|---------------|------------|--------|
+| Commit/push approval | AGENTS.md §14 | git-safety.mdc, github-pr.instructions.md | docs/dev-workflow.md | current |
+| Maven validation | AGENTS.md §14.2 | maven-validation.mdc, maven-java.instructions.md | docs/dev-workflow.md | current |
+| Copilot review handling | AGENTS.md §14.4 / §15.7 / §20.15 | pr-review.mdc, github-pr.instructions.md | docs/dev-workflow.md | current |
+| Provider communication safety | AGENTS.md §20.14 / docs/provider-policy.md | habitv-providers.mdc, plugins.instructions.md | docs/provider-policy.md | current |
+| Concise PR communication | AGENTS.md §20.13 / docs/dev-workflow.md | pr-review.mdc, github-pr.instructions.md | docs/dev-workflow.md | current |
+| Rule drift control | AGENTS.md §17 / §20.16 | 90-rule-evolution.mdc | docs/agent-rule-profiles.md | current |
+| Dev roadmap | docs/dev-tracker.md + docs/dev-tracker.json | maintenance-dashboard.md | docs/dev-workflow.md | current |
+
+## Rule drift audit v2
+
+Run when AI rules or instruction mirrors change (`AGENTS.md` Sections 17.6,
+20.16). Copy into PR body or pre-commit report:
+
+```markdown
+## Rule drift audit v2
+
+* Canonical owner table checked:
+* Mirrors checked:
+* Duplicate rules found:
+* Conflicting rules found:
+* Broken section references:
+* Broken file links:
+* Unique mandatory rules outside AGENTS.md:
+* Changelog/version aligned:
+* Backlog/archive aligned:
+* Actions taken:
+* Remaining risks:
+```
+
+**Checks:**
+
+- every mirror links to `AGENTS.md` and defers detail to the owner doc;
+- no mirror adds approval, validation, or safety rules missing from owners;
+- `AGENTS.md` metadata version matches latest changelog entry;
+- new candidates go to backlog, not new mandatory sections (Section 20.10).
+
 ## Rule cleanup cadence
 
 Every ~10 merged PRs, propose branch `docs/cleanup-agent-rules` with commit

--- a/docs/agent-rules-backlog.md
+++ b/docs/agent-rules-backlog.md
@@ -144,6 +144,7 @@ Prefer implementing guardrails through tooling rather than new text:
 
 ## Recently completed
 
+* v1.5.1 protected-replay opt-in and slug cleanup — see changelog
 * v1.5.0 rule governance streamline — see changelog
 * v1.4.0 productivity and anti-bloat guardrails — see changelog
 * v1.3.0 maintainability guardrails — see changelog

--- a/docs/agent-rules-backlog.md
+++ b/docs/agent-rules-backlog.md
@@ -21,6 +21,71 @@ Prefer implementing guardrails through tooling rather than new text:
 
 ## Candidate rules
 
+### Embedded browser for provider login (CEF / JavaFX)
+
+* **Problem:** Some providers (TF1+, etc.) require a web login before replay
+  URLs are available; Habitv has no in-app browser today.
+* **Proposed rule:** Dedicated tracker + ADR before any JavaFX/CEF integration;
+  reference `habitv-references/captvty` (CefSharp) and
+  `habitv-references/TF1-Downloader` (Selenium) for patterns only.
+* **Priority:** P3
+* **Target file:** `application/trayView` or new tooling module
+* **Trigger:** maintainer request after `docs/provider-policy.md` auth section
+* **Status:** proposed
+
+### Optional local git/gh wrappers for Cursor automation
+
+* **Problem:** Agents prepare commits/PRs but developer runs Git/GitHub manually;
+  no shared safe wrapper scripts for common validate-then-diff flows.
+* **Proposed rule:** Optional `scripts/agent-git-*.ps1` / `.sh` helpers in a
+  dedicated tooling PR; never auto-commit or auto-push.
+* **Priority:** P3
+* **Target file:** `scripts/`
+* **Trigger:** developer request
+* **Status:** proposed
+
+### PR template alignment with concise communication
+
+* **Problem:** PR template sections may encourage verbose bodies inconsistent
+  with §20.13.
+* **Proposed rule:** Align `.github/pull_request_template.md` with
+  `docs/dev-workflow.md#concise-communication` in a dedicated docs PR.
+* **Priority:** P3
+* **Target file:** `.github/pull_request_template.md`
+* **Trigger:** after v1.5.0 merge
+* **Status:** proposed
+
+### Future rule cleanup PR (`docs/cleanup-agent-rules`)
+
+* **Problem:** Mirror files may accumulate duplicate bullets over time.
+* **Proposed rule:** Periodic cleanup per Section 20.11; archive retired wording
+  in `docs/archived-agent-rules.md`.
+* **Priority:** P3
+* **Target file:** `.cursor/rules/`, `.github/instructions/`, nested `AGENTS.md`
+* **Trigger:** ~10 merged PRs after v1.5.0
+* **Status:** proposed
+
+### Optional CODEOWNERS / rulesets / security hardening
+
+* **Problem:** Some gates documented in rules are not yet fully enforced in
+  GitHub UI.
+* **Proposed rule:** Dedicated governance PR for CODEOWNERS, rulesets, and
+  required checks — not mixed with provider or rule-text PRs.
+* **Priority:** P2
+* **Target file:** `.github/CODEOWNERS`, repository settings docs
+* **Trigger:** `branch-protection` tracker item
+* **Status:** proposed
+
+### Provider communication review checklist
+
+* **Problem:** v1.5.0 adds policy text but no optional PR checklist artifact.
+* **Proposed rule:** Add checklist to `docs/provider-policy.md` or PR template
+  if repeated review misses occur.
+* **Priority:** P3
+* **Target file:** `docs/provider-policy.md` or PR template
+* **Trigger:** after first provider PR using §20.14
+* **Status:** proposed
+
 ### Numbered Cursor rule module rename
 
 * **Problem:** Legacy Cursor rule filenames (`git-safety.mdc`, etc.) differ
@@ -79,6 +144,7 @@ Prefer implementing guardrails through tooling rather than new text:
 
 ## Recently completed
 
+* v1.5.0 rule governance streamline — see changelog
 * v1.4.0 productivity and anti-bloat guardrails — see changelog
 * v1.3.0 maintainability guardrails — see changelog
 * v1.1.0 evolutionary governance — see [`agent-rules-changelog.md`](agent-rules-changelog.md)

--- a/docs/agent-rules-changelog.md
+++ b/docs/agent-rules-changelog.md
@@ -2,6 +2,130 @@
 
 Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AGENTS.md).
 
+## 2026-05-31 — v1.5.1
+
+### Added
+
+* Disabled-by-default auth/protected-replay paths in scoped provider PRs
+  (`AGENTS.md` §16.20, §18.4).
+* Plugin helper scripts (logic only, no secrets) allowed under
+  `plugins/<name>/scripts/` (`docs/provider-policy.md`).
+* Public provider API identifiers vs account secrets distinction (§18.4).
+
+### Changed
+
+* Relaxed opt-in gate: maintainer request in **current conversation** **or**
+  **scoped provider PR** with documented maintainer direction (ADR rev. 3).
+* Site authentication may ship in the same provider PR as public catalog.
+* ADR `provider-drm-tiered-policy` → revision 3.
+
+### Removed
+
+* Requirement that opt-in applies only to the current conversation.
+
+### Reason
+
+* Unblock TF1+ / Stremio-equivalent provider work without agents refusing
+  optional gated features that stay inactive until user-local config.
+
+### Follow-up
+
+* Document user-local env setup in provider README (high-level, no secrets).
+
+## 2026-05-31 — v1.5.0
+
+### Added
+
+* Concise public communication rule (`AGENTS.md` §20.13).
+* Provider communication safety rule (`AGENTS.md` §20.14;
+  `docs/provider-policy.md#public-communication-safety`).
+* Site authentication guidance (`docs/provider-policy.md#site-authentication-for-download`).
+* Copilot review loop guard (`AGENTS.md` §20.15;
+  `docs/dev-workflow.md#copilot-review-loop`).
+* Rule ownership and drift-control guidance (`AGENTS.md` §20.16–§20.17).
+* Rule ownership table and drift audit v2 in `docs/agent-rule-profiles.md`.
+* Planning source guidance in `docs/dev-workflow.md`.
+
+### Changed
+
+* Clarified that `AGENTS.md` remains the canonical source; Cursor, Copilot,
+  Claude, Gemini, and nested `AGENTS.md` files are short mirrors.
+* Shortened `.github/copilot-instructions.md` validation section (delegates to
+  `AGENTS.md` §14.2 and `docs/dev-workflow.md`).
+* Mirrors defer protected content policy implicitly via Section 18.4 and
+  `docs/provider-policy.md` — no explicit keyword in instruction mirrors.
+
+### Removed
+
+* None.
+
+### Reason
+
+* Post–PR #125 rationalization: clarify ownership, reduce duplication, add
+  targeted safeguards without expanding mandatory rule bulk.
+
+### Follow-up
+
+* See `docs/agent-rules-backlog.md` for deferred items (local git/gh wrappers,
+  PR template alignment, rule cleanup PR, CODEOWNERS hardening).
+
+## 2026-05-31 — v1.4.3
+
+### Added
+
+* Maintainer opt-in circumvention path in `AGENTS.md` §18.4 (revision 2).
+
+### Changed
+
+* Relaxed tier-2 gates: no mandatory separate PR or Accepted ADR before
+  maintainer-requested circumvention; scoped provider PR plus docs batch OK.
+* ADR `provider-drm-tiered-policy` status → Accepted (rev. 2).
+* Aligned `docs/provider-policy.md`, `.cursor/rules/habitv-providers.mdc`,
+  `.github/instructions/plugins.instructions.md`, `plugins/AGENTS.md`,
+  `docs/risk-register.md`.
+
+### Removed
+
+* Requirement for separate governance-only PR before circumvention work.
+
+### Reason
+
+* Maintainer request to further relax agent blocking while keeping secrets out
+  of the repository.
+
+### Follow-up
+
+* Document circumvention scope and validation in any provider PR that uses this
+  opt-in path.
+
+## 2026-05-31 — v1.4.2
+
+### Added
+
+* Tiered DRM policy in `AGENTS.md` §18.4 (default catalog work vs opt-in
+  circumvention PR).
+* ADR `provider-drm-tiered-policy` (Proposed) in `docs/decision-log.md`.
+* Residual risk `provider-drm-circumvention` in `docs/risk-register.md`.
+
+### Changed
+
+* Replaced absolute “do not bypass DRM” wording in `AGENTS.md` §16.20,
+  `docs/provider-policy.md`, `.cursor/rules/habitv-providers.mdc`,
+  `.github/instructions/plugins.instructions.md`, and `plugins/AGENTS.md`.
+
+### Removed
+
+* None.
+
+### Reason
+
+* Maintainer request to relax agent blocking while keeping secrets and default
+  catalog PRs free of in-repo circumvention (`provider-drm-tiered-policy`).
+
+### Follow-up
+
+* Accept ADR after review; add tracker item before any circumvention PR.
+
 ## 2026-05-31 — v1.4.1
 
 ### Added

--- a/docs/agent-rules-changelog.md
+++ b/docs/agent-rules-changelog.md
@@ -17,7 +17,7 @@ Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AG
 * Relaxed opt-in gate: maintainer request in **current conversation** **or**
   **scoped provider PR** with documented maintainer direction (ADR rev. 3).
 * Site authentication may ship in the same provider PR as public catalog.
-* ADR `provider-drm-tiered-policy` → revision 3.
+* ADR `provider-protected-content-tiered-policy` → revision 3.
 
 ### Removed
 
@@ -79,7 +79,7 @@ Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AG
 
 * Relaxed tier-2 gates: no mandatory separate PR or Accepted ADR before
   maintainer-requested circumvention; scoped provider PR plus docs batch OK.
-* ADR `provider-drm-tiered-policy` status → Accepted (rev. 2).
+* ADR `provider-protected-content-tiered-policy` status → Accepted (rev. 2).
 * Aligned `docs/provider-policy.md`, `.cursor/rules/habitv-providers.mdc`,
   `.github/instructions/plugins.instructions.md`, `plugins/AGENTS.md`,
   `docs/risk-register.md`.
@@ -102,14 +102,14 @@ Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AG
 
 ### Added
 
-* Tiered DRM policy in `AGENTS.md` §18.4 (default catalog work vs opt-in
+* Tiered protected content policy in `AGENTS.md` §18.4 (default catalog work vs opt-in
   circumvention PR).
-* ADR `provider-drm-tiered-policy` (Proposed) in `docs/decision-log.md`.
-* Residual risk `provider-drm-circumvention` in `docs/risk-register.md`.
+* ADR `provider-protected-content-tiered-policy` (Proposed) in `docs/decision-log.md`.
+* Residual risk `provider-protected-replay-residual` in `docs/risk-register.md`.
 
 ### Changed
 
-* Replaced absolute “do not bypass DRM” wording in `AGENTS.md` §16.20,
+* Replaced absolute “do not bypass protected content” wording in `AGENTS.md` §16.20,
   `docs/provider-policy.md`, `.cursor/rules/habitv-providers.mdc`,
   `.github/instructions/plugins.instructions.md`, and `plugins/AGENTS.md`.
 
@@ -120,7 +120,7 @@ Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AG
 ### Reason
 
 * Maintainer request to relax agent blocking while keeping secrets and default
-  catalog PRs free of in-repo circumvention (`provider-drm-tiered-policy`).
+  catalog PRs free of in-repo circumvention (`provider-protected-content-tiered-policy`).
 
 ### Follow-up
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -27,7 +27,7 @@ older ones rather than rewriting them in place.
 | `ai-policy-source-of-truth` | Align AI workflow policy around AGENTS.md source of truth | ✅ Accepted |
 | `plugin-versioning-policy` | When to bump a plugin `<version>` independently of the parent POM | 🟡 Proposed |
 | `jaxb-activation-dedup-defer` | Plan JAXB/Activation dedup before POM changes; defer namespace migration | 🟡 Proposed |
-| `provider-drm-tiered-policy` | Tiered DRM policy for provider and agent work | ✅ Accepted |
+| `provider-protected-content-tiered-policy` | Tiered protected content policy for provider and agent work | ✅ Accepted |
 
 ---
 
@@ -601,20 +601,20 @@ PRs with the plan validation matrix. Do not upgrade `javax.mail` or exclude
 
 ---
 
-## ✅ `provider-drm-tiered-policy` — Tiered DRM policy for providers
+## ✅ `provider-protected-content-tiered-policy` — Tiered protected content policy for providers
 
 | | |
 |---|---|
 | **Status** | ✅ Accepted |
 | **Date** | 2026-05-31 |
 | **Last revised** | 2026-05-31 (rev. 3) |
-| **Risks** | `provider-drm-circumvention` |
+| **Risks** | `provider-protected-replay-residual` |
 | **Touches** | `AGENTS.md` §16.20, §18.4; `docs/provider-policy.md`; `.cursor/rules/habitv-providers.mdc`; `.github/instructions/plugins.instructions.md`; `plugins/AGENTS.md` |
-| **Supersedes** | implicit absolute “never bypass DRM” wording in provider/agent rules |
+| **Supersedes** | implicit absolute “never bypass protected content” wording in provider/agent rules |
 
 **Context** — TF1+ and other replay providers expose a mixed catalog: some
 episodes are reachable through public discovery and yt-dlp, while others are
-DRM-protected. Maintainers need Stremio-equivalent catalog **and** optional
+encryption-restricted. Maintainers need Stremio-equivalent catalog **and** optional
 protected replay support without agents refusing by default.
 
 **Decision** — Adopt a **tiered** protected-content policy (revision 3):
@@ -638,7 +638,7 @@ protected replay support without agents refusing by default.
 - Default agent work remains safe and catalog-focused.
 - Maintainer-directed TF1+/Stremio-style protected replay work is allowed.
 - Residual legal, ToS, and maintenance risk stays under
-  `provider-drm-circumvention`.
+  `provider-protected-replay-residual`.
 
 ---
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -609,7 +609,7 @@ PRs with the plan validation matrix. Do not upgrade `javax.mail` or exclude
 | **Date** | 2026-05-31 |
 | **Last revised** | 2026-05-31 (rev. 3) |
 | **Risks** | `provider-protected-replay-residual` |
-| **Touches** | `AGENTS.md` §16.20, §18.4; `docs/provider-policy.md`; `.cursor/rules/habitv-providers.mdc`; `.github/instructions/plugins.instructions.md`; `plugins/AGENTS.md` |
+| **Touches** | `AGENTS.md` §15.24, §16.20, §18.2, §18.4, §19.9, §19.16; `docs/provider-policy.md`; `docs/maintainability-policy.md`; `docs/ytdlp-cli-compatibility.md`; `.cursor/rules/habitv-providers.mdc`; `.github/instructions/plugins.instructions.md`; `plugins/AGENTS.md` |
 | **Supersedes** | implicit absolute “never bypass protected content” wording in provider/agent rules |
 
 **Context** — TF1+ and other replay providers expose a mixed catalog: some

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -27,6 +27,7 @@ older ones rather than rewriting them in place.
 | `ai-policy-source-of-truth` | Align AI workflow policy around AGENTS.md source of truth | ✅ Accepted |
 | `plugin-versioning-policy` | When to bump a plugin `<version>` independently of the parent POM | 🟡 Proposed |
 | `jaxb-activation-dedup-defer` | Plan JAXB/Activation dedup before POM changes; defer namespace migration | 🟡 Proposed |
+| `provider-drm-tiered-policy` | Tiered DRM policy for provider and agent work | ✅ Accepted |
 
 ---
 
@@ -597,6 +598,47 @@ PRs with the plan validation matrix. Do not upgrade `javax.mail` or exclude
 - ⚠️ Shade warnings remain until `fix/shade-jaxb-api-dedup` merges.
 - 🔁 Accept or supersede this ADR when an implementation PR records the
   chosen strategy in the decision log.
+
+---
+
+## ✅ `provider-drm-tiered-policy` — Tiered DRM policy for providers
+
+| | |
+|---|---|
+| **Status** | ✅ Accepted |
+| **Date** | 2026-05-31 |
+| **Last revised** | 2026-05-31 (rev. 3) |
+| **Risks** | `provider-drm-circumvention` |
+| **Touches** | `AGENTS.md` §16.20, §18.4; `docs/provider-policy.md`; `.cursor/rules/habitv-providers.mdc`; `.github/instructions/plugins.instructions.md`; `plugins/AGENTS.md` |
+| **Supersedes** | implicit absolute “never bypass DRM” wording in provider/agent rules |
+
+**Context** — TF1+ and other replay providers expose a mixed catalog: some
+episodes are reachable through public discovery and yt-dlp, while others are
+DRM-protected. Maintainers need Stremio-equivalent catalog **and** optional
+protected replay support without agents refusing by default.
+
+**Decision** — Adopt a **tiered** protected-content policy (revision 3):
+
+1. **Default:** public discovery, external downloaders, `protected`/`degraded`
+   status, sanitized failures. Optional auth/protected paths may exist but stay
+   inactive until user-local config is set.
+2. **Maintainer opt-in:** when the maintainer **explicitly requests** work in
+   the **current conversation** **or** directs a **scoped provider PR** (tracker
+   + PR scope), agents may implement provider-scoped auth hooks and external
+   tool delegation in that PR. User license material, account passwords, and
+   sessions stay **outside the repo**. Prefer delegation (yt-dlp, ffmpeg,
+   plugin helper scripts, user-local services) over Java reimplementation.
+3. **Governance:** document residual risk in the PR; update ADR/risk register
+   in the same batch. A separate governance-only PR is not required.
+4. **Always forbidden in git:** license material, account passwords, sessions,
+   tokens, shared credentials, committed browser profiles.
+
+**Consequences**
+
+- Default agent work remains safe and catalog-focused.
+- Maintainer-directed TF1+/Stremio-style protected replay work is allowed.
+- Residual legal, ToS, and maintenance risk stays under
+  `provider-drm-circumvention`.
 
 ---
 

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -39,6 +39,57 @@ refactor, packaging, migration preparation, or investigation only.
    PR branch.
 5. Target PRs at `Mika3578/habitv` → `develop`.
 
+## Agent vs developer Git actions
+
+**Level 1 — Assisted:** Cursor/agents prepare commits, diffs, PR bodies,
+and checklists. The **developer executes** Git and GitHub write actions
+(`git commit`, `git push`, `gh pr create`, review replies, merge) manually
+after explicit approval in the current conversation (`AGENTS.md` Section 14).
+
+## Planning sources
+
+| Document | Purpose |
+|----------|---------|
+| [`dev-tracker.md`](dev-tracker.md) + [`dev-tracker.json`](dev-tracker.json) | Canonical planned work and tracker state |
+| [`maintenance-dashboard.md`](maintenance-dashboard.md) | Short operational view — not a second roadmap |
+| [`agent-rules-backlog.md`](agent-rules-backlog.md) | Future **AI rule** candidates only |
+| [`modernization-backlog.md`](modernization-backlog.md) | Larger modernization queue |
+
+Follow-up work discovered during a task belongs in the appropriate tracker
+or backlog (Section 15.26), not only in PR comments.
+
+## Concise communication
+
+PR titles and commit subjects: Conventional Commits, English, imperative,
+≤ 72 characters (`AGENTS.md` Section 3).
+
+PR bodies should cover: **intent**, **scope**, **validation** (exact commands
+and results), **risk / rollback**, and **follow-up** (if any). Skip long
+file lists when `git diff --stat` suffices; skip implementation walkthroughs
+when the diff is self-explanatory.
+
+Review replies: one short English paragraph — what changed or why not applied,
+plus validation reference when relevant.
+
+Final agent reports (Sections 16.25, 18.19, 19.25): include branch, files,
+validation, risks, and next approval gate — omit repeated policy quotes.
+
+## Copilot review loop
+
+Before PR readiness (`AGENTS.md` Sections 14.4, 20.15):
+
+1. Inspect all Copilot and unresolved review threads.
+2. Classify each recommendation (accepted, rejected with reason, N/A, out of
+   scope, needs decision).
+3. Implement accepted items; reply in English before resolving.
+4. Ask developer approval before GitHub actions that post, resolve, or
+   re-request review (Section 15.25).
+5. Do not resolve threads to silence review or re-resolve without a new commit
+   or explicit developer direction.
+
+Loop is complete when every thread is handled **and** replies are posted or
+deferred with documented developer decision.
+
 ## Validation
 
 Validation tiers (`AGENTS.md` Section 14.2):

--- a/docs/maintainability-policy.md
+++ b/docs/maintainability-policy.md
@@ -50,7 +50,7 @@ If not done: **Ready for developer manual testing** (not commit approval).
 | low | docs, narrow isolated fix | focused validation |
 | medium | provider, Maven config, CI, dep patch/minor | targeted + full Maven |
 | high | dep major, Java migration, packaging, config migration | full + manual + review |
-| critical | security, release, DRM/auth, destructive migration | dedicated plan + decision |
+| critical | security, release, protected content/auth, destructive migration | dedicated plan + decision |
 
 ## Rollback plan (medium+)
 

--- a/docs/provider-policy.md
+++ b/docs/provider-policy.md
@@ -44,8 +44,8 @@ Document why metadata is missing. Do not claim support without validation.
 ## Protected content (tiered)
 
 Full rule: `AGENTS.md` Section 18.4. Governance:
-[tiered policy ADR](decision-log.md#-provider-drm-tiered-policy--tiered-drm-policy-for-providers),
-[residual risk](risk-register.md#provider-drm-circumvention--provider-drm-circumvention-residual-risk).
+[tiered policy ADR](decision-log.md#-provider-protected-content-tiered-policy--tiered-protected-content-policy-for-providers),
+[residual risk](risk-register.md#provider-protected-replay-residual--provider-protected-replay-residual-risk).
 
 **Default (maintainer has not requested protected-replay handling):**
 

--- a/docs/provider-policy.md
+++ b/docs/provider-policy.md
@@ -21,7 +21,7 @@ Update [`provider-inventory.md`](provider-inventory.md) and/or
 |--------|-------------|
 | working | tests + real behavior validated when feasible |
 | degraded | partial function or known gaps |
-| protected | auth, cookies, DRM, geoblocking, anti-bot |
+| protected | auth, encryption, geoblocking, anti-bot |
 | obsolete | dead/replaced endpoint |
 | removed | intentionally delisted |
 | unknown | not recently validated |
@@ -41,14 +41,91 @@ Document why metadata is missing. Do not claim support without validation.
 
 **Live checks:** supplementary only. If skipped, document reason.
 
-**Never:** bypass DRM; commit cookies, sessions, tokens, browser profiles.
+## Protected content (tiered)
+
+Full rule: `AGENTS.md` Section 18.4. Governance:
+[tiered policy ADR](decision-log.md#-provider-drm-tiered-policy--tiered-drm-policy-for-providers),
+[residual risk](risk-register.md#provider-drm-circumvention--provider-drm-circumvention-residual-risk).
+
+**Default (maintainer has not requested protected-replay handling):**
+
+- public discovery plus external downloaders (yt-dlp where applicable);
+- `protected` / `degraded` status for restricted replay;
+- sanitized failures when download is unavailable.
+
+**Maintainer-directed protected replay (opt-in):**
+
+Opt-in when the maintainer requests it in the **current conversation** **or**
+a **scoped provider PR** documents maintainer direction (tracker + PR scope).
+
+- Stremio-equivalent support in a **scoped provider PR** is allowed;
+- prefer external tools and user-local config; plugin helper scripts that
+  contain **logic only** (no secrets) may ship under `plugins/<name>/scripts/`;
+- optional paths may be **disabled until** user-local env/config is set;
+- document legal/ToS residual risk in the PR body;
+- Proposed or Accepted ADR update in the same batch is sufficient.
+
+**Allowed in source (provider plugins):**
+
+- public catalog, GraphQL/HTML parsers, offline fixtures;
+- auth and protected-replay **orchestration** (Java calling external helpers);
+- helper scripts or command builders with **no** embedded credentials or license
+  material;
+- provider-published public API identifiers when required for login.
+
+**Always forbidden in the repository:**
+
+License material, key material, sessions, tokens, browser profiles,
+shared credentials, hardcoded account passwords.
+
+## Site authentication for download
+
+Some providers require a **logged-in account** before a replay URL, manifest,
+or stream becomes available. This is separate from encryption-only protected
+streams (see [Protected content (tiered)](#protected-content-tiered) above).
+
+**Default (current Habitv scope):**
+
+- public catalog and replay pages that do not require login;
+- download delegated to yt-dlp or ffmpeg when URLs are already reachable;
+- auth-gated items marked `protected` or `degraded`;
+- clear sanitized failure when login is required and not configured.
+
+Habitv does **not** ship browser session import or an embedded browser in the
+default lifecycle.
+
+**When site authentication is required (maintainer-directed work):**
+
+Document the requirement in [`provider-inventory.md`](provider-inventory.md).
+May ship in the **same scoped provider PR** as public catalog when maintainer
+direction is documented. Prefer, in order:
+
+1. **User-local credentials** — account login or API tokens in local config
+   or environment variables only (never in git). Reference pattern: Stremio
+   TF1+ addons (`habitv-references/stremio-addon-tvlegal`).
+2. **External downloader auth** — yt-dlp `--username` / `--password` or
+   `.netrc` when the extractor supports it; user-configured paths only (see
+   [`ytdlp-cli-compatibility.md`](ytdlp-cli-compatibility.md)). Habitv does
+   not pass authentication flags by default.
+3. **Browser-mediated login** — when the provider only issues tokens after a
+   web flow:
+   - **Embedded browser** (CEF / CefSharp-style in-app login) — not in Habitv
+     today; needs a dedicated JavaFX/tooling tracker item;
+   - **System browser + manual step** — user logs in externally; session
+     material stays user-local only;
+   - **User-local automation** (Selenium, Playwright, etc.) — out of repo;
+     optional reference: `habitv-references/TF1-Downloader` (Firefox +
+     Selenium).
+
+Do not commit session exports, browser profiles, or credential files.
 
 ## External tools
 
-Tools: yt-dlp, ffmpeg, aria2, rclone, curl, rtmpdump.
+Tools: yt-dlp, ffmpeg, aria2, rclone, curl, rtmpdump, optional user-local
+helpers when maintainer-requested (see Section 18.4).
 
 Dedicated PRs for tool updates. No binaries in git unless requested. No mixing
-with provider behavior changes.
+unrelated provider behavior with dependency or CI changes.
 
 ### External tool update report
 
@@ -65,6 +142,37 @@ with provider behavior changes.
 * Validation:
 * Risk:
 ```
+
+## Public communication safety
+
+Provider/plugin **public text** (PR titles and bodies, commit messages,
+review comments, user-facing docs) must **not** expose unnecessary
+operational detail. Keep wording high-level so reviews stay safe and
+maintainers retain flexibility when endpoints change.
+
+**Avoid in public text:**
+
+- exact replay endpoints or undocumented API paths;
+- request headers, auth/session mechanics;
+- browser profile paths, token names, sensitive URL parameters;
+- selector chains, step-by-step extraction flows, bypass-like mechanics;
+- full provider-specific downloader command lines with auth or protected-content flags.
+
+**Prefer high-level wording:**
+
+- provider routing updated;
+- metadata parsing improved;
+- diagnostics clarified;
+- protected or auth-gated content fails gracefully;
+- offline fixture coverage added;
+- command construction covered by tests.
+
+Code, fixtures, and tests may contain technical detail **inside the
+repository** when required for offline validation — but PR/commit **narrative**
+should still summarize at this level unless the maintainer explicitly requests
+more detail in the current conversation.
+
+Canonical rule: `AGENTS.md` Section 20.14.
 
 ## Runtime diagnostics
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -45,7 +45,7 @@ added, mitigated, realized, or accepted.
 | `youtube-key-hardcoded` | Med | Med | 🟡 P2 | 🟢 Mitigated |
 | `pages-autoindex-gap` | Med | Med | 🟡 P2 | 🟢 Mitigated |
 | `silent-stat-ping` | Med | Med | 🟡 P2 | 🟡 Open |
-| `provider-drm-circumvention` | Med | Med | 🟡 P2 | 🟡 Accepted (residual) |
+| `provider-protected-replay-residual` | Med | Med | 🟡 P2 | 🟡 Accepted (residual) |
 
 ---
 
@@ -388,7 +388,7 @@ host once the flag ships.
 
 ---
 
-### `provider-drm-circumvention` — Provider DRM circumvention residual risk
+### `provider-protected-replay-residual` — Provider protected replay residual risk
 
 | | |
 |---|---|
@@ -401,7 +401,7 @@ Even when implemented outside default catalog PRs, this creates legal/ToS
 exposure, credential-handling risk, and high maintenance cost when providers
 rotate protection.
 
-**Mitigation** — `provider-drm-tiered-policy` ADR (Accepted, rev. 3): default
+**Mitigation** — `provider-protected-content-tiered-policy` ADR (Accepted, rev. 3): default
 work stays on public discovery plus yt-dlp; maintainer-directed scoped provider
 PRs may include optional auth/protected-replay delegation (disabled until
 user-local config); never commit license material, account passwords, or shared

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -19,7 +19,8 @@ added, mitigated, realized, or accepted.
 | 🟢 **Mitigated** | 7 |
 | 🔴 **Open / Critical (P0)** | 1 |
 | 🟠 **Open / High (P1)** | 5 |
-| 🟡 **Open / Medium (P2)** | 3 |
+| 🟡 **Open / Medium (P2)** | 2 |
+| 🟡 **Accepted (residual)** | 1 |
 | 🟢 **Open / Low (P3)** | 0 |
 | **Total tracked** | **16** |
 
@@ -415,6 +416,7 @@ credentials.
 | 🟢 Mitigated | Cause removed, secondary safeguards in place |
 | 🟠 Open / High | P0 / P1 — active threat to the buildable or shippable baseline |
 | 🟡 Open / Medium | P2 — needs action but not blocking the baseline |
+| 🟡 Accepted (residual) | Documented residual risk with ADR mitigations; monitored |
 | 🟢 Open / Low | P3 — known, accepted, monitored |
 | 🔴 Open / Critical | Realized incident or imminent breakage |
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -19,9 +19,9 @@ added, mitigated, realized, or accepted.
 | 🟢 **Mitigated** | 7 |
 | 🔴 **Open / Critical (P0)** | 1 |
 | 🟠 **Open / High (P1)** | 5 |
-| 🟡 **Open / Medium (P2)** | 2 |
+| 🟡 **Open / Medium (P2)** | 3 |
 | 🟢 **Open / Low (P3)** | 0 |
-| **Total tracked** | **15** |
+| **Total tracked** | **16** |
 
 ---
 
@@ -44,6 +44,7 @@ added, mitigated, realized, or accepted.
 | `youtube-key-hardcoded` | Med | Med | 🟡 P2 | 🟢 Mitigated |
 | `pages-autoindex-gap` | Med | Med | 🟡 P2 | 🟢 Mitigated |
 | `silent-stat-ping` | Med | Med | 🟡 P2 | 🟡 Open |
+| `provider-drm-circumvention` | Med | Med | 🟡 P2 | 🟡 Accepted (residual) |
 
 ---
 
@@ -383,6 +384,27 @@ legacy host.
 **Mitigation** — Plan a quarantine flag (`habitv.stat.enabled`,
 default `false`) under `legacy-url-migration`; remove the legacy
 host once the flag ships.
+
+---
+
+### `provider-drm-circumvention` — Provider DRM circumvention residual risk
+
+| | |
+|---|---|
+| **Status** | 🟡 Accepted (residual) |
+| **Likelihood** | Medium · **Impact** Medium · **Priority** 🟡 P2 |
+
+**Description** — Optional user-local protected-replay handling (license
+proxies, external helper tools) may be requested for providers such as TF1+.
+Even when implemented outside default catalog PRs, this creates legal/ToS
+exposure, credential-handling risk, and high maintenance cost when providers
+rotate protection.
+
+**Mitigation** — `provider-drm-tiered-policy` ADR (Accepted, rev. 3): default
+work stays on public discovery plus yt-dlp; maintainer-directed scoped provider
+PRs may include optional auth/protected-replay delegation (disabled until
+user-local config); never commit license material, account passwords, or shared
+credentials.
 
 ---
 

--- a/docs/ytdlp-cli-compatibility.md
+++ b/docs/ytdlp-cli-compatibility.md
@@ -30,8 +30,10 @@ Resolved at download time (`#VIDEO_URL#` → URL, `#FILE_DEST#` → output path)
 ```
 
 These flags are the subset Habitv relied on with youtube-dl; yt-dlp accepts them
-for the supported sites. Habitv does **not** pass DRM bypass, cookie, browser
-profile, or authentication flags.
+for the supported sites. Habitv does **not** pass protected-content, browser
+profile, or authentication flags by default (user may configure yt-dlp locally
+when an extractor supports login — see
+[`docs/provider-policy.md`](provider-policy.md#site-authentication-for-download)).
 
 ## Progress output
 

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -26,8 +26,13 @@ Full policy: [`docs/provider-policy.md`](../docs/provider-policy.md) and
 - Do not rely on live-network-only validation as proof of correctness.
 - Distinguish offline unit tests, live/network tests, and manual tests
   (Section 15.24).
-- If live tests are skipped (geoblocking, auth, DRM, rate limits), state
+- If live tests are skipped (geoblocking, auth, rate limits), state
   why clearly.
+- Protected content work: Section 18.4 and
+  [`docs/provider-policy.md`](../docs/provider-policy.md) (including
+  [site authentication for download](../docs/provider-policy.md#site-authentication-for-download)).
+- Keep provider **public text** high-level (Section 20.14); see
+  [`docs/provider-policy.md`](../docs/provider-policy.md#public-communication-safety).
 - Keep changes scoped to one provider or plugin module when possible.
 - No secrets, binaries, or manual JAXB/XML generated-file edits unless
   explicitly required (root `AGENTS.md` Sections 15.9, 15.12–15.13).


### PR DESCRIPTION
## Summary

Agent rules v1.5.1: streamline governance mirrors, add communication/Copilot guards, and relax protected-replay opt-in for scoped provider PRs (ADR rev. 3).

## Scope

ai-rules-streamline

## Related issue

- N/A

## Changes

- `AGENTS.md` v1.5.1 (§18.4, §20.13–§20.17), `docs/provider-policy.md`, decision log, changelog, mirrors.

## Validation

- `git diff --check` — passed
- Maven — skipped (docs-only)

## Rule drift audit v2

* Canonical owner table checked: yes (`docs/agent-rule-profiles.md`)
* Mirrors checked: `.cursor/rules/*`, `.github/copilot-instructions.md`, `.github/instructions/*`, `CLAUDE.md`, `GEMINI.md`, nested `AGENTS.md`
* Duplicate rules found: none
* Conflicting rules found: none
* Broken section references: fixed (§20.16 drift-audit cross-ref)
* Broken file links: fixed (`../../docs/` in instruction mirrors)
* Unique mandatory rules outside AGENTS.md: none
* Changelog/version aligned: yes (v1.5.1, changelog + backlog)
* Backlog/archive aligned: yes
* Actions taken: Copilot review fixes; ADR/risk slug rename
* Remaining risks: none for this docs scope

## Risk / rollback

- Revert PR if needed; no runtime impact.
