### PR TITLE
Fix CodeQL path injection findings in updater

### DIFF
--- a/application/core/test/com/dabi/habitv/core/updater/UpdateManagerPathIntegrationTest.java
+++ b/application/core/test/com/dabi/habitv/core/updater/UpdateManagerPathIntegrationTest.java
@@ -1,0 +1,227 @@
+package com.dabi.habitv.core.updater;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.dabi.habitv.api.plugin.pub.Subscriber;
+import com.dabi.habitv.core.event.UpdatePluginEvent;
+import com.dabi.habitv.core.event.UpdatePluginStateEnum;
+import com.dabi.habitv.framework.FrameworkConf;
+
+public class UpdateManagerPathIntegrationTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private String previousUpdateEnabled;
+	private String previousUpdateUrl;
+
+	private LocalTestHttpServer server;
+	private final Map<String, String> responses = new HashMap<>();
+
+	@Before
+	public void setUp() throws IOException {
+		previousUpdateEnabled = System.getProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY);
+		previousUpdateUrl = System.getProperty(FrameworkConf.UPDATE_URL_PROPERTY);
+		server = new LocalTestHttpServer(responses);
+		System.setProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY, "true");
+		System.setProperty(FrameworkConf.UPDATE_URL_PROPERTY,
+				"http://127.0.0.1:" + server.getPort() + "/repository/");
+	}
+
+	@After
+	public void tearDown() throws IOException {
+		restoreProperty(FrameworkConf.UPDATE_ENABLED_PROPERTY, previousUpdateEnabled);
+		restoreProperty(FrameworkConf.UPDATE_URL_PROPERTY, previousUpdateUrl);
+		if (server != null) {
+			server.stop();
+		}
+	}
+
+	@Test
+	public void validPluginEntryResolvesInsideTemporaryPluginFolder() throws Exception {
+		responses.put("/repository/plugins.txt", "arte\n");
+		final File pluginDir = temporaryFolder.newFolder("plugins");
+		final Path trustedRoot = pluginDir.toPath().toAbsolutePath().normalize();
+		final Path expectedArtifact = trustedRoot.resolve("arte.jar").normalize();
+		assertTrue(expectedArtifact.startsWith(trustedRoot));
+
+		final List<String> checkedPlugins = new ArrayList<>();
+		final AtomicBoolean completed = new AtomicBoolean(false);
+		final UpdateManager updateManager = new UpdateManager(pluginDir.getAbsolutePath(), true);
+		updateManager.getUpdatePublisher().attach(new Subscriber<UpdatePluginEvent>() {
+			@Override
+			public void update(final UpdatePluginEvent event) {
+				if (event.getState() == UpdatePluginStateEnum.CHECKING) {
+					checkedPlugins.add(event.getPlugin());
+				}
+				if (event.getState() == UpdatePluginStateEnum.ALL_DONE) {
+					completed.set(true);
+				}
+			}
+		});
+
+		updateManager.process();
+
+		assertTrue(completed.get());
+		assertEquals(1, checkedPlugins.size());
+		assertEquals("arte", checkedPlugins.get(0));
+		assertFalse(Files.exists(pluginDir.toPath().resolve("escape.jar")));
+	}
+
+	@Test
+	public void malformedThenValidPluginEntriesSkipTraversalAndContinue() throws Exception {
+		responses.put("/repository/plugins.txt", "../escape\narte\n");
+		final File pluginDir = temporaryFolder.newFolder("plugins");
+		final File outsideDir = temporaryFolder.newFolder("outside");
+		final Path outsideMarker = outsideDir.toPath().resolve("escape.jar");
+		Files.write(outsideMarker, "untouched".getBytes(StandardCharsets.UTF_8));
+
+		final List<String> checkedPlugins = new ArrayList<>();
+		final AtomicBoolean completed = new AtomicBoolean(false);
+		final UpdateManager updateManager = new UpdateManager(pluginDir.getAbsolutePath(), true);
+		updateManager.getUpdatePublisher().attach(new Subscriber<UpdatePluginEvent>() {
+			@Override
+			public void update(final UpdatePluginEvent event) {
+				if (event.getState() == UpdatePluginStateEnum.CHECKING) {
+					checkedPlugins.add(event.getPlugin());
+				}
+				if (event.getState() == UpdatePluginStateEnum.ALL_DONE) {
+					completed.set(true);
+				}
+			}
+		});
+
+		updateManager.process();
+
+		assertTrue(completed.get());
+		assertEquals(2, checkedPlugins.size());
+		assertEquals("../escape", checkedPlugins.get(0));
+		assertEquals("arte", checkedPlugins.get(1));
+		assertTrue(Files.exists(outsideMarker));
+		assertEquals("untouched", new String(Files.readAllBytes(outsideMarker), StandardCharsets.UTF_8));
+		assertFalse(Files.exists(pluginDir.toPath().resolve("escape.jar")));
+	}
+
+	private static void restoreProperty(final String key, final String previousValue) {
+		if (previousValue == null) {
+			System.clearProperty(key);
+		} else {
+			System.setProperty(key, previousValue);
+		}
+	}
+
+	private static final class LocalTestHttpServer {
+		private final ServerSocket serverSocket;
+		private final Thread acceptThread;
+		private final Map<String, String> responses;
+		private volatile boolean running = true;
+
+		private LocalTestHttpServer(final Map<String, String> responses) throws IOException {
+			this.responses = responses;
+			serverSocket = new ServerSocket();
+			serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
+			acceptThread = new Thread(new Runnable() {
+				@Override
+				public void run() {
+					while (running) {
+						try {
+							handleClient(serverSocket.accept());
+						} catch (IOException e) {
+							if (running) {
+								// ignore transient accept errors during shutdown
+							}
+						}
+					}
+				}
+			}, "UpdateManagerPathIntegrationTest-http");
+			acceptThread.setDaemon(true);
+			acceptThread.start();
+		}
+
+		private int getPort() {
+			return serverSocket.getLocalPort();
+		}
+
+		private void stop() throws IOException {
+			running = false;
+			serverSocket.close();
+			acceptThread.interrupt();
+		}
+
+		private void handleClient(final Socket client) {
+			try {
+				final BufferedReader reader = new BufferedReader(
+						new InputStreamReader(client.getInputStream(), "US-ASCII"));
+				final String requestLine = reader.readLine();
+				if (requestLine == null) {
+					return;
+				}
+				String line;
+				while ((line = reader.readLine()) != null && !line.isEmpty()) {
+					// consume request headers
+				}
+				final String path = parseRequestPath(requestLine);
+				final String body = responses.get(path);
+				final OutputStream out = client.getOutputStream();
+				if (body == null) {
+					writeHttpResponse(out, 404, "Not Found", new byte[0], "text/plain; charset=UTF-8");
+				} else {
+					final byte[] payload = body.getBytes("UTF-8");
+					writeHttpResponse(out, 200, "OK", payload, "text/plain; charset=UTF-8");
+				}
+			} catch (IOException e) {
+				// ignore client handling errors for test fixture robustness
+			} finally {
+				try {
+					client.close();
+				} catch (IOException e) {
+					// ignore close errors
+				}
+			}
+		}
+
+		private static String parseRequestPath(final String requestLine) {
+			final String[] parts = requestLine.split(" ");
+			if (parts.length < 2) {
+				return "/";
+			}
+			return parts[1];
+		}
+
+		private static void writeHttpResponse(final OutputStream out, final int statusCode, final String statusText,
+				final byte[] payload, final String contentType) throws IOException {
+			final String headers = "HTTP/1.1 " + statusCode + " " + statusText + "\r\n"
+					+ "Content-Type: " + contentType + "\r\n"
+					+ "Content-Length: " + payload.length + "\r\n"
+					+ "Connection: close\r\n\r\n";
+			out.write(headers.getBytes("US-ASCII"));
+			out.write(payload);
+			out.flush();
+		}
+	}
+}

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/InvalidUpdatePathException.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/InvalidUpdatePathException.java
@@ -1,0 +1,14 @@
+package com.dabi.habitv.framework.plugin.utils.update;
+
+/**
+ * Thrown when remote or caller-supplied update metadata would resolve outside
+ * the trusted updater root or otherwise violate path safety rules.
+ */
+public class InvalidUpdatePathException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public InvalidUpdatePathException(final String message) {
+		super(message);
+	}
+}

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/InvalidUpdatePathException.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/InvalidUpdatePathException.java
@@ -11,4 +11,8 @@ public class InvalidUpdatePathException extends RuntimeException {
 	public InvalidUpdatePathException(final String message) {
 		super(message);
 	}
+
+	public InvalidUpdatePathException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/UpdatePathValidator.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/UpdatePathValidator.java
@@ -1,6 +1,7 @@
 package com.dabi.habitv.framework.plugin.utils.update;
 
 import java.io.File;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.regex.Pattern;
@@ -11,6 +12,8 @@ import java.util.regex.Pattern;
  * must pass through this boundary.
  */
 public final class UpdatePathValidator {
+
+	private static final String WINDOWS_FORBIDDEN_FILENAME_CHARS = "<>:\"|?*";
 
 	private static final Pattern WINDOWS_DRIVE_PATH = Pattern.compile("^[A-Za-z]:[/\\\\].*");
 
@@ -55,7 +58,7 @@ public final class UpdatePathValidator {
 		if (value.indexOf('/') >= 0 || value.indexOf('\\') >= 0) {
 			throw new InvalidUpdatePathException("Rejected " + fieldName + " containing path separators.");
 		}
-		rejectParentDirectorySegments(value, fieldName);
+		rejectWindowsForbiddenFilenameCharacters(value, fieldName);
 		if (value.startsWith("/") || value.startsWith("\\")) {
 			throw new InvalidUpdatePathException("Rejected absolute " + fieldName + " path.");
 		}
@@ -65,17 +68,14 @@ public final class UpdatePathValidator {
 		if (UNC_PATH.matcher(value).matches()) {
 			throw new InvalidUpdatePathException("Rejected UNC " + fieldName + " path.");
 		}
-		final Path candidate = Paths.get(value);
+		final Path candidate = parsePath(value, fieldName);
+		rejectParentDirectorySegments(candidate, fieldName);
 		if (candidate.isAbsolute()) {
 			throw new InvalidUpdatePathException("Rejected absolute " + fieldName + " path.");
 		}
 	}
 
-	private static void rejectParentDirectorySegments(final String value, final String fieldName) {
-		if (".".equals(value) || "..".equals(value)) {
-			throw new InvalidUpdatePathException("Rejected parent-directory " + fieldName + " value.");
-		}
-		final Path candidate = Paths.get(value);
+	private static void rejectParentDirectorySegments(final Path candidate, final String fieldName) {
 		for (int i = 0; i < candidate.getNameCount(); i++) {
 			final String segment = candidate.getName(i).toString();
 			if (".".equals(segment) || "..".equals(segment)) {
@@ -99,6 +99,23 @@ public final class UpdatePathValidator {
 			}
 		}
 		return sanitized.toString();
+	}
+
+	private static void rejectWindowsForbiddenFilenameCharacters(final String value, final String fieldName) {
+		for (int i = 0; i < value.length(); i++) {
+			if (WINDOWS_FORBIDDEN_FILENAME_CHARS.indexOf(value.charAt(i)) >= 0) {
+				throw new InvalidUpdatePathException(
+						"Rejected " + fieldName + " containing Windows-forbidden filename characters.");
+			}
+		}
+	}
+
+	private static Path parsePath(final String value, final String fieldName) {
+		try {
+			return Paths.get(value);
+		} catch (final InvalidPathException e) {
+			throw new InvalidUpdatePathException("Rejected invalid " + fieldName + " path.", e);
+		}
 	}
 
 	private static void ensureUnderTrustedRoot(final Path normalizedRoot, final Path resolved,

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/UpdatePathValidator.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/UpdatePathValidator.java
@@ -1,0 +1,121 @@
+package com.dabi.habitv.framework.plugin.utils.update;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+/**
+ * Validates updater-controlled path components before they are used in local
+ * filesystem operations. Remote plugin lists, manifests and artifact metadata
+ * must pass through this boundary.
+ */
+public final class UpdatePathValidator {
+
+	private static final Pattern WINDOWS_DRIVE_PATH = Pattern.compile("^[A-Za-z]:[/\\\\].*");
+
+	private static final Pattern UNC_PATH = Pattern.compile("^[/\\\\]{2}[^/\\\\]+[/\\\\].*");
+
+	private UpdatePathValidator() {
+	}
+
+	public static Path resolveArtifactFile(final File trustedRootDir, final String artifactId, final String extension) {
+		validateFilenameComponent(artifactId, "artifactId");
+		validateFilenameComponent(extension, "extension");
+		final Path normalizedRoot = normalizeTrustedRoot(trustedRootDir);
+		final Path resolved = normalizedRoot.resolve(artifactId + "." + extension).normalize();
+		ensureUnderTrustedRoot(normalizedRoot, resolved, artifactId + "." + extension);
+		return resolved;
+	}
+
+	public static Path resolveDownloadTempFile(final Path validatedArtifactFile, final Path normalizedRoot) {
+		if (validatedArtifactFile == null) {
+			throw new InvalidUpdatePathException("Validated artifact path is required.");
+		}
+		final Path resolved = validatedArtifactFile.resolveSibling(
+				validatedArtifactFile.getFileName().toString() + ".tmp").normalize();
+		ensureUnderTrustedRoot(normalizedRoot, resolved, validatedArtifactFile.getFileName() + ".tmp");
+		return resolved;
+	}
+
+	public static Path normalizeTrustedRoot(final File trustedRootDir) {
+		if (trustedRootDir == null) {
+			throw new InvalidUpdatePathException("Trusted updater root is required.");
+		}
+		return trustedRootDir.toPath().toAbsolutePath().normalize();
+	}
+
+	public static void validateFilenameComponent(final String value, final String fieldName) {
+		if (value == null || value.trim().isEmpty()) {
+			throw new InvalidUpdatePathException("Rejected blank " + fieldName + " for updater path resolution.");
+		}
+		if (containsUnsafeControlCharacter(value)) {
+			throw new InvalidUpdatePathException("Rejected " + fieldName + " containing unsafe control characters.");
+		}
+		if (value.indexOf('/') >= 0 || value.indexOf('\\') >= 0) {
+			throw new InvalidUpdatePathException("Rejected " + fieldName + " containing path separators.");
+		}
+		rejectParentDirectorySegments(value, fieldName);
+		if (value.startsWith("/") || value.startsWith("\\")) {
+			throw new InvalidUpdatePathException("Rejected absolute " + fieldName + " path.");
+		}
+		if (WINDOWS_DRIVE_PATH.matcher(value).matches()) {
+			throw new InvalidUpdatePathException("Rejected Windows drive-qualified " + fieldName + " path.");
+		}
+		if (UNC_PATH.matcher(value).matches()) {
+			throw new InvalidUpdatePathException("Rejected UNC " + fieldName + " path.");
+		}
+		final Path candidate = Paths.get(value);
+		if (candidate.isAbsolute()) {
+			throw new InvalidUpdatePathException("Rejected absolute " + fieldName + " path.");
+		}
+	}
+
+	private static void rejectParentDirectorySegments(final String value, final String fieldName) {
+		if (".".equals(value) || "..".equals(value)) {
+			throw new InvalidUpdatePathException("Rejected parent-directory " + fieldName + " value.");
+		}
+		final Path candidate = Paths.get(value);
+		for (int i = 0; i < candidate.getNameCount(); i++) {
+			final String segment = candidate.getName(i).toString();
+			if (".".equals(segment) || "..".equals(segment)) {
+				throw new InvalidUpdatePathException(
+						"Rejected parent-directory segment in " + fieldName + " path.");
+			}
+		}
+	}
+
+	public static String sanitizeForLog(final String value) {
+		if (value == null) {
+			return "<null>";
+		}
+		final StringBuilder sanitized = new StringBuilder(value.length());
+		for (int i = 0; i < value.length(); i++) {
+			final char current = value.charAt(i);
+			if (current == '\r' || current == '\n' || current < 0x20 || current == 0x7F) {
+				sanitized.append('?');
+			} else {
+				sanitized.append(current);
+			}
+		}
+		return sanitized.toString();
+	}
+
+	private static void ensureUnderTrustedRoot(final Path normalizedRoot, final Path resolved,
+			final String describedValue) {
+		if (!resolved.startsWith(normalizedRoot)) {
+			throw new InvalidUpdatePathException(
+					"Rejected updater path outside trusted root for value \"" + sanitizeForLog(describedValue) + "\".");
+		}
+	}
+
+	private static boolean containsUnsafeControlCharacter(final String value) {
+		for (int i = 0; i < value.length(); i++) {
+			final char current = value.charAt(i);
+			if (current < 0x20 || current == 0x7F) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/Updater.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/Updater.java
@@ -116,7 +116,7 @@ public abstract class Updater {
 				onUpdateError(current, artifactNewVersion);
 				throw new TechnicalException(e);
 			}
-			updateFile(currentPath, tempPath);
+			updateFile(current, tempPath.toFile());
 
 			onUpdateDone(current, artifactNewVersion);
 		}
@@ -131,20 +131,9 @@ public abstract class Updater {
 	protected abstract boolean performUpdate(File current, ArtifactVersion artifactNewVersion);
 
 	protected void updateFile(final File current, final File newVersion) {
-		updateFile(current.toPath(), newVersion.toPath());
-	}
-
-	protected void updateFile(final Path current, final Path newVersion) {
-		if (Files.exists(newVersion)) {
-			if (Files.exists(current)) {
-				try {
-					Files.delete(current);
-				} catch (final IOException e) {
-					throw new TechnicalException(e);
-				}
-			}
+		if (newVersion.exists()) {
 			try {
-				Files.move(newVersion, current, StandardCopyOption.REPLACE_EXISTING);
+				Files.move(newVersion.toPath(), current.toPath(), StandardCopyOption.REPLACE_EXISTING);
 			} catch (final IOException e) {
 				throw new TechnicalException(e);
 			}

--- a/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/Updater.java
+++ b/fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/Updater.java
@@ -1,12 +1,14 @@
 package com.dabi.habitv.framework.plugin.utils.update;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
 
@@ -54,6 +56,10 @@ public abstract class Updater {
 		for (final String fileToUpdate : filesToUpdate) {
 			try {
 				updateFile(currentFolder, fileToUpdate);
+			} catch (final InvalidUpdatePathException e) {
+				LOG.warn("Skipping unsafe update entry for artifactId="
+						+ UpdatePathValidator.sanitizeForLog(fileToUpdate) + " under root "
+						+ UpdatePathValidator.sanitizeForLog(folderToUpdate) + ": " + e.getMessage());
 			} catch (final Exception e) {
 				LOG.error("", e);
 			}
@@ -65,24 +71,28 @@ public abstract class Updater {
 
 	private void updateFile(final File currentFolder, final String fileToUpdate) {
 		onChecking(fileToUpdate);
-		LOG.info("Resolving update artifact: artifactId=" + fileToUpdate + ", extension=" + getServerExtension());
+		final Path trustedRoot = UpdatePathValidator.normalizeTrustedRoot(currentFolder);
+		final Path currentPath = UpdatePathValidator.resolveArtifactFile(currentFolder, fileToUpdate, getLocalExtension());
+		LOG.info("Resolving update artifact: artifactId=" + UpdatePathValidator.sanitizeForLog(fileToUpdate)
+				+ ", extension=" + getLocalExtension());
 		final ArtifactVersion artifactNewVersion = FindArtifactUtils.findLastVersionUrl(groupId, fileToUpdate, coreVersion,
 				autoriseSnapshot, getServerExtension());
 		if (artifactNewVersion == null) {
-			LOG.warn("Skipping artifact " + fileToUpdate + " because no downloadable URL could be resolved.");
+			LOG.warn("Skipping artifact " + UpdatePathValidator.sanitizeForLog(fileToUpdate)
+					+ " because no downloadable URL could be resolved.");
 			return;
 		}
-		LOG.info("Resolved artifact " + fileToUpdate + " from " + artifactNewVersion.getSource()
-				+ " with version " + artifactNewVersion.getVersion() + " at " + artifactNewVersion.getUrl());
-		final File currentFile = new File(folderToUpdate + "/" + fileToUpdate + "." + getLocalExtension());
+		LOG.info("Resolved artifact " + UpdatePathValidator.sanitizeForLog(fileToUpdate) + " from "
+				+ artifactNewVersion.getSource() + " with version " + artifactNewVersion.getVersion());
+		final File currentFile = currentPath.toFile();
 		if (currentFile.exists()) {
-			final String currentVersion = getCurrentVersion(currentFile);//
+			final String currentVersion = getCurrentVersion(currentFile);
 			if (currentVersion == null || currentVersion.contains("-SNAPSHOT")
 					|| AlphanumComparator.INSTANCE.compare(currentVersion, artifactNewVersion.getVersion()) < 0) {
-				updateFile(artifactNewVersion, currentFile);
+				updateFile(artifactNewVersion, currentPath, trustedRoot);
 			}
 		} else {
-			updateFile(artifactNewVersion, currentFile);
+			updateFile(artifactNewVersion, currentPath, trustedRoot);
 		}
 	}
 
@@ -94,18 +104,19 @@ public abstract class Updater {
 
 	protected abstract String getServerExtension();
 
-	private void updateFile(final ArtifactVersion artifactNewVersion, final File current) {
+	private void updateFile(final ArtifactVersion artifactNewVersion, final Path currentPath, final Path trustedRoot) {
+		final File current = currentPath.toFile();
 		if (performUpdate(current, artifactNewVersion)) {
 			onUpdate(current, artifactNewVersion);
-			File newVersion;
+			final Path tempPath = UpdatePathValidator.resolveDownloadTempFile(currentPath, trustedRoot);
 			try {
-				LOG.info("Downloading artifact from " + artifactNewVersion.getUrl() + " to " + current.getPath() + ".tmp");
-				newVersion = new File(downloadFile(artifactNewVersion.getUrl(), current.getPath() + ".tmp"));
+				LOG.info("Downloading artifact from " + artifactNewVersion.getUrl() + " to " + tempPath);
+				downloadFile(artifactNewVersion.getUrl(), tempPath);
 			} catch (final IOException e) {
 				onUpdateError(current, artifactNewVersion);
 				throw new TechnicalException(e);
 			}
-			updateFile(current, newVersion);
+			updateFile(currentPath, tempPath);
 
 			onUpdateDone(current, artifactNewVersion);
 		}
@@ -120,34 +131,43 @@ public abstract class Updater {
 	protected abstract boolean performUpdate(File current, ArtifactVersion artifactNewVersion);
 
 	protected void updateFile(final File current, final File newVersion) {
-		if (newVersion.exists()) {
-			if (current.exists()) {
+		updateFile(current.toPath(), newVersion.toPath());
+	}
+
+	protected void updateFile(final Path current, final Path newVersion) {
+		if (Files.exists(newVersion)) {
+			if (Files.exists(current)) {
 				try {
-					Files.delete(current.toPath());
+					Files.delete(current);
 				} catch (final IOException e) {
 					throw new TechnicalException(e);
 				}
 			}
-			newVersion.renameTo(current);
+			try {
+				Files.move(newVersion, current, StandardCopyOption.REPLACE_EXISTING);
+			} catch (final IOException e) {
+				throw new TechnicalException(e);
+			}
 		}
 	}
 
 	/**
 	 * Cette méthode télécharge un fichier sur internet et le stocke en local
-	 * 
+	 *
 	 * @param filePath
 	 *            , chemin du fichier à télécharger
 	 * @param destination
 	 *            , chemin du fichier en local
-	 * @return
 	 * @throws IOException
 	 */
-	private String downloadFile(final String filePath, final String destination) throws IOException {
+	private void downloadFile(final String filePath, final Path destination) throws IOException {
 		final URL website = new URL(filePath);
-		try (final ReadableByteChannel rbc = Channels.newChannel(website.openStream());) {
-			try (FileOutputStream fos = new FileOutputStream(destination);) {
-				fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
-				return destination;
+		try (final InputStream inputStream = website.openStream();
+				final ReadableByteChannel rbc = Channels.newChannel(inputStream)) {
+			try (java.nio.channels.FileChannel destinationChannel = java.nio.channels.FileChannel.open(destination,
+					java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE,
+					java.nio.file.StandardOpenOption.TRUNCATE_EXISTING)) {
+				destinationChannel.transferFrom(rbc, 0, Long.MAX_VALUE);
 			}
 		}
 	}

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdatePathValidatorTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdatePathValidatorTest.java
@@ -43,6 +43,24 @@ public class UpdatePathValidatorTest {
 	}
 
 	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsColonInArtifactId() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "bad:name", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsAsteriskInArtifactId() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "bad*name", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsQuestionMarkInArtifactId() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "bad?name", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
 	public void rejectsStandaloneParentDirectoryArtifactId() throws IOException {
 		final File root = temporaryFolder.newFolder("plugins");
 		UpdatePathValidator.resolveArtifactFile(root, "..", "jar");

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdatePathValidatorTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdatePathValidatorTest.java
@@ -1,0 +1,146 @@
+package com.dabi.habitv.framework.plugin.utils.update;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class UpdatePathValidatorTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void acceptsNormalJarFilename() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		final Path resolved = UpdatePathValidator.resolveArtifactFile(root, "youtube", "jar");
+		assertTrue(resolved.startsWith(root.toPath().toAbsolutePath().normalize()));
+		assertEquals("youtube.jar", resolved.getFileName().toString());
+	}
+
+	@Test
+	public void acceptsHyphenatedArtifactId() throws IOException {
+		final File root = temporaryFolder.newFolder("bin");
+		final Path resolved = UpdatePathValidator.resolveArtifactFile(root, "yt-dlp", "exe");
+		assertEquals("yt-dlp.exe", resolved.getFileName().toString());
+	}
+
+	@Test
+	public void acceptsConsecutiveDotsInsideArtifactId() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		final Path resolved = UpdatePathValidator.resolveArtifactFile(root, "plugin..backup", "jar");
+		assertEquals("plugin..backup.jar", resolved.getFileName().toString());
+		assertTrue(resolved.startsWith(root.toPath().toAbsolutePath().normalize()));
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsStandaloneParentDirectoryArtifactId() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "..", "jar");
+	}
+
+	@Test
+	public void tempFileStaysUnderTrustedRoot() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		final Path trustedRoot = UpdatePathValidator.normalizeTrustedRoot(root);
+		final Path artifact = UpdatePathValidator.resolveArtifactFile(root, "arte", "jar");
+		final Path temp = UpdatePathValidator.resolveDownloadTempFile(artifact, trustedRoot);
+		assertTrue(temp.startsWith(trustedRoot));
+		assertEquals("arte.jar.tmp", temp.getFileName().toString());
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsParentDirectoryTraversalUnix() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "../escape", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsParentDirectoryTraversalWindows() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "..\\escape", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsNestedParentDirectoryTraversal() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "dir/../../escape", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsAbsolutePosixPath() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "/absolute/escape", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsWindowsDriveBackslashPath() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "C:\\absolute\\escape", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsWindowsDriveForwardSlashPath() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "C:/absolute/escape", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsUncBackslashPath() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "\\\\server\\share\\escape", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsUncForwardSlashPath() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "//server/share/escape", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsBlankArtifactId() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "   ", "jar");
+	}
+
+	@Test(expected = InvalidUpdatePathException.class)
+	public void rejectsControlCharacterArtifactId() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		UpdatePathValidator.resolveArtifactFile(root, "bad\u0000name", "jar");
+	}
+
+	@Test
+	public void sanitizeForLogRemovesControlCharactersAndNewlines() {
+		assertEquals("bad?name", UpdatePathValidator.sanitizeForLog("bad\u0000name"));
+		assertEquals("line?injection", UpdatePathValidator.sanitizeForLog("line\rinjection"));
+		assertFalse(UpdatePathValidator.sanitizeForLog("line\rinjection").contains("\r"));
+		assertFalse(UpdatePathValidator.sanitizeForLog("line\ninjection").contains("\n"));
+	}
+
+	@Test
+	public void invalidEntryDoesNotCreateFilesOutsideTrustedRoot() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		final File outside = temporaryFolder.newFolder("outside");
+		final Path outsideMarker = outside.toPath().resolve("escape.jar");
+		Files.write(outsideMarker, "marker".getBytes(StandardCharsets.UTF_8));
+
+		try {
+			UpdatePathValidator.resolveArtifactFile(root, "../outside/escape", "jar");
+		} catch (final InvalidUpdatePathException expected) {
+			// expected
+		}
+
+		assertTrue(Files.exists(outsideMarker));
+		assertEquals("marker", new String(Files.readAllBytes(outsideMarker), StandardCharsets.UTF_8));
+		assertFalse(Files.exists(root.toPath().resolve("escape.jar")));
+	}
+}

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdaterFileDispatchTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdaterFileDispatchTest.java
@@ -1,0 +1,410 @@
+package com.dabi.habitv.framework.plugin.utils.update;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.dabi.habitv.api.plugin.exception.TechnicalException;
+import com.dabi.habitv.framework.FrameworkConf;
+import com.dabi.habitv.framework.plugin.utils.update.FindArtifactUtils.ArtifactVersion;
+
+/**
+ * Regression tests for the protected {@code updateFile(File, File)} hook used by
+ * {@link ZipExeUpdater} and other updater subclasses.
+ */
+public class UpdaterFileDispatchTest {
+
+	private static final String GROUP_ID = "com.dabi.habitv";
+	private static final String ARTIFACT_ID = "testtool";
+	private static final String ARTIFACT_VERSION = "4.1.0";
+	private static final String RELATIVE_JAR = "com/dabi/habitv/testtool/4.1.0/testtool-4.1.0.jar";
+	private static final String DOWNLOAD_PAYLOAD = "downloaded-artifact-bytes";
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private String previousUpdateUrl;
+	private LocalTestHttpServer server;
+	private final Map<String, String> responses = new HashMap<>();
+
+	@Before
+	public void setUp() throws IOException {
+		previousUpdateUrl = System.getProperty(FrameworkConf.UPDATE_URL_PROPERTY);
+		server = new LocalTestHttpServer(responses);
+		System.setProperty(FrameworkConf.UPDATE_URL_PROPERTY,
+				"http://127.0.0.1:" + server.getPort() + "/repository/");
+		FindArtifactUtils.clearManifestCache();
+	}
+
+	@After
+	public void tearDown() throws IOException {
+		if (previousUpdateUrl == null) {
+			System.clearProperty(FrameworkConf.UPDATE_URL_PROPERTY);
+		} else {
+			System.setProperty(FrameworkConf.UPDATE_URL_PROPERTY, previousUpdateUrl);
+		}
+		FindArtifactUtils.clearManifestCache();
+		if (server != null) {
+			server.stop();
+		}
+	}
+
+	@Test
+	public void postDownloadFlowInvokesFileBasedUpdateFileOverride() throws Exception {
+		addManifestEntry();
+		responses.put("/repository/" + RELATIVE_JAR, DOWNLOAD_PAYLOAD);
+
+		final File root = temporaryFolder.newFolder("bin");
+		final Path trustedRoot = root.toPath().toAbsolutePath().normalize();
+		final RecordingUpdater updater = new RecordingUpdater(root.getAbsolutePath());
+
+		updater.update(ARTIFACT_ID);
+
+		assertEquals("Subclass updateFile(File, File) must be invoked after download", 1,
+				updater.getFileUpdateCallCount());
+		assertTrue("Downloaded temp must stay under trusted root",
+				updater.getLastNewVersion().getAbsolutePath().startsWith(trustedRoot.toString()));
+		assertEquals(DOWNLOAD_PAYLOAD,
+				new String(Files.readAllBytes(updater.getLastNewVersion().toPath()), StandardCharsets.UTF_8));
+		assertFalse("Destination must not receive a raw move when override handles the archive",
+				Files.exists(trustedRoot.resolve("testtool.jar")));
+	}
+
+	@Test
+	public void unzipStyleFileOverrideExtractsArchiveInsteadOfMovingIt() throws Exception {
+		addManifestEntry();
+		responses.put("/repository/" + RELATIVE_JAR, "zip-archive-bytes");
+
+		final File root = temporaryFolder.newFolder("bin");
+		final Path trustedRoot = root.toPath().toAbsolutePath().normalize();
+		final UnzipStyleUpdater updater = new UnzipStyleUpdater(root.getAbsolutePath());
+
+		updater.update(ARTIFACT_ID);
+
+		assertTrue("ZipExeUpdater-style override must run", updater.isUnzipStyleOverrideCalled());
+		assertTrue(Files.exists(trustedRoot.resolve("extracted-marker.txt")));
+		assertEquals("zip-archive-bytes",
+				new String(Files.readAllBytes(trustedRoot.resolve("extracted-marker.txt")), StandardCharsets.UTF_8));
+		assertFalse(Files.exists(trustedRoot.resolve("testtool.jar")));
+		assertFalse(Files.exists(trustedRoot.resolve("testtool.jar.tmp")));
+	}
+
+	@Test
+	public void defaultUpdateFileReplacesDestinationWithoutPreDelete() throws Exception {
+		final File root = temporaryFolder.newFolder("plugins");
+		final File current = new File(root, "tool.jar");
+		Files.write(current.toPath(), "old".getBytes(StandardCharsets.UTF_8));
+		final File temp = new File(root, "tool.jar.tmp");
+		Files.write(temp.toPath(), "new".getBytes(StandardCharsets.UTF_8));
+
+		final DefaultUpdateFileUpdater updater = new DefaultUpdateFileUpdater(root.getAbsolutePath());
+		updater.invokeDefaultUpdateFile(current, temp);
+
+		assertEquals("new", new String(Files.readAllBytes(current.toPath()), StandardCharsets.UTF_8));
+		assertFalse(temp.exists());
+	}
+
+	private void addManifestEntry() {
+		responses.put("/repository/habitv-update-manifest.properties",
+				"plugin|" + GROUP_ID + "|" + ARTIFACT_ID + "|" + ARTIFACT_VERSION + "|jar|" + RELATIVE_JAR + "\n");
+	}
+
+	private static final class RecordingUpdater extends Updater {
+
+		private int fileUpdateCallCount;
+		private File lastNewVersion;
+
+		RecordingUpdater(final String folderToUpdate) {
+			super(folderToUpdate, GROUP_ID, "4.1.0-SNAPSHOT", true);
+		}
+
+		int getFileUpdateCallCount() {
+			return fileUpdateCallCount;
+		}
+
+		File getLastNewVersion() {
+			return lastNewVersion;
+		}
+
+		@Override
+		protected boolean deleteFiles() {
+			return false;
+		}
+
+		@Override
+		protected void onChecking(final String fileToUpdate) {
+		}
+
+		@Override
+		protected String getCurrentVersion(final File currentFile) {
+			return null;
+		}
+
+		@Override
+		protected String getLocalExtension() {
+			return "jar";
+		}
+
+		@Override
+		protected String getServerExtension() {
+			return "jar";
+		}
+
+		@Override
+		protected boolean performUpdate(final File current, final ArtifactVersion artifactVersion) {
+			return true;
+		}
+
+		@Override
+		protected void updateFile(final File current, final File newVersion) {
+			fileUpdateCallCount++;
+			lastNewVersion = newVersion;
+		}
+
+		@Override
+		protected void onUpdateError(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+
+		@Override
+		protected void onUpdateDone(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+
+		@Override
+		protected void onUpdate(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+	}
+
+	/**
+	 * Emulates {@link ZipExeUpdater}'s protected {@code updateFile(File, File)}
+	 * contract: extract archive contents and delete the temporary download.
+	 */
+	private static final class UnzipStyleUpdater extends Updater {
+
+		private boolean unzipStyleOverrideCalled;
+
+		UnzipStyleUpdater(final String folderToUpdate) {
+			super(folderToUpdate, GROUP_ID, "4.1.0-SNAPSHOT", true);
+		}
+
+		boolean isUnzipStyleOverrideCalled() {
+			return unzipStyleOverrideCalled;
+		}
+
+		@Override
+		protected boolean deleteFiles() {
+			return false;
+		}
+
+		@Override
+		protected void onChecking(final String fileToUpdate) {
+		}
+
+		@Override
+		protected String getCurrentVersion(final File currentFile) {
+			return null;
+		}
+
+		@Override
+		protected String getLocalExtension() {
+			return "jar";
+		}
+
+		@Override
+		protected String getServerExtension() {
+			return "jar";
+		}
+
+		@Override
+		protected boolean performUpdate(final File current, final ArtifactVersion artifactVersion) {
+			return true;
+		}
+
+		@Override
+		protected void updateFile(final File current, final File newVersion) {
+			unzipStyleOverrideCalled = true;
+			if (newVersion.exists()) {
+				try {
+					Files.write(new File(getFolderToUpdate(), "extracted-marker.txt").toPath(),
+							Files.readAllBytes(newVersion.toPath()));
+					Files.delete(newVersion.toPath());
+				} catch (final IOException e) {
+					throw new TechnicalException(e);
+				}
+			}
+		}
+
+		@Override
+		protected void onUpdateError(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+
+		@Override
+		protected void onUpdateDone(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+
+		@Override
+		protected void onUpdate(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+	}
+
+	private static final class DefaultUpdateFileUpdater extends Updater {
+
+		DefaultUpdateFileUpdater(final String folderToUpdate) {
+			super(folderToUpdate, GROUP_ID, "4.1.0-SNAPSHOT", false);
+		}
+
+		void invokeDefaultUpdateFile(final File current, final File newVersion) {
+			updateFile(current, newVersion);
+		}
+
+		@Override
+		protected boolean deleteFiles() {
+			return false;
+		}
+
+		@Override
+		protected void onChecking(final String fileToUpdate) {
+		}
+
+		@Override
+		protected String getCurrentVersion(final File currentFile) {
+			return null;
+		}
+
+		@Override
+		protected String getLocalExtension() {
+			return "jar";
+		}
+
+		@Override
+		protected String getServerExtension() {
+			return "jar";
+		}
+
+		@Override
+		protected boolean performUpdate(final File current, final ArtifactVersion artifactVersion) {
+			return false;
+		}
+
+		@Override
+		protected void onUpdateError(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+
+		@Override
+		protected void onUpdateDone(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+
+		@Override
+		protected void onUpdate(final File current, final ArtifactVersion artifactNewVersion) {
+		}
+	}
+
+	private static final class LocalTestHttpServer {
+		private final ServerSocket serverSocket;
+		private final Thread acceptThread;
+		private final Map<String, String> responses;
+		private volatile boolean running = true;
+
+		private LocalTestHttpServer(final Map<String, String> responses) throws IOException {
+			this.responses = responses;
+			serverSocket = new ServerSocket();
+			serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
+			acceptThread = new Thread(new Runnable() {
+				@Override
+				public void run() {
+					while (running) {
+						try {
+							handleClient(serverSocket.accept());
+						} catch (IOException e) {
+							if (running) {
+								// ignore transient accept errors during shutdown
+							}
+						}
+					}
+				}
+			}, "UpdaterFileDispatchTest-http");
+			acceptThread.setDaemon(true);
+			acceptThread.start();
+		}
+
+		private int getPort() {
+			return serverSocket.getLocalPort();
+		}
+
+		private void stop() throws IOException {
+			running = false;
+			serverSocket.close();
+			acceptThread.interrupt();
+		}
+
+		private void handleClient(final Socket client) {
+			try {
+				final BufferedReader reader = new BufferedReader(
+						new InputStreamReader(client.getInputStream(), "US-ASCII"));
+				final String requestLine = reader.readLine();
+				if (requestLine == null) {
+					return;
+				}
+				String line;
+				while ((line = reader.readLine()) != null && !line.isEmpty()) {
+					// consume request headers
+				}
+				final String path = parseRequestPath(requestLine);
+				final String body = responses.get(path);
+				final OutputStream out = client.getOutputStream();
+				if (body == null) {
+					writeHttpResponse(out, 404, "Not Found", new byte[0], "text/plain; charset=UTF-8");
+				} else {
+					final byte[] payload = body.getBytes("UTF-8");
+					writeHttpResponse(out, 200, "OK", payload, "text/plain; charset=UTF-8");
+				}
+			} catch (IOException e) {
+				// ignore client handling errors for test fixture robustness
+			} finally {
+				try {
+					client.close();
+				} catch (IOException e) {
+					// ignore close errors
+				}
+			}
+		}
+
+		private static String parseRequestPath(final String requestLine) {
+			final String[] parts = requestLine.split(" ");
+			if (parts.length < 2) {
+				return "/";
+			}
+			return parts[1];
+		}
+
+		private static void writeHttpResponse(final OutputStream out, final int statusCode, final String statusText,
+				final byte[] payload, final String contentType) throws IOException {
+			final String headers = "HTTP/1.1 " + statusCode + " " + statusText + "\r\n"
+					+ "Content-Type: " + contentType + "\r\n"
+					+ "Content-Length: " + payload.length + "\r\n"
+					+ "Connection: close\r\n\r\n";
+			out.write(headers.getBytes("US-ASCII"));
+			out.write(payload);
+			out.flush();
+		}
+	}
+}

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdaterPathValidationTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdaterPathValidationTest.java
@@ -61,6 +61,18 @@ public class UpdaterPathValidationTest {
 	}
 
 	@Test
+	public void continuesWithValidEntryAfterWindowsForbiddenCharacter() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		final TestUpdater updater = new TestUpdater(root.getAbsolutePath());
+		updater.update("bad:name", "arte");
+
+		assertEquals(2, updater.getCheckedArtifactIds().size());
+		assertEquals("bad:name", updater.getCheckedArtifactIds().get(0));
+		assertEquals("arte", updater.getCheckedArtifactIds().get(1));
+		assertTrue(containsSkippingUnsafeMessage());
+	}
+
+	@Test
 	public void continuesWithValidEntryAfterMalformedEntry() throws IOException {
 		final File root = temporaryFolder.newFolder("plugins");
 		final TestUpdater updater = new TestUpdater(root.getAbsolutePath());

--- a/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdaterPathValidationTest.java
+++ b/fwk/framework/test/com/dabi/habitv/framework/plugin/utils/update/UpdaterPathValidationTest.java
@@ -1,0 +1,159 @@
+package com.dabi.habitv.framework.plugin.utils.update;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class UpdaterPathValidationTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private final List<String> loggedMessages = new ArrayList<>();
+
+	private AppenderSkeleton appender;
+
+	@Before
+	public void setUp() {
+		appender = new AppenderSkeleton() {
+			@Override
+			protected void append(final LoggingEvent event) {
+				if (event.getLevel().isGreaterOrEqual(Level.WARN)) {
+					loggedMessages.add(event.getRenderedMessage());
+				}
+			}
+
+			@Override
+			public void close() {
+			}
+
+			@Override
+			public boolean requiresLayout() {
+				return false;
+			}
+		};
+		Logger.getLogger(Updater.class).addAppender(appender);
+	}
+
+	@After
+	public void tearDown() {
+		if (appender != null) {
+			Logger.getLogger(Updater.class).removeAppender(appender);
+		}
+	}
+
+	@Test
+	public void continuesWithValidEntryAfterMalformedEntry() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		final TestUpdater updater = new TestUpdater(root.getAbsolutePath());
+		updater.update("../outside/escape", "arte");
+
+		assertEquals(2, updater.getCheckedArtifactIds().size());
+		assertEquals("../outside/escape", updater.getCheckedArtifactIds().get(0));
+		assertEquals("arte", updater.getCheckedArtifactIds().get(1));
+		assertTrue(containsSkippingUnsafeMessage());
+	}
+
+	@Test
+	public void skipsUnsafeArtifactWithoutTouchingFilesOutsideRoot() throws IOException {
+		final File root = temporaryFolder.newFolder("plugins");
+		final File outside = temporaryFolder.newFolder("outside");
+		final Path outsideMarker = outside.toPath().resolve("escape.jar");
+		Files.write(outsideMarker, "safe".getBytes(StandardCharsets.UTF_8));
+
+		final TestUpdater updater = new TestUpdater(root.getAbsolutePath());
+		updater.update("../outside/escape");
+
+		assertTrue(Files.exists(outsideMarker));
+		assertFalse(Files.exists(root.toPath().resolve("escape.jar")));
+		assertTrue(containsSkippingUnsafeMessage());
+	}
+
+	private boolean containsSkippingUnsafeMessage() {
+		for (final String message : loggedMessages) {
+			if (message != null && message.contains("Skipping unsafe update entry")) {
+				assertFalse(message.contains("\r"));
+				assertFalse(message.contains("\n"));
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static final class TestUpdater extends Updater {
+
+		private final List<String> checkedArtifactIds = new ArrayList<>();
+
+		TestUpdater(final String folderToUpdate) {
+			super(folderToUpdate, "com.dabi.habitv", "4.1.0-SNAPSHOT", false);
+		}
+
+		List<String> getCheckedArtifactIds() {
+			return checkedArtifactIds;
+		}
+
+		@Override
+		protected boolean deleteFiles() {
+			return false;
+		}
+
+		@Override
+		protected void onChecking(final String fileToUpdate) {
+			checkedArtifactIds.add(fileToUpdate);
+		}
+
+		@Override
+		protected String getCurrentVersion(final java.io.File currentFile) {
+			return null;
+		}
+
+		@Override
+		protected String getLocalExtension() {
+			return "jar";
+		}
+
+		@Override
+		protected String getServerExtension() {
+			return "jar";
+		}
+
+		@Override
+		protected boolean performUpdate(final java.io.File current,
+				final FindArtifactUtils.ArtifactVersion artifactVersion) {
+			return false;
+		}
+
+		@Override
+		protected void onUpdateError(final java.io.File current,
+				final FindArtifactUtils.ArtifactVersion artifactNewVersion) {
+		}
+
+		@Override
+		protected void onUpdateDone(final java.io.File current,
+				final FindArtifactUtils.ArtifactVersion artifactNewVersion) {
+		}
+
+		@Override
+		protected void onUpdate(final java.io.File current,
+				final FindArtifactUtils.ArtifactVersion artifactNewVersion) {
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Centralize validation of updater-controlled filesystem paths so remote plugin
lists and manifest artifact identifiers cannot escape the configured plugin or
bin directory. Reject absolute paths, traversal segments, Windows-forbidden
filename characters, and paths outside trusted roots before any download,
delete, or move operation.

Follow-up commit `3b8b335e` addresses four Copilot review findings: restore
`updateFile(File, File)` dynamic dispatch for `ZipExeUpdater`, centralize
`InvalidPathException` handling, and remove delete-before-move in the default
replacement path.

## Scope

codeql-updater-path-validation

## Related issue

- N/A

## Changes

- Add `UpdatePathValidator` and `InvalidUpdatePathException` in `fwk/framework`.
- Validate artifact IDs in `Updater` before `FindArtifactUtils` and all filesystem sinks.
- Keep `JarUpdater` and `ZipExeUpdater` unchanged; subclasses inherit the validated
  path flow and the overridable `updateFile(File, File)` hook.
- Post-download flow invokes `updateFile(current, tempPath.toFile())` so
  `ZipExeUpdater` continues to unzip downloaded archives on Windows.
- Centralize path parsing in `parsePath()`; map `InvalidPathException` to
  `InvalidUpdatePathException` with cause preserved.
- Reject Windows-forbidden filename characters (`< > : " | ? *`) on all platforms.
- Default file replacement uses `Files.move(..., REPLACE_EXISTING)` without a
  pre-delete.
- Add cross-platform traversal regression tests in `fwk/framework`.
- Add `UpdaterFileDispatchTest` for post-download `File` dispatch, ZipExe-style
  unzip contract, and default replacement behavior.
- Add `UpdateManager` offline integration tests for valid and malformed
  `plugins.txt` entries.

## Commits

1. `e5a025ef` — `fix(security): constrain updater paths to trusted roots`
2. `3b8b335e` — `fix(security): address updater review findings`

**PR head:** `3b8b335e` (2 commits, 7 files, +1165 / −28 vs `develop`)

## Copilot review

Four inline comments on the initial commit were addressed in `3b8b335e`:

1. Subclass dispatch regression (`updateFile(Path, Path)` bypass) — fixed.
2. `validateFilenameComponent` uncaught `InvalidPathException` — fixed via `parsePath()`.
3. Duplicate `Paths.get` in `rejectParentDirectorySegments` — fixed; accepts parsed `Path`.
4. Delete-before-move in default replacement — fixed.

All four threads replied with SHA `3b8b335e`, resolved, and marked outdated after
the fix. No new Copilot review requested (anti-review-loop policy).

## Security impact

Remote update metadata (`plugins.txt`, update manifest fallback, plugin
`getFilesToUpdate()` values) is treated as untrusted. `UpdatePathValidator`
enforces filename-only artifact IDs, normalizes the trusted root, resolves
`artifactId.extension` beneath that root, and verifies
`resolved.startsWith(normalizedRoot)` before download temp files, deletes, or
moves. Unsafe entries are skipped per artifact with a sanitized warning.

Targeted CodeQL alerts on `develop`: #5–#12 (`java/path-injection` in
`Updater.java` / `JarUpdater.java`). **No open `java/path-injection` alerts**
on branch `fix/codeql-updater-path-validation` after `3b8b335e` (GitHub
code-scanning query). Definitive closure on `develop` requires merge.

## Validation

Local (on `3b8b335e`):

- `git -c core.whitespace=cr-at-eol show --check --oneline HEAD` → exit 0
- `mvn -B -ntp -pl fwk/framework test -Dtest=UpdatePathValidatorTest,UpdaterPathValidationTest,UpdaterFileDispatchTest -Dsurefire.failIfNoSpecifiedTests=false` → BUILD SUCCESS (**26** tests)
- `mvn -B -ntp -pl fwk/framework -am test` → BUILD SUCCESS (**70** tests)
- `mvn -B -ntp -pl application/core -am test -Dtest=UpdateManagerTest,UpdateManagerPathIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false` → BUILD SUCCESS (**6** tests)
- `mvn -B -ntp -DskipTests verify` → BUILD SUCCESS
- `mvn -B -ntp verify` → BUILD SUCCESS

CI on `3b8b335e` (all SUCCESS): Maven CI (Java 8/17/21, macOS), CodeQL Analyze
Java, CodeQL, SonarCloud, dependency-review, Snyk.

`Updater.java`: CRLF preserved (`i/crlf w/crlf`); logical diff +3 / −14 in
follow-up commit.

## Compatibility

Valid layouts preserved: simple artifact IDs (`youtube`, `yt-dlp`, `arte`) resolve
to `<trustedRoot>/<artifactId>.jar`. Consecutive dots inside a name (e.g.
`plugin..backup`) remain accepted. Existing per-entry error isolation and update
manager flow unchanged.

**Manual test before merge (recommended):** Windows yt-dlp update via
`ZipExeUpdater` — confirm ZIP is extracted and the expected executable is
installed under the trusted bin directory.

## Risk / rollback

- Risk: pre-existing symbolic links inside the trusted root are outside this PR
  scope.
- Rollback: revert commits `3b8b335e` and `e5a025ef`, or reset branch to
  `develop`.

## Notes

- No `.gitattributes` change in this security PR.
- No CodeQL suppressions or query exclusions.
- No `ZipExeUpdater.java` source change.
- Backup ref `backup/codeql-updater-path-validation-c93338d` kept local only.
- Merge via rebase/squash to keep linear history on `develop`.

## Checklist

- [x] Branch was created from `develop`
- [x] Duplicate-prevention checks completed before branch creation
- [x] No open PR already covered the same scope
- [x] No unrelated source changes
- [x] CRLF-compatible whitespace check passed on HEAD
- [x] `mvn -B -ntp verify` passed
- [x] PR keeps linear history (2 commits)
- [x] English used for branches, commits, comments, docs, and PR text
- [x] Copilot review threads handled (4/4 replied and resolved)
- [ ] Documentation tracker update deferred (security fix scope only)
- [x] No plugin version bumps
- [x] No secrets, tokens, local paths, or build outputs committed
- [ ] Manual Windows yt-dlp / ZipExeUpdater update test before merge
