### PR TITLE
ci(versioning): add advisory semver validation

### DIFF
--- a/.github/workflows/validate-versions.yml
+++ b/.github/workflows/validate-versions.yml
@@ -1,0 +1,135 @@
+name: Validate Versioning
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate-commit-format:
+    name: Validate Conventional Commit Format
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Get commit message
+        id: commit
+        run: |
+          COMMIT_MSG="$(git log -1 --pretty=%B)"
+          DELIMITER="COMMIT_MSG_$(date +%s%N)"
+          {
+            echo "message<<$DELIMITER"
+            echo "$COMMIT_MSG"
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate format
+        run: |
+          bash scripts/validate-conventional-commit.sh "${{ steps.commit.outputs.message }}"
+
+  validate-version-consistency:
+    name: Validate Version Bump Consistency
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Get commit details
+        id: commit
+        run: |
+          COMMIT_MSG="$(git log -1 --pretty=%B)"
+          FIRST_LINE="$(printf '%s\n' "$COMMIT_MSG" | head -n 1)"
+          COMMIT_TYPE="$(printf '%s\n' "$FIRST_LINE" | sed -nE 's/^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-zA-Z0-9._-]+\)!?: .+$/\1/p')"
+          if printf '%s\n' "$FIRST_LINE" | grep -qE '^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-zA-Z0-9._-]+\)!:'; then
+            COMMIT_TYPE="breaking-change"
+          elif printf '%s\n' "$COMMIT_MSG" | grep -q "BREAKING CHANGE:"; then
+            COMMIT_TYPE="breaking-change"
+          fi
+          echo "type=$COMMIT_TYPE" >> "$GITHUB_OUTPUT"
+
+      - name: Extract versions
+        id: version
+        run: |
+          CURRENT=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          if git rev-parse HEAD^ >/dev/null 2>&1; then
+            PREVIOUS=$(git show HEAD^:pom.xml | grep -m1 '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          else
+            PREVIOUS="$CURRENT"
+          fi
+          echo "previous=$PREVIOUS" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate expected bump
+        id: bump
+        run: |
+          COMMIT_TYPE="${{ steps.commit.outputs.type }}"
+          PREVIOUS="${{ steps.version.outputs.previous }}"
+          if [[ -z "$COMMIT_TYPE" ]]; then
+            echo "type=NONE" >> "$GITHUB_OUTPUT"
+            echo "expected=$PREVIOUS" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          OUTPUT=$(bash scripts/calculate-version-bump.sh "$COMMIT_TYPE" "$PREVIOUS")
+          BUMP_TYPE=$(echo "$OUTPUT" | cut -d'|' -f1)
+          EXPECTED_VERSION=$(echo "$OUTPUT" | cut -d'|' -f2)
+          echo "type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
+          echo "expected=$EXPECTED_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Report version consistency
+        run: |
+          echo "📋 Version Bump Report"
+          echo "─────────────────────"
+          echo "Commit type: ${{ steps.commit.outputs.type }}"
+          echo "Previous version: ${{ steps.version.outputs.previous }}"
+          echo "Current version in pom.xml: ${{ steps.version.outputs.current }}"
+          echo "Expected bump: ${{ steps.bump.outputs.type }} → ${{ steps.bump.outputs.expected }}"
+          echo ""
+
+          if [[ "${{ steps.bump.outputs.type }}" == "NONE" ]]; then
+            echo "ℹ️  No version bump required for this commit type"
+            exit 0
+          fi
+
+          if [[ "${{ steps.version.outputs.current }}" != "${{ steps.bump.outputs.expected }}" ]]; then
+            echo "⚠️  Version mismatch detected!"
+            echo "    Expected: ${{ steps.bump.outputs.expected }}"
+            echo "    Actual:   ${{ steps.version.outputs.current }}"
+            echo ""
+            echo "This is ADVISORY for now. Not blocking the build."
+            echo "Future: this will fail the build."
+          else
+            echo "✅ Version bump is consistent with commit type"
+          fi
+
+  run-unit-tests:
+    name: Run Versioning Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run versioning tests
+        run: bash tests/test-versioning.sh

--- a/.github/workflows/validate-versions.yml
+++ b/.github/workflows/validate-versions.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: validate-versioning-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
@@ -26,15 +30,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          # PR workflows check out a merge commit by default; validate the PR head instead.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Get commit message
         id: commit
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          COMMIT_MSG="$(git log -1 --pretty=%B)"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            COMMIT_MSG="$PR_TITLE"
+          else
+            COMMIT_MSG="$(git log -1 --pretty=%B)"
+          fi
           DELIMITER="COMMIT_MSG_$(date +%s%N)"
           {
             echo "message<<$DELIMITER"
@@ -60,11 +69,17 @@ jobs:
 
       - name: Get commit details
         id: commit
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          COMMIT_MSG="$(git log -1 --pretty=%B)"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            COMMIT_MSG="$PR_TITLE"
+          else
+            COMMIT_MSG="$(git log -1 --pretty=%B)"
+          fi
           FIRST_LINE="$(printf '%s\n' "$COMMIT_MSG" | head -n 1)"
-          COMMIT_TYPE="$(printf '%s\n' "$FIRST_LINE" | sed -nE 's/^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-zA-Z0-9._-]+\)!?: .+$/\1/p')"
-          if printf '%s\n' "$FIRST_LINE" | grep -qE '^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-zA-Z0-9._-]+\)!:'; then
+          COMMIT_TYPE="$(printf '%s\n' "$FIRST_LINE" | sed -nE 's/^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-z0-9\-]+\)!?: .+$/\1/p')"
+          if printf '%s\n' "$FIRST_LINE" | grep -qE '^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-z0-9\-]+\)!:'; then
             COMMIT_TYPE="breaking-change"
           elif printf '%s\n' "$COMMIT_MSG" | grep -q "BREAKING CHANGE:"; then
             COMMIT_TYPE="breaking-change"

--- a/.github/workflows/validate-versions.yml
+++ b/.github/workflows/validate-versions.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          # PR workflows check out a merge commit by default; validate the PR head instead.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -52,6 +54,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/validate-versions.yml
+++ b/.github/workflows/validate-versions.yml
@@ -78,8 +78,8 @@ jobs:
             COMMIT_MSG="$(git log -1 --pretty=%B)"
           fi
           FIRST_LINE="$(printf '%s\n' "$COMMIT_MSG" | head -n 1)"
-          COMMIT_TYPE="$(printf '%s\n' "$FIRST_LINE" | sed -nE 's/^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-z0-9\-]+\)!?: .+$/\1/p')"
-          if printf '%s\n' "$FIRST_LINE" | grep -qE '^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-z0-9\-]+\)!:'; then
+          COMMIT_TYPE="$(printf '%s\n' "$FIRST_LINE" | sed -nE 's/^(feat|fix|docs|test|refactor|perf|chore|ci|build|style|revert)\([a-z0-9\-]+\)!?: .+$/\1/p')"
+          if printf '%s\n' "$FIRST_LINE" | grep -qE '^(feat|fix|docs|test|refactor|perf|chore|ci|build|style|revert)\([a-z0-9\-]+\)!:'; then
             COMMIT_TYPE="breaking-change"
           elif printf '%s\n' "$COMMIT_MSG" | grep -q "BREAKING CHANGE:"; then
             COMMIT_TYPE="breaking-change"

--- a/.github/workflows/validate-versions.yml
+++ b/.github/workflows/validate-versions.yml
@@ -88,10 +88,16 @@ jobs:
 
       - name: Extract versions
         id: version
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           CURRENT=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-          if git rev-parse HEAD^ >/dev/null 2>&1; then
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA"
+            PREVIOUS=$(git show "${BASE_SHA}:pom.xml" | grep -m1 '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          elif git rev-parse HEAD^ >/dev/null 2>&1; then
             PREVIOUS=$(git show HEAD^:pom.xml | grep -m1 '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
           else
             PREVIOUS="$CURRENT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,10 +228,11 @@ scope**:
 ```
 
 **Types validated by CI scripts:** `feat`, `fix`, `docs`, `test`,
-`refactor`, `perf`, `chore`, `ci`, `build`.
+`refactor`, `perf`, `chore`, `ci`, `build`, `style`, `revert`.
 
-Section 3 also allows `style` and `revert` for repository policy; those
-types are not yet enforced by `scripts/validate-conventional-commit.sh`.
+`style` and `revert` map to **NONE** for parent POM bumps unless the
+commit is breaking (`type(scope)!:` or `BREAKING CHANGE:` footer), in
+which case pass `breaking-change` to the bump calculator.
 
 Validate locally:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ complement, but do not replace, the human review process.
 
 ## Agent rules metadata
 
-* **Version:** 1.5.1
-* **Last updated:** 2026-05-31
+* **Version:** 1.6.0
+* **Last updated:** 2026-06-18
 * **Maintainer:** repository maintainer
 * **Scope:** Habitv AI-assisted development workflow
 * **Canonical source:** `AGENTS.md`
@@ -207,6 +207,80 @@ Conventional Commits, English, imperative, lowercase, ≤ 72 chars.
 `chore`, `build`, `ci`, `style`, `revert`.
 
 **One logical change per commit.** Split any subject containing "and".
+
+### 3.1 Automated versioning with Conventional Commits
+
+**Purpose:** Manage parent POM semantic versioning (SemVer) from commit
+types. See ADR `automated-semver-versioning` in
+[`docs/decision-log.md`](docs/decision-log.md).
+
+#### Conventional Commits format (mandatory for validated commits)
+
+All commits **must** follow Conventional Commits 1.0.0 with a **required
+scope**:
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer: BREAKING CHANGE: ...]
+```
+
+**Types validated by CI scripts:** `feat`, `fix`, `docs`, `test`,
+`refactor`, `perf`, `chore`, `ci`, `build`.
+
+Section 3 also allows `style` and `revert` for repository policy; those
+types are not yet enforced by `scripts/validate-conventional-commit.sh`.
+
+Validate locally:
+
+```bash
+bash scripts/validate-conventional-commit.sh "<commit message>"
+```
+
+#### SemVer bump rules (parent POM)
+
+| Trigger | Bump |
+|---------|------|
+| `BREAKING CHANGE:` footer or `breaking-change` type | MAJOR |
+| `feat` | MINOR |
+| `fix`, `refactor`, `perf` | PATCH |
+| `chore`, `docs`, `test`, `ci`, `build` | NONE |
+
+Calculate expected version:
+
+```bash
+bash scripts/calculate-version-bump.sh <type> <current-version>
+# Output: BUMP_TYPE|NEW_VERSION  (e.g. MINOR|4.2.0-SNAPSHOT)
+```
+
+Plugin module version overrides remain governed by
+`plugin-versioning-policy` (independent of parent bumps).
+
+#### Agent workflow (mandatory)
+
+When preparing a commit that may require a parent version bump:
+
+1. Draft the Conventional Commit message (`type(scope): subject`).
+2. Read the current parent version from root `pom.xml`.
+3. Run `scripts/calculate-version-bump.sh` with the commit type.
+4. If the bump is `NONE`, do **not** change parent POM versions.
+5. If the bump is `MAJOR`, `MINOR`, or `PATCH`, update the root
+   `pom.xml` `<version>` and aligned reactor parent references to the
+   new version.
+6. Show `git status` and `git diff` for all version changes.
+7. **Wait for explicit developer approval** before committing.
+8. Never auto-commit or auto-push version bumps.
+
+CI workflow `.github/workflows/validate-versions.yml` runs advisory
+format/consistency checks and blocking unit tests for the scripts.
+
+Run unit tests locally:
+
+```bash
+bash tests/test-versioning.sh
+```
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,12 +241,17 @@ bash scripts/validate-conventional-commit.sh "<commit message>"
 
 #### SemVer bump rules (parent POM)
 
+Breaking-change signals **override** the normal type mapping. When any
+apply, pass `breaking-change` to `calculate-version-bump.sh`:
+
 | Trigger | Bump |
 |---------|------|
-| `BREAKING CHANGE:` footer or `breaking-change` type | MAJOR |
+| `type(scope)!: subject` | MAJOR |
+| `BREAKING CHANGE:` footer | MAJOR |
+| `breaking-change` type (agent/script input) | MAJOR |
 | `feat` | MINOR |
 | `fix`, `refactor`, `perf` | PATCH |
-| `chore`, `docs`, `test`, `ci`, `build` | NONE |
+| `chore`, `docs`, `test`, `ci`, `build`, `style`, `revert` | NONE |
 
 Calculate expected version:
 
@@ -262,9 +267,13 @@ Plugin module version overrides remain governed by
 
 When preparing a commit that may require a parent version bump:
 
-1. Draft the Conventional Commit message (`type(scope): subject`).
+1. Draft the Conventional Commit message (`type(scope): subject` or
+   `type(scope)!: subject`).
 2. Read the current parent version from root `pom.xml`.
-3. Run `scripts/calculate-version-bump.sh` with the commit type.
+3. Determine the bump input for `scripts/calculate-version-bump.sh`:
+   - If the header uses `type(scope)!: subject`, or the body contains
+     `BREAKING CHANGE:`, pass `breaking-change`.
+   - Otherwise pass the normal commit type (`feat`, `fix`, etc.).
 4. If the bump is `NONE`, do **not** change parent POM versions.
 5. If the bump is `MAJOR`, `MINOR`, or `PATCH`, update the root
    `pom.xml` `<version>` and aligned reactor parent references to the

--- a/docs/agent-rules-changelog.md
+++ b/docs/agent-rules-changelog.md
@@ -2,6 +2,21 @@
 
 Version history for Habitv AI agent rules. Canonical source: [`AGENTS.md`](../AGENTS.md).
 
+## 2026-06-18 — v1.6.0
+
+### Added
+
+* Automated SemVer versioning workflow (`AGENTS.md` §3.1).
+* Scripts: `validate-conventional-commit.sh`, `calculate-version-bump.sh`.
+* Unit tests: `tests/test-versioning.sh`.
+* Advisory CI workflow: `.github/workflows/validate-versions.yml`.
+* ADR `automated-semver-versioning` (Proposed).
+
+### Reason
+
+* Zero manual parent POM version management; agent proposes bumps, developer
+  approves before commit.
+
 ## 2026-05-31 — v1.5.1
 
 ### Added

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -674,8 +674,9 @@ under `plugin-versioning-policy`.
 
 - Parent version consistency becomes visible in CI before enforcement.
 - Format/consistency jobs may graduate to blocking after a soak period.
-- `style` and `revert` commit types remain outside script validation until
-  explicitly added.
+- `style` and `revert` are accepted by the validator and workflow;
+  they map to NONE unless breaking (`!` or `BREAKING CHANGE:`), which
+  maps to MAJOR.
 
 ---
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -28,6 +28,7 @@ older ones rather than rewriting them in place.
 | `plugin-versioning-policy` | When to bump a plugin `<version>` independently of the parent POM | 🟡 Proposed |
 | `jaxb-activation-dedup-defer` | Plan JAXB/Activation dedup before POM changes; defer namespace migration | 🟡 Proposed |
 | `provider-protected-content-tiered-policy` | Tiered protected content policy for provider and agent work | ✅ Accepted |
+| `automated-semver-versioning` | Automated SemVer from Conventional Commits with advisory CI | 🟡 Proposed |
 
 ---
 
@@ -639,6 +640,42 @@ protected replay support without agents refusing by default.
 - Maintainer-directed TF1+/Stremio-style protected replay work is allowed.
 - Residual legal, ToS, and maintenance risk stays under
   `provider-protected-replay-residual`.
+
+---
+
+## 🟡 `automated-semver-versioning` — Automated SemVer from Conventional Commits
+
+| | |
+|---|---|
+| **Status** | 🟡 Proposed |
+| **Date** | 2026-06-18 |
+| **Tracker** | `automated-semver-versioning` |
+| **Touches** | `AGENTS.md` §3.1, `scripts/`, `tests/`, `.github/workflows/validate-versions.yml` |
+| **Legacy code** | ADR-007 (informal reference only) |
+
+**Context** — Parent POM version bumps (`4.1.0-SNAPSHOT`, etc.) are
+manual and easy to forget. Habitv already mandates Conventional Commits
+in `AGENTS.md` §3 but had no tooling to compute SemVer bumps or validate
+format in CI.
+
+**Decision** — Add bash scripts to validate commit messages and compute
+SemVer bumps; unit tests; and a GitHub Actions workflow that:
+
+- runs **advisory** (non-blocking) commit-format and version-consistency
+  checks on `develop` / `master` pushes and PRs;
+- runs **blocking** unit tests for the scripts.
+
+Agents **propose** parent POM version bumps using
+`scripts/calculate-version-bump.sh`, show the diff, and **wait for
+developer approval** before committing. Plugin version overrides remain
+under `plugin-versioning-policy`.
+
+**Consequences**
+
+- Parent version consistency becomes visible in CI before enforcement.
+- Format/consistency jobs may graduate to blocking after a soak period.
+- `style` and `revert` commit types remain outside script validation until
+  explicitly added.
 
 ---
 

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "version": 3,
   "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync. Identifiers use descriptive kebab-case slugs (see descriptive-slug-ids ADR). Legacy HBTV codes are historical-only and not for new workflow naming.",
-  "lastRefresh": "2026-05-31",
+  "lastRefresh": "2026-06-18",
   "statusValues": [
     "proposed",
     "in-progress",
@@ -18,11 +18,11 @@
   ],
   "summary": {
     "done": 13,
-    "inProgress": 7,
+    "inProgress": 8,
     "proposed": 1,
     "deferred": 0,
     "blocked": 0,
-    "total": 21,
+    "total": 22,
     "overallProgressPercent": 80
   },
   "items": [
@@ -482,6 +482,30 @@
       ],
       "pr": "docs: add clean squash merge policy (this PR)",
       "notes": "Documentation and workflow only; no application code or CI behavior changes."
+    },
+    {
+      "id": "automated-semver-versioning",
+      "legacyCode": null,
+      "displayTitle": "Automated SemVer from Conventional Commits",
+      "icon": "🏷️",
+      "status": "in-progress",
+      "priority": "P2",
+      "progressPercent": 85,
+      "scope": "Add advisory Conventional Commit validation, SemVer bump calculation scripts, shell unit tests, and a GitHub Actions workflow for commit/version consistency visibility on develop and master.",
+      "acceptanceCriteria": [
+        "scripts/validate-conventional-commit.sh validates type(scope): subject and type(scope)!: subject for all repository commit types including style and revert.",
+        "scripts/calculate-version-bump.sh computes MAJOR/MINOR/PATCH/NONE bumps without mutating POMs.",
+        "tests/test-versioning.sh covers validator and bump edge cases.",
+        ".github/workflows/validate-versions.yml runs advisory format/consistency checks and blocking unit tests.",
+        "AGENTS.md and docs/decision-log.md document the agent workflow and ADR automated-semver-versioning."
+      ],
+      "validation": [
+        "bash tests/test-versioning.sh",
+        "actionlint .github/workflows/validate-versions.yml",
+        "git diff --check"
+      ],
+      "pr": "ci(versioning): add advisory semver validation (#151)",
+      "notes": "Advisory commit-format and version-consistency checks plus blocking script unit tests. Parent POM bumps remain developer-approved; plugin bumps stay under plugin-versioning-policy."
     },
     {
       "id": "external-tools-recommendations",

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -58,6 +58,7 @@ automatic category behavior, provider summary, doc map).
 | 🔑 `youtube-apikey` — YouTube Data API key externalization | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧩 `jaxb-launcher-recovery` — JAXB generated sources & launcher classpath recovery | ✅ Done | 🟠 P1 | `████████████████████` 100% |
 | 🧱 `maven-pr-validation` — Maven PR validation workflow | ✅ Done | 🟠 P1 | `████████████████████` 100% |
+| 🏷️ `automated-semver-versioning` — Automated SemVer from Conventional Commits | 🟡 In progress | 🟡 P2 | `█████████████████░░░` 85% |
 | 🔒 `dependency-security-audit` — Dependency security audit & remediation | 🟡 In progress | 🟠 P1 | `████░░░░░░░░░░░░░░░░` 20% |
 | 📝 `clean-squash-merge-policy` — Clean squash merge policy | 🟡 In progress | 🟢 P3 | `██████████░░░░░░░░░░` 50% |
 | 🔒 `critical-log4j-cve-remediation` — Critical Log4j 1.x CVE remediation | ✅ Done | 🔴 P0 | `████████████████████` 100% |
@@ -695,6 +696,45 @@ mvn -B -ntp -DskipTests package
 diagnostic until JAXB and JavaFX modernization work is complete. CodeQL:
 `.github/workflows/codeql.yml`; see [`ci.md`](ci.md) for accepted Lombok
 tracer warnings during analysis.
+
+---
+
+## 🏷️ `automated-semver-versioning` — Automated SemVer from Conventional Commits
+
+| | |
+|---|---|
+| **Status** | 🟡 In progress |
+| **Priority** | 🟡 P2 |
+| **Progress** | `█████████████████░░░` 85% |
+
+**Scope** — Add advisory Conventional Commit validation, SemVer bump
+calculation scripts, shell unit tests, and a GitHub Actions workflow for
+commit/version consistency visibility on `develop` and `master`.
+
+**Acceptance criteria**
+- ✅ `scripts/validate-conventional-commit.sh` validates
+  `type(scope): subject` and `type(scope)!: subject` for all repository
+  commit types including `style` and `revert`
+- ✅ `scripts/calculate-version-bump.sh` computes MAJOR/MINOR/PATCH/NONE
+  bumps without mutating POMs
+- ✅ `tests/test-versioning.sh` covers validator and bump edge cases
+- ✅ `.github/workflows/validate-versions.yml` runs advisory
+  format/consistency checks and blocking unit tests
+- ✅ `AGENTS.md` and `docs/decision-log.md` document the agent workflow
+  and ADR `automated-semver-versioning`
+
+**Validation**
+```bash
+bash tests/test-versioning.sh
+actionlint .github/workflows/validate-versions.yml
+git diff --check
+```
+
+**Related PR** · [#151](https://github.com/Mika3578/habitv/pull/151)
+
+**Notes** — Advisory commit-format and version-consistency checks plus
+blocking script unit tests. Parent POM bumps remain developer-approved;
+plugin bumps stay under `plugin-versioning-policy`.
 
 ---
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -6,7 +6,8 @@ root file wins.
 ## Scope
 
 This file applies to work under `scripts/` — maintenance, packaging
-helpers, static-repo tooling, and security inventory scripts.
+helpers, static-repo tooling, security inventory scripts, and versioning
+helpers (`validate-conventional-commit.sh`, `calculate-version-bump.sh`).
 
 ## Path-specific rules
 

--- a/scripts/calculate-version-bump.sh
+++ b/scripts/calculate-version-bump.sh
@@ -56,7 +56,7 @@ case "$COMMIT_TYPE" in
         NEW_MINOR=0
         NEW_PATCH=0
         ;;
-    chore|docs|test|ci|build)
+    chore|docs|test|ci|build|style|revert)
         BUMP_TYPE="NONE"
         NEW_MAJOR=$MAJOR
         NEW_MINOR=$MINOR

--- a/scripts/calculate-version-bump.sh
+++ b/scripts/calculate-version-bump.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Calculate SemVer bump based on Conventional Commit type
+#
+# Usage: calculate-version-bump.sh <commit-type> <current-version>
+#
+# Outputs: <BUMP_TYPE>|<NEW_VERSION>
+#   where BUMP_TYPE = MAJOR|MINOR|PATCH|NONE
+#   and NEW_VERSION = X.Y.Z (or X.Y.Z-SNAPSHOT if input was SNAPSHOT)
+#
+# Examples:
+#   calculate-version-bump.sh "feat" "4.2.0" → MINOR|4.3.0
+#   calculate-version-bump.sh "fix" "2.1.0-SNAPSHOT" → PATCH|2.1.1-SNAPSHOT
+#   calculate-version-bump.sh "breaking-change" "4.2.0" → MAJOR|5.0.0
+
+set -e
+
+COMMIT_TYPE="$1"
+CURRENT_VERSION="$2"
+
+# Validate inputs
+if [[ -z "$COMMIT_TYPE" ]] || [[ -z "$CURRENT_VERSION" ]]; then
+    echo "❌ Usage: calculate-version-bump.sh <type> <current-version>" >&2
+    exit 1
+fi
+
+# Remove -SNAPSHOT suffix for parsing
+CLEAN_VERSION=$(echo "$CURRENT_VERSION" | sed 's/-SNAPSHOT$//')
+
+# Check if version is in X.Y.Z format
+if ! echo "$CLEAN_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "❌ Invalid version format: $CURRENT_VERSION" >&2
+    echo "   Expected format: X.Y.Z or X.Y.Z-SNAPSHOT" >&2
+    exit 1
+fi
+
+# Parse major.minor.patch
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CLEAN_VERSION"
+
+# Determine bump type and calculate new version
+case "$COMMIT_TYPE" in
+    feat)
+        BUMP_TYPE="MINOR"
+        NEW_MAJOR=$MAJOR
+        NEW_MINOR=$((MINOR + 1))
+        NEW_PATCH=0
+        ;;
+    fix|refactor|perf)
+        BUMP_TYPE="PATCH"
+        NEW_MAJOR=$MAJOR
+        NEW_MINOR=$MINOR
+        NEW_PATCH=$((PATCH + 1))
+        ;;
+    breaking-change|breaking_change)
+        BUMP_TYPE="MAJOR"
+        NEW_MAJOR=$((MAJOR + 1))
+        NEW_MINOR=0
+        NEW_PATCH=0
+        ;;
+    chore|docs|test|ci|build)
+        BUMP_TYPE="NONE"
+        NEW_MAJOR=$MAJOR
+        NEW_MINOR=$MINOR
+        NEW_PATCH=$PATCH
+        ;;
+    *)
+        echo "❌ Unknown commit type: $COMMIT_TYPE" >&2
+        exit 1
+        ;;
+esac
+
+# Build new version
+NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
+
+# Preserve -SNAPSHOT suffix if original had it
+if [[ "$CURRENT_VERSION" == *"-SNAPSHOT" ]]; then
+    NEW_VERSION="$NEW_VERSION-SNAPSHOT"
+fi
+
+# Output in format: BUMP_TYPE|NEW_VERSION
+echo "$BUMP_TYPE|$NEW_VERSION"

