### PR TITLE
test: strengthen FranceTV category-order coverage

### DIFF
--- a/application/core/test/com/dabi/habitv/core/dao/GrabConfigDAOTest.java
+++ b/application/core/test/com/dabi/habitv/core/dao/GrabConfigDAOTest.java
@@ -150,6 +150,60 @@ public class GrabConfigDAOTest {
 	}
 
 	@Test
+	public final void updateGrabConfigPreservesOrderWhenNoCategoryOrderMetadata() {
+		Map<String, CategoryDTO> channel2Categories = buildChannelMap(true, false);
+		dao.saveGrabConfig(channel2Categories);
+		channel2Categories = buildChannelMap(false, true);
+		dao.updateGrabConfig(channel2Categories);
+
+		final List<String> orderAfterFirst = categoryNames(
+				dao.load(LoadModeEnum.ALL).get("channel1").getSubCategories());
+		assertEquals(Arrays.asList("cat1", "cat2"), orderAfterFirst);
+
+		dao.updateGrabConfig(channel2Categories);
+		final List<String> orderAfterSecond = categoryNames(
+				dao.load(LoadModeEnum.ALL).get("channel1").getSubCategories());
+		assertEquals(orderAfterFirst, orderAfterSecond);
+	}
+
+	@Test
+	public final void updateGrabConfigRepeatedFrancetvSyncIsIdempotent() throws IOException {
+		Files.copy(new File(STALE_FRANCETV_FIXTURE).toPath(), new File(XML_FILE).toPath(),
+				java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+		final Map<String, CategoryDTO> pluginTree = buildFreshFrancetvPluginTree();
+
+		dao.updateGrabConfig(pluginTree);
+		final List<String> orderAfterFirst = categoryNames(
+				findChild(dao.load(LoadModeEnum.ALL).get(FRANCETV_PLUGIN), PUBLIC_ROOT_NAME).getSubCategories());
+		assertEquals(EXPECTED_PUBLIC_HUB_ORDER, orderAfterFirst);
+
+		dao.updateGrabConfig(pluginTree);
+		final List<String> orderAfterSecond = categoryNames(
+				findChild(dao.load(LoadModeEnum.ALL).get(FRANCETV_PLUGIN), PUBLIC_ROOT_NAME).getSubCategories());
+		assertEquals(orderAfterFirst, orderAfterSecond);
+	}
+
+	@Test
+	public final void updateGrabConfigMarksRemovedHubDeletedAndAppendsAfterReorder() throws IOException {
+		Files.copy(new File(STALE_FRANCETV_FIXTURE).toPath(), new File(XML_FILE).toPath(),
+				java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+		dao.updateGrabConfig(buildFreshFrancetvPluginTree());
+
+		final Map<String, CategoryDTO> reducedTree = buildFreshFrancetvPluginTree();
+		final CategoryDTO publicRoot = findChild(reducedTree.get(FRANCETV_PLUGIN), PUBLIC_ROOT_NAME);
+		publicRoot.getSubCategories().remove(findChild(publicRoot, "Mieux"));
+		dao.updateGrabConfig(reducedTree);
+
+		final CategoryDTO mergedRoot = findChild(dao.load(LoadModeEnum.ALL).get(FRANCETV_PLUGIN), PUBLIC_ROOT_NAME);
+		final List<String> hubNames = categoryNames(mergedRoot.getSubCategories());
+		assertEquals(EXPECTED_PUBLIC_HUB_ORDER.size(), hubNames.size());
+		assertEquals(EXPECTED_PUBLIC_HUB_ORDER.subList(0, EXPECTED_PUBLIC_HUB_ORDER.size() - 1),
+				hubNames.subList(0, EXPECTED_PUBLIC_HUB_ORDER.size() - 1));
+		assertEquals("Mieux", hubNames.get(hubNames.size() - 1));
+		assertEquals(StatusEnum.DELETED, findChild(mergedRoot, "Mieux").getState());
+	}
+
+	@Test
 	public final void updateGrabConfigSkipsCategoriesWithoutIdAndRemainsSchemaValid() throws IOException {
 		Files.copy(new File(STALE_FRANCETV_FIXTURE).toPath(), new File(XML_FILE).toPath(),
 				java.nio.file.StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
## Related issue

None

## Scope

francetv-category-order-test-coverage

## Summary

Add deterministic offline tests for the category-order synchronization behavior introduced with FranceTV public hub discovery.

No production code is changed by this pull request.

## Changes

- `GrabConfigDAOTest.updateGrabConfigPreservesOrderWhenNoCategoryOrderMetadata` — preserves existing XML category order when no category-order metadata is provided.
- `GrabConfigDAOTest.updateGrabConfigRepeatedFrancetvSyncIsIdempotent` — verifies repeated FranceTV synchronization is idempotent.
- `GrabConfigDAOTest.updateGrabConfigMarksRemovedHubDeletedAndAppendsAfterReorder` — verifies a removed public hub is marked DELETED, retained, and appended after the currently ordered hubs.

## Existing behavior under test

FranceTV supplies `publicHubOrder` through category parameters generated from `FranceTvConf.PUBLIC_ROOT_DISPLAY_ORDER`.

`GrabConfigDAO` uses this metadata to place plugin categories first, while retaining unmatched XML categories in their previous relative order. Providers without ordering metadata are not reordered.

Production implementation was already merged in PR #137 (`d904663a`).

## Validation

Pre-commit and post-commit (commit `4da0339f`):

- `mvn -B -ntp -pl application/core -am -Dtest=GrabConfigDAOTest -Dsurefire.failIfNoSpecifiedTests=false test` — SUCCESS; 8 run, 0 failures, 1 skipped (`testLoadOld` @Ignore)
- `mvn -B -ntp -pl application/core -am test` — SUCCESS; 89 run, 0 failures, 4 skipped
- `mvn -B -ntp -pl application/core -am -DskipTests verify` — SUCCESS
- `mvn -B -ntp -pl application/core -am verify` — SUCCESS
- `mvn -B -ntp verify` — SUCCESS (full reactor)

Skipped tests (pre-existing, unrelated): `testLoadOld`, `XMLUserConfigTest` (1), `DownloadTaskTest` (1), `TestListHttp` (1).

## Risk / rollback

Low risk. Test-only change. Revert commit `4da0339f` if needed.

## Notes

Known edge cases outside this PR: duplicate category names and blank-but-non-null ordering metadata are not modified by this test-only change.