--- a/scripts/validate-conventional-commit.sh
+++ b/scripts/validate-conventional-commit.sh
@@ -12,12 +12,15 @@
 #
 #   [optional footer: BREAKING CHANGE: ...]
 #
-# Valid types: feat, fix, docs, test, refactor, perf, chore, ci, build
+# Valid types: feat, fix, docs, test, refactor, perf, chore, ci, build,
+#              style, revert
 # Valid scopes: core, framework, ffmpeg-exporter, francetv-provider, etc.
 
 set -e
 
 MSG="$1"
+
+COMMIT_TYPES='feat|fix|docs|test|refactor|perf|chore|ci|build|style|revert'
 
 # Check if message is empty
 if [[ -z "$MSG" ]]; then
@@ -30,7 +33,7 @@ FIRST_LINE=$(echo "$MSG" | head -1)
 
 # Check format: type(scope): subject or type(scope)!: subject
 # Pattern: type(scope)[!]: subject (non-empty)
-COMMIT_HEADER_RE='^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-z0-9\-]+\)!?: .+'
+COMMIT_HEADER_RE="^(${COMMIT_TYPES})\([a-z0-9\-]+\)!?: .+"
 if ! echo "$FIRST_LINE" | grep -qE "$COMMIT_HEADER_RE"; then
     echo "❌ Invalid commit format"
     echo ""
@@ -40,15 +43,16 @@ if ! echo "$FIRST_LINE" | grep -qE "$COMMIT_HEADER_RE"; then
     echo "  type(scope): subject"
     echo "  type(scope)!: subject"
     echo ""
-    echo "Valid types: feat, fix, docs, test, refactor, perf, chore, ci, build"
+    echo "Valid types: feat, fix, docs, test, refactor, perf, chore, ci, build, style, revert"
     echo "Example: feat(francetv-provider): add series description extraction"
+    echo "Example: style(format): normalize shell script indentation"
     echo "Example: feat(core)!: rename provider API"
     echo ""
     exit 1
 fi
 
 # Warn if breaking change via ! syntax
-if echo "$FIRST_LINE" | grep -qE '^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-z0-9\-]+\)!:'; then
+if echo "$FIRST_LINE" | grep -qE "^(${COMMIT_TYPES})\([a-z0-9\-]+\)!:"; then
     echo "⚠️  BREAKING CHANGE detected via ! syntax"
     echo "   → This commit will bump MAJOR version"
 fi

--- a/scripts/validate-conventional-commit.sh
+++ b/scripts/validate-conventional-commit.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Validate Conventional Commits format for Habitv
+#
+# Usage: validate-conventional-commit.sh "<commit message>"
+# Exit 0 if valid, 1 if invalid
+#
+# Expected format:
+#   type(scope): subject
+#   type(scope)!: subject
+#
+#   [optional body]
+#
+#   [optional footer: BREAKING CHANGE: ...]
+#
+# Valid types: feat, fix, docs, test, refactor, perf, chore, ci, build
+# Valid scopes: core, framework, ffmpeg-exporter, francetv-provider, etc.
+
+set -e
+
+MSG="$1"
+
+# Check if message is empty
+if [[ -z "$MSG" ]]; then
+    echo "❌ Commit message is empty"
+    exit 1
+fi
+
+# Extract first line
+FIRST_LINE=$(echo "$MSG" | head -1)
+
+# Check format: type(scope): subject or type(scope)!: subject
+# Pattern: type(scope)[!]: subject (non-empty)
+COMMIT_HEADER_RE='^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-z0-9\-]+\)!?: .+'
+if ! echo "$FIRST_LINE" | grep -qE "$COMMIT_HEADER_RE"; then
+    echo "❌ Invalid commit format"
+    echo ""
+    echo "Got: '$FIRST_LINE'"
+    echo ""
+    echo "Expected format:"
+    echo "  type(scope): subject"
+    echo "  type(scope)!: subject"
+    echo ""
+    echo "Valid types: feat, fix, docs, test, refactor, perf, chore, ci, build"
+    echo "Example: feat(francetv-provider): add series description extraction"
+    echo "Example: feat(core)!: rename provider API"
+    echo ""
+    exit 1
+fi
+
+# Warn if breaking change via ! syntax
+if echo "$FIRST_LINE" | grep -qE '^(feat|fix|docs|test|refactor|perf|chore|ci|build)\([a-z0-9\-]+\)!:'; then
+    echo "⚠️  BREAKING CHANGE detected via ! syntax"
+    echo "   → This commit will bump MAJOR version"
+fi
+
+# Warn if BREAKING CHANGE footer present
+if echo "$MSG" | grep -q "BREAKING CHANGE:"; then
+    echo "⚠️  BREAKING CHANGE detected"
+    echo "   → This commit will bump MAJOR version"
+fi
+
+echo "✅ Valid Conventional Commit format"
+exit 0

--- a/tests/test-versioning.sh
+++ b/tests/test-versioning.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Unit tests for versioning scripts
+#
+# Run with: bash tests/test-versioning.sh
+# Exit 0 if all tests pass, 1 if any fail
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATE_SCRIPT="$SCRIPT_DIR/scripts/validate-conventional-commit.sh"
+BUMP_SCRIPT="$SCRIPT_DIR/scripts/calculate-version-bump.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Helper function to run a test
+run_test() {
+    local test_name="$1"
+    local command="$2"
+    local expected_exit="$3"  # 0 for success, 1 for failure
+
+    echo -n "Testing: $test_name ... "
+
+    if eval "$command" > /dev/null 2>&1; then
+        actual_exit=0
+    else
+        actual_exit=1
+    fi
+
+    if [[ $actual_exit -eq $expected_exit ]]; then
+        echo "✅"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "❌ (expected exit $expected_exit, got $actual_exit)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Helper function for version bump tests
+test_bump() {
+    local test_name="$1"
+    local type="$2"
+    local current="$3"
+    local expected_output="$4"
+
+    echo -n "Testing: $test_name ... "
+
+    output=$("$BUMP_SCRIPT" "$type" "$current")
+
+    if [[ "$output" == "$expected_output" ]]; then
+        echo "✅"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "❌"
+        echo "   Expected: $expected_output"
+        echo "   Got:      $output"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+echo ""
+echo "=== Conventional Commits Validation Tests ==="
+echo ""
+
+# Valid commits
+run_test "Valid: feat(core)" \
+    "$VALIDATE_SCRIPT 'feat(core): add new feature'" \
+    0
+
+run_test "Valid: fix(ffmpeg-exporter)" \
+    "$VALIDATE_SCRIPT 'fix(ffmpeg-exporter): handle codec error'" \
+    0
+
+run_test "Valid: refactor(framework)" \
+    "$VALIDATE_SCRIPT 'refactor(framework): simplify plugin loader'" \
+    0
+
+run_test "Valid: with BREAKING CHANGE footer" \
+    "$VALIDATE_SCRIPT \$'feat(core): rename IProvider interface\n\nBREAKING CHANGE: IProvider.getEpisodes() renamed to retrieve()'" \
+    0
+
+run_test "Valid: breaking via ! syntax" \
+    "$VALIDATE_SCRIPT 'feat(core)!: rename API interface'" \
+    0
+
+run_test "Valid: fix breaking via ! syntax" \
+    "$VALIDATE_SCRIPT 'fix(download)!: change retry contract'" \
+    0
+
+# Invalid commits
+run_test "Invalid: missing scope" \
+    "$VALIDATE_SCRIPT 'feat: add feature'" \
+    1
+
+run_test "Invalid: empty subject" \
+    "$VALIDATE_SCRIPT 'fix(core):'" \
+    1
+
+run_test "Invalid: unknown type" \
+    "$VALIDATE_SCRIPT 'unknown(core): subject'" \
+    1
+
+run_test "Invalid: empty message" \
+    "$VALIDATE_SCRIPT ''" \
+    1
+
+echo ""
+echo "=== Version Bump Calculation Tests ==="
+echo ""
+
+# MINOR bumps (feat)
+test_bump "MINOR: 4.2.0 → 4.3.0" \
+    "feat" "4.2.0" \
+    "MINOR|4.3.0"
+
+test_bump "MINOR: 1.0.0 → 1.1.0" \
+    "feat" "1.0.0" \
+    "MINOR|1.1.0"
+
+# PATCH bumps (fix, refactor, perf)
+test_bump "PATCH (fix): 2.0.0 → 2.0.1" \
+    "fix" "2.0.0" \
+    "PATCH|2.0.1"
+
+test_bump "PATCH (refactor): 4.2.5 → 4.2.6" \
+    "refactor" "4.2.5" \
+    "PATCH|4.2.6"
+
+test_bump "PATCH (perf): 1.2.3 → 1.2.4" \
+    "perf" "1.2.3" \
+    "PATCH|1.2.4"
+
+# MAJOR bumps (breaking-change)
+test_bump "MAJOR: 4.2.0 → 5.0.0" \
+    "breaking-change" "4.2.0" \
+    "MAJOR|5.0.0"
+
+test_bump "MAJOR: 1.5.3 → 2.0.0" \
+    "breaking-change" "1.5.3" \
+    "MAJOR|2.0.0"
+
+# NO bump (chore, docs, test)
+test_bump "NONE (chore): 4.2.0 stays 4.2.0" \
+    "chore" "4.2.0" \
+    "NONE|4.2.0"
+
+test_bump "NONE (docs): 1.0.0 stays 1.0.0" \
+    "docs" "1.0.0" \
+    "NONE|1.0.0"
+
+# Preserve -SNAPSHOT
+test_bump "PATCH with -SNAPSHOT: 4.2.0-SNAPSHOT → 4.2.1-SNAPSHOT" \
+    "fix" "4.2.0-SNAPSHOT" \
+    "PATCH|4.2.1-SNAPSHOT"
+
+test_bump "MINOR with -SNAPSHOT: 4.2.0-SNAPSHOT → 4.3.0-SNAPSHOT" \
+    "feat" "4.2.0-SNAPSHOT" \
+    "MINOR|4.3.0-SNAPSHOT"
+
+test_bump "MAJOR with -SNAPSHOT: 4.2.0-SNAPSHOT → 5.0.0-SNAPSHOT" \
+    "breaking-change" "4.2.0-SNAPSHOT" \
+    "MAJOR|5.0.0-SNAPSHOT"
+
+echo ""
+echo "=== Test Summary ==="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo ""
+
+if [[ $TESTS_FAILED -eq 0 ]]; then
+    echo "✅ All tests passed!"
+    exit 0
+else
+    echo "❌ Some tests failed"
+    exit 1
+fi

--- a/tests/test-versioning.sh
+++ b/tests/test-versioning.sh
@@ -120,6 +120,22 @@ run_test "Valid: fix breaking via ! syntax" \
     "$VALIDATE_SCRIPT 'fix(download)!: change retry contract'" \
     0
 
+run_test "Valid: style(scope)" \
+    "$VALIDATE_SCRIPT 'style(format): normalize whitespace'" \
+    0
+
+run_test "Valid: revert(scope)" \
+    "$VALIDATE_SCRIPT 'revert(versioning): revert previous versioning change'" \
+    0
+
+run_test "Valid: style breaking via ! syntax" \
+    "$VALIDATE_SCRIPT 'style(format)!: change formatting contract'" \
+    0
+
+run_test "Valid: revert breaking via ! syntax" \
+    "$VALIDATE_SCRIPT 'revert(versioning)!: revert public behavior change'" \
+    0
+
 # Invalid commits
 run_test "Invalid: missing scope" \
     "$VALIDATE_SCRIPT 'feat: add feature'" \

--- a/tests/test-versioning.sh
+++ b/tests/test-versioning.sh
@@ -45,7 +45,17 @@ test_bump() {
 
     echo -n "Testing: $test_name ... "
 
-    output=$("$BUMP_SCRIPT" "$type" "$current")
+    set +e
+    output="$("$BUMP_SCRIPT" "$type" "$current" 2>&1)"
+    status=$?
+    set -e
+
+    if [[ $status -ne 0 ]]; then
+        echo "❌ (script exited $status)"
+        echo "   Output: $output"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return
+    fi
 
     if [[ "$output" == "$expected_output" ]]; then
         echo "✅"
@@ -54,6 +64,29 @@ test_bump() {
         echo "❌"
         echo "   Expected: $expected_output"
         echo "   Got:      $output"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Helper for bump calculator failures (invalid input must not abort suite)
+test_bump_failure() {
+    local test_name="$1"
+    local type="$2"
+    local current="$3"
+
+    echo -n "Testing: $test_name ... "
+
+    set +e
+    output="$("$BUMP_SCRIPT" "$type" "$current" 2>&1)"
+    status=$?
+    set -e
+
+    if [[ $status -ne 0 ]]; then
+        echo "✅"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "❌ (expected non-zero exit, got 0)"
+        echo "   Output: $output"
         TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
 }
@@ -147,6 +180,17 @@ test_bump "NONE (chore): 4.2.0 stays 4.2.0" \
 test_bump "NONE (docs): 1.0.0 stays 1.0.0" \
     "docs" "1.0.0" \
     "NONE|1.0.0"
+
+test_bump "NONE (style): 4.2.0 stays 4.2.0" \
+    "style" "4.2.0" \
+    "NONE|4.2.0"
+
+test_bump "NONE (revert): 1.0.0 stays 1.0.0" \
+    "revert" "1.0.0" \
+    "NONE|1.0.0"
+
+test_bump_failure "Invalid type aborts calculator with non-zero exit" \
+    "unknown" "4.2.0"
 
 # Preserve -SNAPSHOT
 test_bump "PATCH with -SNAPSHOT: 4.2.0-SNAPSHOT → 4.2.1-SNAPSHOT" \


### PR DESCRIPTION
## Summary

- Add advisory Conventional Commit validation
- Add dry-run SemVer bump calculation
- Add shell unit tests for versioning behavior
- Add advisory GitHub Actions workflow for commit/version checks
- Document the versioning workflow in agent rules and decision log
- Track the ADR with `automated-semver-versioning` in the dev tracker
- Align `style` and `revert` handling across validator, workflow, tests, AGENTS.md, and ADR

## Safety

This PR is advisory only.

It does not:
- modify POM versions automatically
- stage files
- commit or push from CI
- mutate repository files in CI
- change Java, Maven runtime, provider, or application behavior
- change download/provider behavior

## Validation

- `bash tests/test-versioning.sh` — 29 passed, 0 failed
- `git diff --check` on task files — pass
- `actionlint .github/workflows/validate-versions.yml` — pass
- `python -m json.tool docs/dev-tracker.json` — pass
- Tracker Markdown/JSON sync — OK, 22 items, summary matches

Full `git diff --check` still has a pre-existing trailing whitespace issue in `GrabConfigDAO.java`, which is outside this PR and was not touched.

Maven skipped locally — scripts/workflow/docs/tracker only; no Java/POM/runtime behavior changed.

GitHub Maven CI passed on the PR.

## Review cleanup

- First Copilot review: 7 / 7 threads resolved
- Second Copilot review: 9 / 9 threads resolved
- No unrelated local changes included

## Files changed

- `.github/workflows/validate-versions.yml`
- `AGENTS.md`
- `docs/agent-rules-changelog.md`
- `docs/decision-log.md`
- `docs/dev-tracker.md`
- `docs/dev-tracker.json`
- `scripts/AGENTS.md`
- `scripts/calculate-version-bump.sh`
- `scripts/validate-conventional-commit.sh`
- `tests/test-versioning.sh`

## Merge plan

Use GitHub squash merge after all required checks are green and all review conversations remain resolved.
